### PR TITLE
Refine chip readability and popover stability

### DIFF
--- a/script.js
+++ b/script.js
@@ -242,7 +242,7 @@
       const c=document.createElement('span');
       c.className='chip';
       c.style.borderColor = guest.color;
-
+      c.style.color = guest.color;
       c.title = guest.name;
 
       const initial=document.createElement('span');
@@ -253,7 +253,7 @@
       const x=document.createElement('button');
       x.className='x';
       x.type='button';
-
+      x.setAttribute('aria-label', `Remove ${guest.name}`);
       x.title=`Remove ${guest.name}`;
       x.textContent='×';
       x.onclick=(e)=>{

--- a/style.css
+++ b/style.css
@@ -27,7 +27,13 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email{background:#fff;border:1px solid var(--border);padding:12px;border-radius:12px;min-height:260px;white-space:pre-wrap}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 
-.chip:hover .x{display:flex}
+.chip{width:24px;height:24px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-weight:500;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
+.chip::after{content:'';position:absolute;top:50%;left:50%;width:6px;height:6px;border-radius:50%;background:currentColor;opacity:.85;transform:translate(-50%,-50%);}
+.chip .initial{position:relative;z-index:1;font-size:13px;line-height:1;font-weight:500;letter-spacing:.02em;transition:opacity .12s ease;}
+.chip .x{position:absolute;inset:2px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;background:rgba(255,255,255,.95);border:none;padding:0;cursor:pointer;color:var(--ink);opacity:0;transition:opacity .12s ease;}
+.chip .x:focus{outline:2px solid var(--brand);outline-offset:1px;opacity:1;}
+.chip:hover .x,.chip:focus-within .x{opacity:1;}
+.chip:hover .initial,.chip:focus-within .initial{opacity:0;}
 .guest-input{height:36px;padding:0 12px;border:1px solid var(--border);border-radius:12px;background:#fff}
 .icon-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;padding:0;border-radius:12px;background:#f1f5f9;border:1px solid var(--border)}
 .icon-btn svg{display:block}
@@ -42,8 +48,8 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .item-left{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
 .item .add{min-width:40px}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:24px;padding:3px 10px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;cursor:default}
-
-.tag-everyone:hover .popover{display:flex}
+.tag-everyone .popover{position:absolute;left:50%;bottom:100%;transform:translate(-50%,8px);display:flex;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;opacity:0;pointer-events:none;transition:opacity .15s ease,transform .15s ease;z-index:10;}
+.tag-everyone:hover .popover,.tag-everyone:focus-within .popover{opacity:1;pointer-events:auto;transform:translate(-50%,0);}
 .tag-row{display:flex;gap:6px;flex-wrap:wrap}
 .stick-right{justify-content:flex-end}
 .section{margin-top:16px}


### PR DESCRIPTION
## Summary
- slim down chip initials and keep them centered for easier legibility
- center the hover remove control within chips and fade the initial while it is active
- keep the Everyone popover visible while hovering so guests can be removed reliably

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dcc6275ae0833084426d43fa30c134