### PR TITLE
Adjust itinerary preview formatting

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email .email-section-title{margin:16px 0 12px;font-size:18px;font-weight:700;text-decoration:underline}
 .email .email-day{margin-bottom:20px}
 .email .email-day:last-of-type{margin-bottom:0}
-.email .email-day-title{margin:0 0 10px;font-size:17px;font-weight:700}
+.email .email-day-title{margin:0 0 10px;font-size:17px;font-weight:700;text-decoration:none}
+.email sup{font-size:0.65em;vertical-align:super;line-height:0}
+#dayTitle sup{font-size:0.65em;vertical-align:super;line-height:0}
 .email .email-activity{margin:6px 0;font-size:16px}
 .email .email-empty{margin:12px 0 0;font-size:15px;color:var(--muted)}
 .chips{display:flex;gap:8px;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- render ordinal suffixes with superscript markup and sanitize preview HTML output for copying
- ensure the departure day check-out line always appears first and bold the time portions across activities, check-in, and check-out entries
- add styling for superscript ordinals while keeping day headings un-underlined in the preview and activity header

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd9b9a4dc0833095b86842aea9197c