### PR TITLE
Improve email preview formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <!-- Preview -->
     <section class="right card">
       <h2>Preview</h2>
-      <pre id="email" class="email" spellcheck="false"></pre>
+      <div id="email" class="email" spellcheck="false"></div>
       <div class="row stick-right">
         <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>
         <button id="copy" title="Copy">⧉</button>

--- a/style.css
+++ b/style.css
@@ -27,7 +27,15 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .days button.arrival,.days button.departure{background:var(--stayEdge);box-shadow:inset 0 0 0 2px var(--brand)}
 .days button.stay{background:var(--stayBand)}
 #dayTitle{font-weight:600}
-.email{background:#fff;border:1px solid var(--border);padding:12px;border-radius:12px;min-height:260px;white-space:pre-wrap}
+.email{background:#fff;border:1px solid var(--border);padding:20px;border-radius:12px;min-height:260px;font-size:15px;line-height:1.6;color:var(--ink)}
+.email:focus{outline:none}
+.email .email-body{margin:0 0 12px;font-size:15px;line-height:1.6}
+.email .email-section-title{margin:16px 0 12px;font-size:18px;font-weight:700;text-decoration:underline}
+.email .email-day{margin-bottom:20px}
+.email .email-day:last-of-type{margin-bottom:0}
+.email .email-day-title{margin:0 0 10px;font-size:17px;font-weight:700}
+.email .email-activity{margin:6px 0;font-size:16px}
+.email .email-empty{margin:12px 0 0;font-size:15px;color:var(--muted)}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 
 .chip{width:26px;height:26px;border-radius:50%;display:inline-grid;place-items:center;font-weight:500;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}


### PR DESCRIPTION
## Summary
- render the itinerary preview as styled HTML rather than plain text
- adjust preview styles for headings, day titles, and activity rows to match email hierarchy
- enhance copy functionality to copy rich HTML content when possible

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dd77cd43908330bc23c9fcf00cfbaf