### PR TITLE
Limit itinerary preview to stay dates and improve editing controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,8 @@ body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.45 -apple-system
 h2{margin:0 0 12px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
 button{border:1px solid var(--border);background:#f1f5f9;border-radius:10px;padding:8px 10px;cursor:pointer;touch-action:manipulation}
 button:focus{outline:2px solid var(--brand);outline-offset:2px}
+.lock-icon{width:1em;height:1em;display:block}
+#toggleEdit{display:flex;align-items:center;justify-content:center;gap:0;line-height:1}
 .muted{color:var(--muted)}
 .grid{display:grid;grid-template-columns:repeat(7,1fr);gap:6px}
 .dow div{font-size:11px;color:var(--muted);text-align:center}


### PR DESCRIPTION
## Summary
- restrict the itinerary preview to arrival/departure stay dates via a new getStayKeys helper and enforce clean spacing
- preserve manual preview edits by freezing regeneration while editing and toggling the edit control with a lock icon state
- add copy button feedback and light styling to keep the lock icon aligned with the existing pen glyph

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dce04b3a288330b35a42607d3110e1