### PR TITLE
Improve activity chip styling and popover behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -242,7 +242,7 @@
       const c=document.createElement('span');
       c.className='chip';
       c.style.borderColor = guest.color;
-
+      c.style.color = guest.color;
       c.title = guest.name;
 
       const initial=document.createElement('span');
@@ -253,7 +253,7 @@
       const x=document.createElement('button');
       x.className='x';
       x.type='button';
-
+      x.setAttribute('aria-label', `Remove ${guest.name}`);
       x.title=`Remove ${guest.name}`;
       x.textContent='×';
       x.onclick=(e)=>{

--- a/style.css
+++ b/style.css
@@ -27,6 +27,11 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email{background:#fff;border:1px solid var(--border);padding:12px;border-radius:12px;min-height:260px;white-space:pre-wrap}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 
+.chip{width:24px;height:24px;border-radius:50%;display:inline-grid;place-items:center;font-weight:700;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
+.chip::after{content:'';position:absolute;top:50%;left:50%;width:6px;height:6px;border-radius:50%;background:currentColor;opacity:.85;transform:translate(-50%,-50%);}
+.chip .initial{position:relative;z-index:1;font-size:12px;line-height:1;}
+.chip .x{position:absolute;right:-6px;top:-6px;width:18px;height:18px;border-radius:50%;display:none;align-items:center;justify-content:center;font-weight:800;background:#fff;border:1px solid var(--border);padding:0;cursor:pointer;color:var(--ink);}
+.chip .x:focus{outline:2px solid var(--brand);outline-offset:1px;}
 .chip:hover .x{display:flex}
 .guest-input{height:36px;padding:0 12px;border:1px solid var(--border);border-radius:12px;background:#fff}
 .icon-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;padding:0;border-radius:12px;background:#f1f5f9;border:1px solid var(--border)}
@@ -42,7 +47,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .item-left{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
 .item .add{min-width:40px}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:24px;padding:3px 10px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;cursor:default}
-
+.tag-everyone .popover{position:absolute;transform:translate(-50%,-6px);bottom:100%;left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;}
 .tag-everyone:hover .popover{display:flex}
 .tag-row{display:flex;gap:6px;flex-wrap:wrap}
 .stick-right{justify-content:flex-end}


### PR DESCRIPTION
## Summary
- style activity assignment chips as circular initials with hover-only delete affordances and guest-colored accents
- add hover popover chips to the Everyone pill while keeping the pill styling aligned with other tags
- ensure chip interactions announce removals accessibly by adding aria labels

## Testing
- python3 -m http.server 8000 (manually verified UI in browser)


------
https://chatgpt.com/codex/tasks/task_e_68dcc6275ae0833084426d43fa30c134