### PR TITLE
Enhance guest toggle and assignment popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,14 +38,13 @@
         <h2>Guests</h2>
         <div class="row">
           <input id="guestName" class="guest-input" type="text" placeholder="Add guest" aria-label="Guest name">
-          <button id="addGuest" class="icon-btn" aria-label="Add guest" title="Add">
-            <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true" focusable="false">
-              <path d="M6 1v10M1 6h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
+            <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+              <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>
+              <rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/>
             </svg>
           </button>
-        </div>
-        <div class="row">
-          <button id="toggleAll" title="Toggle all guests">Toggle All</button>
         </div>
         <div id="guests" class="chips" aria-label="Guests"></div>
       </div>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         <h2>Guests</h2>
         <div class="row">
           <input id="guestName" class="guest-input" type="text" placeholder="Add guest" aria-label="Guest name">
-          <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
+          <button id="toggleAll" class="icon-btn" type="button" aria-label="Toggle all guests" title="Toggle all guests">
             <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
               <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>

--- a/script.js
+++ b/script.js
@@ -34,6 +34,7 @@
   const calMonth=$('#calMonth'), calYear=$('#calYear'), calGrid=$('#calGrid'), dow=$('#dow');
   const dayTitle=$('#dayTitle'), activitiesEl=$('#activities'), email=$('#email');
   const guestsEl=$('#guests'), guestName=$('#guestName');
+  const toggleAllBtn=$('#toggleAll');
   const toggleEditBtn=$('#toggleEdit');
   const copyBtn=$('#copy');
   toggleEditBtn.textContent='✎';
@@ -164,14 +165,50 @@
       };
       guestsEl.appendChild(b);
     });
+    updateToggleAllButton();
   }
-  $('#addGuest').onclick=()=>addGuest(guestName.value.trim());
-  guestName.addEventListener('keydown',e=>{ if(e.key==='Enter') addGuest(guestName.value.trim()); });
-  $('#toggleAll').onclick=()=>{
-    const anyInactive = state.guests.some(g=>!g.active);
-    state.guests.forEach(g=>g.active = anyInactive ? true : false);
-    renderGuests();
+  const toggleIcons = {
+    allOn: `<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/><line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/><rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/></svg>`,
+    someOff: `<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/><line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/><rect x="8.2" y="12.9" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/></svg>`
   };
+
+  guestName.addEventListener('keydown',e=>{
+    if(e.key==='Enter' || e.key==='NumpadEnter'){
+      e.preventDefault();
+      addGuest(guestName.value.trim());
+    }
+  });
+  if(toggleAllBtn){
+    toggleAllBtn.addEventListener('click',()=>{
+      const anyInactive = state.guests.some(g=>!g.active);
+      state.guests.forEach(g=>g.active = anyInactive ? true : false);
+      renderGuests();
+    });
+  }
+
+  function updateToggleAllButton(){
+    if(!toggleAllBtn) return;
+    const total = state.guests.length;
+    const allActive = total>0 && state.guests.every(g=>g.active);
+    const anyInactive = state.guests.some(g=>!g.active);
+    toggleAllBtn.disabled = total===0;
+    toggleAllBtn.setAttribute('aria-pressed', total>0 && allActive ? 'true' : 'false');
+    if(total===0){
+      toggleAllBtn.innerHTML = toggleIcons.allOn;
+      toggleAllBtn.setAttribute('aria-label','Toggle all guests');
+      toggleAllBtn.title = 'Toggle all guests';
+      return;
+    }
+    if(anyInactive){
+      toggleAllBtn.innerHTML = toggleIcons.someOff;
+      toggleAllBtn.setAttribute('aria-label','Turn all guests on');
+      toggleAllBtn.title = 'Turn all guests on';
+    }else{
+      toggleAllBtn.innerHTML = toggleIcons.allOn;
+      toggleAllBtn.setAttribute('aria-label','Turn all guests off');
+      toggleAllBtn.title = 'Turn all guests off';
+    }
+  }
 
   // ---------- Activities ----------
   function renderActivities(){

--- a/script.js
+++ b/script.js
@@ -35,6 +35,11 @@
   const dayTitle=$('#dayTitle'), activitiesEl=$('#activities'), email=$('#email');
   const guestsEl=$('#guests'), guestName=$('#guestName');
   const toggleAllBtn=$('#toggleAll');
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const toggleIconTemplates = {
+    allOn: createToggleSwitchSvg(true),
+    someOff: createToggleSwitchSvg(false)
+  };
   const toggleEditBtn=$('#toggleEdit');
   const copyBtn=$('#copy');
   toggleEditBtn.textContent='✎';
@@ -167,10 +172,55 @@
     });
     updateToggleAllButton();
   }
