### PR TITLE
Use CSS custom property for guest pill color

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,7 +122,7 @@
     state.guests.forEach((g,ix)=>{
       const b=document.createElement('button');
       b.className='guest-pill'+(g.active?' active':'');
-      b.style.borderColor=g.color;
+      b.style.setProperty('--pillColor', g.color);
       const star = g.primary ? '<span class="star">★</span>' : '';
       b.innerHTML = `${star}${g.name} <span class="x" aria-hidden="true" title="Remove">×</span>`;
       b.onclick=(e)=>{


### PR DESCRIPTION
## Summary
- update guest pill rendering to assign color via the --pillColor CSS custom property
- allow CSS to control both border and active background styling without further JS changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcb26f91cc83309f012eb1da0a693c