### PR TITLE
Fix chip hover control and everyone popover layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -179,18 +179,11 @@
 
       const dateK = keyDate(state.focus);
       const day = getOrCreateDay(dateK);
-      const ent = day.find(e=> e.type==='activity' && e.title===row.title && e.start===row.start && e.end===row.end);
-      const assignedIds = ent ? Array.from(ent.guestIds) : [];
+      const entry = day.find(e=> e.type==='activity' && e.title===row.title && e.start===row.start && e.end===row.end);
+      const assignedIds = entry ? Array.from(entry.guestIds) : [];
 
       if(state.guests.length>0){
-        if(assignedIds.length===state.guests.length){
-          const ev=document.createElement('span');
-          ev.className='tag-everyone'; ev.textContent='Everyone'; ev.title='Click to show guests';
-          ev.onclick=()=>{ ev.remove(); renderGuestChips(tagWrap, assignedIds); };
-          tagWrap.appendChild(ev);
-        }else{
-          renderGuestChips(tagWrap, assignedIds);
-        }
+        renderAssignments(tagWrap, entry, assignedIds, dateK);
       }
 
       left.appendChild(tagWrap);
@@ -201,9 +194,10 @@
         const actives = state.guests.filter(g=>g.active);
         if(actives.length===0){ alert('Toggle at least one guest pill before assigning.'); return; }
         const d = getOrCreateDay(dateK);
-        let entry = d.find(e=> e.type==='activity' && e.title===row.title && e.start===row.start && e.end===row.end);
-        if(!entry){ entry = {type:'activity', title:row.title, start:row.start, end:row.end, guestIds:new Set()}; d.push(entry); }
-        actives.forEach(g=> entry.guestIds.add(g.id));
+        let target = d.find(e=> e.type==='activity' && e.title===row.title && e.start===row.start && e.end===row.end);
+        if(!target){ target = {type:'activity', title:row.title, start:row.start, end:row.end, guestIds:new Set()}; d.push(target); }
+        actives.forEach(g=> target.guestIds.add(g.id));
+        sortDayEntries(dateK);
         renderActivities(); renderPreview();
       };
 
@@ -211,23 +205,75 @@
       activitiesEl.appendChild(div);
     });
 
