### PR TITLE
Fix calendar toolbar layout stability

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,8 +41,8 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 #calMonth{font-weight:700;font-size:16px}
 #calYear{color:var(--muted);font-size:12px}
 .toolbar{margin-bottom:8px}
-.toolbar .nav-row{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap}
-.toolbar .monthyear-col{display:flex;flex-direction:column;line-height:1.05;align-items:center;text-align:center}
+.toolbar .nav-row{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:nowrap;width:100%}
+.toolbar .monthyear-col{display:flex;flex-direction:column;line-height:1.05;align-items:center;text-align:center;flex:0 0 140px;white-space:nowrap}
 .toolbar .nav-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;border-radius:10px;padding:0}
 .calendar-actions{display:flex;gap:6px;margin-top:8px;flex-wrap:wrap;align-items:center}
 .calendar-actions button{height:32px;padding:0 10px;border-radius:10px}


### PR DESCRIPTION
## Summary
- prevent the calendar toolbar navigation row from wrapping and allow it to span the full width of the toolbar
- lock the month/year column width so navigation buttons stay in place when month names change

## Testing
- Manual verification in browser: navigated through months with varying name lengths to confirm navigation buttons remain fixed


------
https://chatgpt.com/codex/tasks/task_e_68dcae01c1288330b96aabc03d425cfb