-  const toggleIcons = {
-    allOn: `<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/><line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/><rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/></svg>`,
-    someOff: `<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/><line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/><rect x="8.2" y="12.9" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/></svg>`
-  };
+  function createToggleSwitchSvg(pressedTop){
+    const svg=document.createElementNS(SVG_NS,'svg');
+    svg.setAttribute('width','24');
+    svg.setAttribute('height','24');
+    svg.setAttribute('viewBox','0 0 24 24');
+    svg.setAttribute('aria-hidden','true');
+    svg.setAttribute('focusable','false');
+
+    const outline=document.createElementNS(SVG_NS,'rect');
+    outline.setAttribute('x','7');
+    outline.setAttribute('y','3.5');
+    outline.setAttribute('width','10');
+    outline.setAttribute('height','17');
+    outline.setAttribute('rx','2.5');
+    outline.setAttribute('fill','none');
+    outline.setAttribute('stroke','currentColor');
+    outline.setAttribute('stroke-width','1.5');
+    svg.appendChild(outline);
+
+    const divider=document.createElementNS(SVG_NS,'line');
+    divider.setAttribute('x1','7');
+    divider.setAttribute('y1','12');
+    divider.setAttribute('x2','17');
+    divider.setAttribute('y2','12');
+    divider.setAttribute('stroke','currentColor');
+    divider.setAttribute('stroke-width','1.25');
+    divider.setAttribute('stroke-linecap','round');
+    divider.setAttribute('opacity','0.6');
+    svg.appendChild(divider);
+
+    const pressed=document.createElementNS(SVG_NS,'rect');
+    pressed.setAttribute('x','8.2');
+    pressed.setAttribute('width','7.6');
+    pressed.setAttribute('height','6');
+    pressed.setAttribute('rx','1.4');
+    pressed.setAttribute('fill','currentColor');
+    pressed.setAttribute('opacity','0.18');
+    pressed.setAttribute('y', pressedTop ? '5' : '12.9');
+    svg.appendChild(pressed);
+
+    return svg;
+  }
+
+  function setToggleIcon(state){
+    if(!toggleAllBtn) return;
+    const tpl = toggleIconTemplates[state];
+    if(!tpl) return;
+    toggleAllBtn.replaceChildren(tpl.cloneNode(true));
+  }
 
   guestName.addEventListener('keydown',e=>{
     if(e.key==='Enter' || e.key==='NumpadEnter'){
@@ -194,17 +244,17 @@
     toggleAllBtn.disabled = total===0;
     toggleAllBtn.setAttribute('aria-pressed', total>0 && allActive ? 'true' : 'false');
     if(total===0){
-      toggleAllBtn.innerHTML = toggleIcons.allOn;
+      setToggleIcon('allOn');
       toggleAllBtn.setAttribute('aria-label','Toggle all guests');
       toggleAllBtn.title = 'Toggle all guests';
       return;
     }
     if(anyInactive){
-      toggleAllBtn.innerHTML = toggleIcons.someOff;
+      setToggleIcon('someOff');
       toggleAllBtn.setAttribute('aria-label','Turn all guests on');
       toggleAllBtn.title = 'Turn all guests on';
     }else{
-      toggleAllBtn.innerHTML = toggleIcons.allOn;
+      setToggleIcon('allOn');
       toggleAllBtn.setAttribute('aria-label','Turn all guests off');
       toggleAllBtn.title = 'Turn all guests off';
     }

--- a/style.css
+++ b/style.css
@@ -30,16 +30,15 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email{background:#fff;border:1px solid var(--border);padding:12px;border-radius:12px;min-height:260px;white-space:pre-wrap}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 
-.chip{width:24px;height:24px;border-radius:50%;display:inline-grid;place-items:center;font-weight:700;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
-.chip::after{content:'';position:absolute;top:50%;left:50%;width:6px;height:6px;border-radius:50%;background:currentColor;opacity:.85;transform:translate(-50%,-50%);}
-.chip .initial{position:relative;z-index:1;font-size:12px;line-height:1;color:currentColor;transition:opacity .16s ease;}
+.chip{width:24px;height:24px;border-radius:50%;display:inline-grid;place-items:center;font-weight:500;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
+.chip .initial{position:relative;z-index:1;font-size:12px;line-height:1;color:currentColor;transition:opacity .16s ease;font-weight:500;letter-spacing:.01em;}
 .chip .x{position:absolute;top:50%;left:50%;width:18px;height:18px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;background:#fff;border:1px solid var(--border);padding:0;cursor:pointer;color:var(--ink);z-index:2;transform:translate(-50%,-50%);opacity:0;pointer-events:none;transition:opacity .16s ease;}
 @media(hover:hover){.chip:hover .initial,.chip:focus-within .initial{opacity:0;}.chip:hover .x,.chip:focus-within .x{opacity:1;pointer-events:auto;}}
 @media(hover:none){.chip .x{opacity:1;pointer-events:auto;}}
 .chip .x:focus{outline:2px solid var(--brand);outline-offset:1px;}
 .guest-input{height:36px;padding:0 12px;border:1px solid var(--border);border-radius:12px;background:#fff}
 .icon-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;padding:0;border-radius:12px;background:#f1f5f9;border:1px solid var(--border)}
-.icon-btn svg{display:block}
+.icon-btn svg{display:block;width:24px;height:24px}
 .section .row{margin-bottom:8px}
 #guests{padding-top:4px}
 .guest-pill{padding:6px 10px;border-radius:999px;border:1px solid var(--border);background:#fff;cursor:pointer;user-select:none;display:flex;align-items:center;gap:4px}
@@ -54,7 +53,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .item .add{min-width:40px}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:4px 12px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;color:var(--chipText);cursor:pointer;appearance:none;font:inherit;line-height:1;transition:box-shadow .2s ease;}
 .tag-everyone:focus{outline:2px solid var(--brand);outline-offset:2px;}
-.tag-everyone .popover{position:absolute;transform:translate(-50%,-8px);bottom:100%;left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;z-index:10;min-width:160px;justify-content:flex-start}
+.tag-everyone .popover{position:absolute;transform:translate(-50%,0);bottom:100%;left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;z-index:10;min-width:0;width:max-content;max-width:min(320px,90vw);justify-content:flex-start}
 .tag-everyone[aria-expanded="true"] .popover,.tag-everyone:focus-within .popover{display:flex}
 @media(hover:hover){.tag-everyone:hover .popover{display:flex}}
 .tag-row{display:flex;gap:6px;flex-wrap:wrap}

--- a/style.css
+++ b/style.css
@@ -31,7 +31,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 
 .chip{width:24px;height:24px;border-radius:50%;display:inline-grid;place-items:center;font-weight:500;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
-.chip .initial{position:relative;z-index:1;font-size:12px;line-height:1;color:currentColor;transition:opacity .16s ease;font-weight:500;letter-spacing:.01em;}
+.chip .initial{position:relative;z-index:1;font-size:12px;line-height:1;color:currentColor;transition:opacity .16s ease;font-weight:500;letter-spacing:.02em;}
 .chip .x{position:absolute;top:50%;left:50%;width:18px;height:18px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;background:#fff;border:1px solid var(--border);padding:0;cursor:pointer;color:var(--ink);z-index:2;transform:translate(-50%,-50%);opacity:0;pointer-events:none;transition:opacity .16s ease;}
 @media(hover:hover){.chip:hover .initial,.chip:focus-within .initial{opacity:0;}.chip:hover .x,.chip:focus-within .x{opacity:1;pointer-events:auto;}}
 @media(hover:none){.chip .x{opacity:1;pointer-events:auto;}}


### PR DESCRIPTION
## Summary
- replace the guest toggle button artwork with stateful light-switch SVGs and disable it when no guests exist
- update the toggle logic to refresh the icon, aria labels, and pressed state whenever guest activity changes
- lighten activity assignment initials and adjust the Everyone popover to stay open without gaps while sizing to its contents
- ensure the guest input handles Enter and Numpad Enter presses to add guests now that the add button is removed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcf39e5f5083309f82236c3a8bf6bf