-    function renderGuestChips(container, ids){
+    function renderAssignments(container, entry, ids, dateK){
       container.innerHTML='';
-      ids.forEach(id=>{
-        const g = state.guests.find(x=>x.id===id); if(!g) return;
-        const c=document.createElement('span'); c.className='chip';
-        c.style.borderColor=g.color; c.style.background='#fff';
-        c.textContent = g.name.charAt(0).toUpperCase();
-        const x=document.createElement('button'); x.className='x'; x.title=`Remove ${g.name}`; x.textContent='×';
-        x.onclick=()=>{
-          const dk = keyDate(state.focus);
-          const day = state.schedule[dk]||[];
-          day.forEach(e=>{ if(e.guestIds) e.guestIds.delete(g.id); });
-          renderActivities(); renderPreview();
-        };
-        c.appendChild(x);
-        container.appendChild(c);
+      if(ids.length===0) return;
+
+      const idSet = new Set(ids);
+      const orderedIds = state.guests.map(g=>g.id).filter(id=>idSet.has(id));
+
+      if(orderedIds.length===state.guests.length){
+        const pill=document.createElement('span');
+        pill.className='tag-everyone';
+        const label=document.createElement('span');
+        label.textContent='Everyone';
+        pill.appendChild(label);
+
+        const pop=document.createElement('div');
+        pop.className='popover';
+        orderedIds.forEach(id=>{
+          const guest = state.guests.find(g=>g.id===id);
+          if(!guest) return;
+          pop.appendChild(createChip(guest, entry, dateK));
+        });
+        pill.appendChild(pop);
+        container.appendChild(pill);
+        return;
+      }
+
+      orderedIds.forEach(id=>{
+        const guest = state.guests.find(g=>g.id===id);
+        if(!guest) return;
+        container.appendChild(createChip(guest, entry, dateK));
       });
+    }
+
+    function createChip(guest, entry, dateK){
+      const c=document.createElement('span');
+      c.className='chip';
+      c.style.borderColor = guest.color;
+      c.style.color = guest.color;
+      c.title = guest.name;
+
+      const initial=document.createElement('span');
+      initial.className='initial';
+      initial.textContent = guest.name.charAt(0).toUpperCase();
+      c.appendChild(initial);
+
+      const x=document.createElement('button');
+      x.className='x';
+      x.type='button';
+      x.setAttribute('aria-label', `Remove ${guest.name}`);
+      x.title=`Remove ${guest.name}`;
+      x.textContent='×';
+      x.onclick=(e)=>{
+        e.stopPropagation();
+        if(!entry) return;
+        entry.guestIds.delete(guest.id);
+        if(entry.guestIds.size===0){
+          const day = state.schedule[dateK];
+          if(day){
+            const idx = day.indexOf(entry);
+            if(idx>-1) day.splice(idx,1);
+            if(day.length===0) delete state.schedule[dateK];
+          }
+        }
+        sortDayEntries(dateK);
+        renderActivities();
+        renderPreview();
+      };
+      c.appendChild(x);
+      return c;
     }
     function renderStatusMessage(text){
       activitiesEl.innerHTML='';
@@ -244,6 +290,15 @@
     }
   }
   function getOrCreateDay(dateK){ if(!state.schedule[dateK]) state.schedule[dateK]=[]; return state.schedule[dateK]; }
+  function sortDayEntries(dateK){
+    const day = state.schedule[dateK];
+    if(!day) return;
+    day.sort((a,b)=>{
+      const sa = a.start || '';
+      const sb = b.start || '';
+      return sa.localeCompare(sb);
+    });
+  }
 
   // ---------- Preview ----------
   function renderPreview(){

--- a/style.css
+++ b/style.css
@@ -26,8 +26,11 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 #dayTitle{font-weight:600}
 .email{background:#fff;border:1px solid var(--border);padding:12px;border-radius:12px;min-height:260px;white-space:pre-wrap}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
-.chip{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;background:var(--chip);border:1px solid var(--chipBorder);color:var(--chipText);font-weight:600}
-.chip .x{border:none;background:transparent;cursor:pointer;font-weight:700}
+.chip{width:24px;height:24px;border-radius:50%;display:inline-grid;place-items:center;font-weight:700;border:1px solid var(--chipBorder);background:#fff;user-select:none;position:relative}
+.chip::after{content:'';width:6px;height:6px;border-radius:50%;background:currentColor;opacity:.85;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:0}
+.chip .initial{position:relative;z-index:1;font-size:12px;line-height:1;color:var(--chipText)}
+.chip .x{position:absolute;right:-6px;top:-6px;width:18px;height:18px;border-radius:50%;display:none;align-items:center;justify-content:center;font-weight:800;background:#fff;border:1px solid var(--border);cursor:pointer;padding:0;font-size:12px;line-height:1}
+.chip:hover .x{display:flex}
 .guest-input{height:36px;padding:0 12px;border:1px solid var(--border);border-radius:12px;background:#fff}
 .icon-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;padding:0;border-radius:12px;background:#f1f5f9;border:1px solid var(--border)}
 .icon-btn svg{display:block}
@@ -41,7 +44,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .item{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:#fff}
 .item-left{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
 .item .add{min-width:40px}
-.tag-everyone{padding:3px 8px;border-radius:8px;border:1px solid var(--border);background:#fafafa;cursor:pointer}
+.tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:24px;padding:3px 10px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;cursor:default}
+.tag-everyone .popover{position:absolute;transform:translate(-50%,-6px);bottom:100%;left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);z-index:10}
+.tag-everyone:hover .popover{display:flex}
 .tag-row{display:flex;gap:6px;flex-wrap:wrap}
 .stick-right{justify-content:flex-end}
 .section{margin-top:16px}


### PR DESCRIPTION
## Summary
- restore circular chip styling with centered initials and a hover-only delete control
- drive the inner accent dot from each guest color while keeping initials legible
- realign the Everyone pill popover so guest chips stay reachable on hover

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcb8230fac83309ae7dbe9afc14fe7