### PR TITLE
Fix initial render crash after data layer load

### DIFF
--- a/script.js
+++ b/script.js
@@ -233,7 +233,8 @@
     console.error(err);
     state.data = null;
     state.dataStatus = 'error';
-    renderAll();
+    // Defer the render until after script evaluation so const bindings below are initialized.
+    setTimeout(renderAll, 0);
     email.textContent = 'Data layer missing. Load data/data-layer.js before script.js.';
   }else{
     try{
@@ -242,12 +243,14 @@
       state.data = { activities: activitiesDataset, spa: spaDataset };
       state.dataStatus = 'ready';
       ensureFocusInSeason();
-      renderAll();
+      // Wait for the rest of this module to register helpers (e.g. toggleIcons) before rendering.
+      setTimeout(renderAll, 0);
     }catch(e){
       console.error(e);
       state.data = null;
       state.dataStatus = 'error';
-      renderAll();
+      // Keep the render async so we don't hit TDZ checks while the script continues parsing.
+      setTimeout(renderAll, 0);
       email.textContent = 'Data layer failed to initialize. See console for details.';
     }
   }


### PR DESCRIPTION
## Summary
- defer the first render until after script evaluation so toggleIcons is initialized
- keep the data-layer error paths async to avoid early crashes when CHSDataLayer is missing

## Testing
- Manual check in browser

------
https://chatgpt.com/codex/tasks/task_e_68dde0f327ac8330a96d55318ab7bc19