### PR TITLE
Refine activities list interactions and styling

### DIFF
--- a/activities-demo.html
+++ b/activities-demo.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Activities Column Preview</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .demo-actions{display:flex;gap:12px;flex-wrap:wrap;align-items:center;}
+    .demo-log{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:12px;min-height:80px;font-size:14px;display:flex;flex-direction:column;gap:6px;}
+    .demo-log-entry{margin:0;}
+    .demo-activities{background:var(--panel);border:1px solid var(--border);border-radius:18px;padding:8px 0;}
+    .demo-toolbar{display:flex;flex-direction:column;gap:12px;}
+    .demo-hint{font-size:13px;color:var(--muted);margin:0;}
+  </style>
+</head>
+<body class="demo-page">
+  <div class="demo-container">
+    <header class="demo-header">
+      <h1>Activities column interactions</h1>
+      <p class="demo-section-copy">This sandbox illustrates the updated Apple-inspired list for activities, including hover, press, disabled, keyboard, and analytics logging states.</p>
+    </header>
+
+    <section class="demo-section">
+      <div class="demo-toolbar">
+        <div class="demo-actions">
+          <button id="demoThemeToggle" type="button">Toggle dark mode</button>
+          <button id="demoFocusFirst" type="button">Focus first row</button>
+          <span class="demo-hint">Use mouse, keyboard (Space/Enter), or touch simulation to trigger rows.</span>
+        </div>
+        <p class="demo-hint">Activation log updates live to confirm the shared handler fires exactly once per interaction.</p>
+      </div>
+      <div class="demo-activities" id="demoActivities" role="list" aria-label="Demo activities"></div>
+      <div class="demo-log" id="demoLog" aria-live="polite" aria-atomic="false"></div>
+    </section>
+  </div>
+
+  <script src="activities-interactions.js"></script>
+  <script src="activities-demo.js"></script>
+</body>
+</html>

--- a/activities-demo.js
+++ b/activities-demo.js
@@ -1,0 +1,214 @@
+(function(){
+  const interactions = window.CHSActivitiesInteractions;
+  const attach = interactions && typeof interactions.attachRowPressInteractions === 'function'
+    ? interactions.attachRowPressInteractions
+    : (element, { onActivate }) => {
+        element.addEventListener('click', onActivate);
+        return { dispose(){} };
+      };
+
+  const list = document.getElementById('demoActivities');
+  const logEl = document.getElementById('demoLog');
+  if(!list || !logEl) return;
+
+  const sampleActivities = [
+    {
+      start: '8:30am',
+      end: '9:25am',
+      title: 'Rise & Shine Flow Yoga',
+      guests: [
+        { name: 'Alex', color: '#6366f1' },
+        { name: 'Bailey', color: '#ec4899' }
+      ]
+    },
+    {
+      start: '10:15am',
+      end: '11:00am',
+      title: 'Botanical Immersion Walk',
+      pill: { label: 'Both', aria: 'Both guests preview' }
+    },
+    {
+      start: '1:00pm',
+      end: '2:00pm',
+      title: 'Sound Bath Session',
+      disabled: true
+    }
+  ];
+
+  const log = (message) => {
+    const entry = document.createElement('p');
+    entry.className = 'demo-log-entry';
+    entry.textContent = `${new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' })} — ${message}`;
+    logEl.prepend(entry);
+    while(logEl.children.length > 6){
+      logEl.removeChild(logEl.lastChild);
+    }
+  };
+
+  sampleActivities.forEach((activity, index) => {
+    const row = document.createElement('div');
+    row.className = 'activity-row';
+    row.setAttribute('role', 'button');
+
+    const disabled = !!activity.disabled;
+    if(disabled){
+      row.dataset.disabled = 'true';
+      row.setAttribute('aria-disabled', 'true');
+      row.tabIndex = -1;
+    }else{
+      row.tabIndex = 0;
+    }
+
+    const ariaLabel = `Add activity: ${activity.start} to ${activity.end} ${activity.title}`;
+    row.setAttribute('aria-label', ariaLabel);
+
+    const body = document.createElement('div');
+    body.className = 'activity-row-body';
+
+    const headline = document.createElement('div');
+    headline.className = 'activity-row-headline';
+
+    const time = document.createElement('span');
+    time.className = 'activity-row-time';
+    time.textContent = `${activity.start} – ${activity.end}`;
+    headline.appendChild(time);
+
+    const title = document.createElement('span');
+    title.className = 'activity-row-title';
+    title.textContent = activity.title;
+    headline.appendChild(title);
+
+    body.appendChild(headline);
+
+    const tagRow = document.createElement('div');
+    tagRow.className = 'tag-row';
+
+    if(activity.pill){
+      const pill = document.createElement('button');
+      pill.type = 'button';
+      pill.className = 'tag-everyone';
+      pill.dataset.pressExempt = 'true';
+      pill.addEventListener('pointerdown', e => e.stopPropagation());
+      pill.textContent = activity.pill.label;
+      pill.setAttribute('aria-label', activity.pill.aria || activity.pill.label);
+      pill.addEventListener('click', e => {
+        e.stopPropagation();
+        log(`Previewed group pill: ${activity.pill.label}`);
+      });
+      tagRow.appendChild(pill);
+    }
+
+    if(Array.isArray(activity.guests)){
+      activity.guests.forEach(guest => {
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.style.borderColor = guest.color;
+        chip.style.color = guest.color;
+        chip.title = guest.name;
+
+        const initial = document.createElement('span');
+        initial.className = 'initial';
+        initial.textContent = guest.name.charAt(0).toUpperCase();
+        chip.appendChild(initial);
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'x';
+        remove.textContent = '×';
+        remove.dataset.pressExempt = 'true';
+        remove.addEventListener('pointerdown', e => e.stopPropagation());
+        remove.addEventListener('click', e => {
+          e.stopPropagation();
+          log(`Simulated removal of ${guest.name}`);
+        });
+        chip.appendChild(remove);
+
+        tagRow.appendChild(chip);
+      });
+    }
+
+    body.appendChild(tagRow);
+    row.appendChild(body);
+    list.appendChild(row);
+
+    const setPressed = (pressed) => {
+      if(pressed){
+        row.dataset.pressed = 'true';
+      }else{
+        delete row.dataset.pressed;
+      }
+    };
+
+    const activate = () => {
+      if(disabled){
+        log(`Disabled activity blocked: ${activity.title}`);
+        return;
+      }
+      log(`Activated ${activity.title}`);
+    };
+
+    attach(row, {
+      onActivate: activate,
+      isDisabled: () => disabled,
+      onPressChange: setPressed
+    });
+
+    let keyboardPress = false;
+    row.addEventListener('keydown', (event) => {
+      if(disabled) return;
+      if(event.key === ' ' || event.key === 'Spacebar'){
+        event.preventDefault();
+        if(!keyboardPress){
+          keyboardPress = true;
+          setPressed(true);
+        }
+      }else if(event.key === 'Enter'){
+        event.preventDefault();
+        activate();
+      }
+    });
+
+    row.addEventListener('keyup', (event) => {
+      if(!keyboardPress) return;
+      if(event.key === ' ' || event.key === 'Spacebar'){
+        event.preventDefault();
+        keyboardPress = false;
+        setPressed(false);
+        if(!disabled){
+          activate();
+        }
+      }
+    });
+
+    row.addEventListener('blur', () => {
+      keyboardPress = false;
+      setPressed(false);
+    });
+
+    if(disabled){
+      log(`Disabled: ${activity.title}`);
+    }
+  });
+
+  const focusFirstBtn = document.getElementById('demoFocusFirst');
+  if(focusFirstBtn){
+    focusFirstBtn.addEventListener('click', () => {
+      const first = list.querySelector('.activity-row:not([data-disabled="true"])');
+      if(first){
+        first.focus();
+      }
+    });
+  }
+
+  const toggleThemeBtn = document.getElementById('demoThemeToggle');
+  if(toggleThemeBtn){
+    toggleThemeBtn.addEventListener('click', () => {
+      const isDark = document.body.dataset.theme === 'dark';
+      if(isDark){
+        document.body.removeAttribute('data-theme');
+      }else{
+        document.body.dataset.theme = 'dark';
+      }
+    });
+  }
+})();

--- a/activities-interactions.js
+++ b/activities-interactions.js
@@ -1,0 +1,129 @@
+(function(globalFactory){
+  const globalRef = typeof globalThis !== 'undefined' ? globalThis : (typeof window !== 'undefined' ? window : this);
+  if(typeof module === 'object' && module.exports){
+    module.exports = globalFactory();
+  }else{
+    globalRef.CHSActivitiesInteractions = globalFactory();
+  }
+})(function(){
+  const DEFAULT_THRESHOLD = 6;
+
+  function attachRowPressInteractions(element, options = {}){
+    if(!element || typeof element.addEventListener !== 'function'){
+      throw new Error('attachRowPressInteractions requires an element with addEventListener.');
+    }
+
+    const {
+      onActivate = () => {},
+      threshold = DEFAULT_THRESHOLD,
+      isDisabled = () => false,
+      onPressChange = () => {}
+    } = options;
+
+    let activePointerId = null;
+    let origin = null;
+    let pointerMoved = false;
+    let pressed = false;
+
+    const supportsClosest = target => !!(target && typeof target.closest === 'function');
+
+    const setPressed = (next) => {
+      if(pressed === next) return;
+      pressed = next;
+      try{
+        onPressChange(Boolean(next));
+      }catch(err){
+        if(typeof console !== 'undefined' && console.error){
+          console.error(err);
+        }
+      }
+    };
+
+    const clearPointerState = () => {
+      if(activePointerId !== null && typeof element.releasePointerCapture === 'function'){
+        try{ element.releasePointerCapture(activePointerId); }catch(_){}
+      }
+      activePointerId = null;
+      origin = null;
+      pointerMoved = false;
+      setPressed(false);
+    };
+
+    const isPressExempt = (target) => {
+      if(!target) return false;
+      if(supportsClosest(target)){
+        const match = target.closest('[data-press-exempt="true"]');
+        if(match) return true;
+      }
+      return false;
+    };
+
+    const handlePointerDown = (event) => {
+      if(isDisabled()) return;
+      if(event.pointerType === 'mouse' && event.button !== 0) return;
+      if(isPressExempt(event.target)) return;
+
+      activePointerId = event.pointerId ?? 'mouse';
+      origin = { x: Number(event.clientX) || 0, y: Number(event.clientY) || 0 };
+      pointerMoved = false;
+      setPressed(true);
+
+      if(typeof element.setPointerCapture === 'function' && activePointerId !== null){
+        try{ element.setPointerCapture(activePointerId); }catch(_){}
+      }
+    };
+
+    const handlePointerMove = (event) => {
+      if(activePointerId === null || event.pointerId !== activePointerId) return;
+      if(!origin) return;
+      const dx = (Number(event.clientX) || 0) - origin.x;
+      const dy = (Number(event.clientY) || 0) - origin.y;
+      const distance = Math.hypot(dx, dy);
+      if(distance > threshold){
+        pointerMoved = true;
+        setPressed(false);
+      }
+    };
+
+    const handlePointerUp = (event) => {
+      if(activePointerId === null || event.pointerId !== activePointerId) return;
+      const shouldActivate = !pointerMoved && !isDisabled() && !isPressExempt(event.target);
+      clearPointerState();
+      if(shouldActivate){
+        onActivate(event);
+      }
+    };
+
+    const handlePointerCancel = (event) => {
+      if(activePointerId === null || event.pointerId !== activePointerId) return;
+      clearPointerState();
+    };
+
+    const handlePointerLeave = (event) => {
+      if(activePointerId === null || event.pointerId !== activePointerId) return;
+      setPressed(false);
+    };
+
+    element.addEventListener('pointerdown', handlePointerDown);
+    element.addEventListener('pointermove', handlePointerMove);
+    element.addEventListener('pointerup', handlePointerUp);
+    element.addEventListener('pointercancel', handlePointerCancel);
+    element.addEventListener('pointerleave', handlePointerLeave);
+
+    return {
+      dispose(){
+        element.removeEventListener('pointerdown', handlePointerDown);
+        element.removeEventListener('pointermove', handlePointerMove);
+        element.removeEventListener('pointerup', handlePointerUp);
+        element.removeEventListener('pointercancel', handlePointerCancel);
+        element.removeEventListener('pointerleave', handlePointerLeave);
+        clearPointerState();
+      }
+    };
+  }
+
+  return {
+    attachRowPressInteractions,
+    DEFAULT_THRESHOLD
+  };
+});

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
 
   <script src="data/data-layer.js"></script>
   <script src="assignment-chip-logic.js"></script>
+  <script src="activities-interactions.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -34,6 +34,21 @@
   }));
   const attachGroupPillInteractions = assignmentChipLogic.attachGroupPillInteractions || (() => ({ open: () => {}, close: () => {} }));
 
+  const attachRowPressInteractions = (window.CHSActivitiesInteractions && typeof window.CHSActivitiesInteractions.attachRowPressInteractions === 'function')
+    ? window.CHSActivitiesInteractions.attachRowPressInteractions
+    : (element, { onActivate }) => {
+        const handler = (event) => {
+          if(event && event.target && event.target.closest && event.target.closest('[data-press-exempt="true"]')){
+            return;
+          }
+          onActivate(event);
+        };
+        element.addEventListener('click', handler);
+        return {
+          dispose(){ element.removeEventListener('click', handler); }
+        };
+      };
+
   const dinnerIconSvg = `<svg viewBox="-96 0 512 512" aria-hidden="true" focusable="false" class="dinner-icon"><path fill="currentColor" d="M16,0c-8.837,0 -16,7.163 -16,16l0,187.643c0,7.328 0.667,13.595 2,18.802c1.333,5.207 2.917,9.305 4.75,12.294c1.833,2.989 4.5,5.641 8,7.955c3.5,2.314 6.583,3.953 9.25,4.917c2.667,0.965 6.542,2.266 11.625,3.905c2.399,0.774 5.771,1.515 8.997,2.224c1.163,0.256 2.306,0.507 3.378,0.754l0,225.506c0,17.673 14.327,32 32,32c17.673,0 32,-14.327 32,-32l0,-225.506c1.072,-0.247 2.215,-0.499 3.377,-0.754c3.227,-0.709 6.599,-1.45 8.998,-2.224c5.083,-1.639 8.958,-2.94 11.625,-3.905c2.667,-0.964 5.75,-2.603 9.25,-4.917c3.5,-2.314 6.167,-4.966 8,-7.955c1.833,-2.989 3.417,-7.087 4.75,-12.294c1.333,-5.207 2,-11.474 2,-18.802l0,-187.643c0,-8.837 -7.163,-16 -16,-16c-8.837,0 -16,7.163 -16,16l0,128c0,8.837 -7.163,16 -16,16c-8.837,0 -16,-7.163 -16,-16l0,-128c0,-8.837 -7.163,-16 -16,-16c-8.837,0 -16,7.163 -16,16l0,128c0,8.837 -7.163,16 -16,16c-8.837,0 -16,-7.163 -16,-16l0,-128c0,-8.837 -7.163,-16 -16,-16Zm304,18.286l0,267.143c0,0.458 -0.007,0.913 -0.022,1.364c0.015,0.4 0.022,0.803 0.022,1.207l0,192c0,17.673 -14.327,32 -32,32c-17.673,0 -32,-14.327 -32,-32l0,-160l-69.266,0c-2.41,0 -4.449,-0.952 -6.118,-2.857c-3.523,-3.619 -3.377,-8.286 0.887,-32.286c0.741,-4.762 2.178,-14.428 4.31,-29c2.133,-14.571 4.126,-28.19 5.98,-40.857c1.854,-12.667 4.449,-28.048 7.787,-46.143c3.337,-18.095 6.767,-34.428 10.29,-49c3.522,-14.571 7.926,-29.619 13.21,-45.143c5.284,-15.523 10.8,-28.476 16.547,-38.857c5.748,-10.381 12.515,-18.952 20.302,-25.714c7.787,-6.762 15.945,-10.143 24.473,-10.143l17.799,0c4.821,0 8.992,1.81 12.515,5.429c3.523,3.619 5.284,7.904 5.284,12.857Z"></path></svg>`;
   const pencilSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4.5 16.75 3 21l4.25-1.5L19.5 7.25 16.75 4.5 4.5 16.75Zm12.5-12.5 2.75 2.75 1-1a1.88 1.88 0 0 0 0-2.62l-.88-.88a1.88 1.88 0 0 0-2.62 0l-1 1Z" fill="currentColor"/></svg>';
   const trashSvg = `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><g fill="currentColor"><path d="M0.982,5.073 L2.007,15.339 C2.007,15.705 2.314,16 2.691,16 L10.271,16 C10.648,16 10.955,15.705 10.955,15.339 L11.98,5.073 L0.982,5.073 L0.982,5.073 Z M7.033,14.068 L5.961,14.068 L5.961,6.989 L7.033,6.989 L7.033,14.068 L7.033,14.068 Z M9.033,14.068 L7.961,14.068 L8.961,6.989 L10.033,6.989 L9.033,14.068 L9.033,14.068 Z M5.033,14.068 L3.961,14.068 L2.961,6.989 L4.033,6.989 L5.033,14.068 L5.033,14.068 Z"/><path d="M12.075,2.105 L8.937,2.105 L8.937,0.709 C8.937,0.317 8.481,0 8.081,0 L4.986,0 C4.586,0 4.031,0.225 4.031,0.615 L4.031,2.011 L0.886,2.105 C0.485,2.105 0.159,2.421 0.159,2.813 L0.159,3.968 L12.8,3.968 L12.8,2.813 C12.801,2.422 12.477,2.105 12.075,2.105 L12.075,2.105 Z M4.947,1.44 C4.947,1.128 5.298,0.875 5.73,0.875 L7.294,0.875 C7.726,0.875 8.076,1.129 8.076,1.44 L8.076,2.105 L4.946,2.105 L4.946,1.44 L4.947,1.44 Z"/></g></svg>`;
@@ -467,12 +482,38 @@
         return;
       }
       const row = item.data;
-      const div=document.createElement('div'); div.className='item';
-      const left=document.createElement('div'); left.className='item-left';
+      const div=document.createElement('div');
+      div.className='activity-row';
+      div.setAttribute('role','button');
+      const disabled = !!row.disabled;
+      if(disabled){
+        div.dataset.disabled='true';
+        div.setAttribute('aria-disabled','true');
+        div.tabIndex = -1;
+      }else{
+        div.tabIndex = 0;
+        div.removeAttribute('aria-disabled');
+      }
+      const ariaLabel = `Add activity: ${fmt12(row.start)} to ${fmt12(row.end)} ${row.title}`;
+      div.setAttribute('aria-label', ariaLabel);
 
-      const text=document.createElement('div');
-      text.textContent = `${fmt12(row.start)} - ${fmt12(row.end)} | ${row.title}`;
-      left.appendChild(text);
+      const body=document.createElement('div');
+      body.className='activity-row-body';
+
+      const headline=document.createElement('div');
+      headline.className='activity-row-headline';
+
+      const time=document.createElement('span');
+      time.className='activity-row-time';
+      time.textContent = `${fmt12(row.start)} – ${fmt12(row.end)}`;
+      headline.appendChild(time);
+
+      const title=document.createElement('span');
+      title.className='activity-row-title';
+      title.textContent = row.title;
+      headline.appendChild(title);
+
+      body.appendChild(headline);
 
       const tagWrap=document.createElement('div'); tagWrap.className='tag-row';
 
@@ -485,11 +526,18 @@
         renderAssignments(tagWrap, entry, assignedIds, dateK);
       }
 
-      left.appendChild(tagWrap);
+      body.appendChild(tagWrap);
 
-      const add=document.createElement('button');
-      add.className='add'; add.textContent='+'; add.title='Assign active guests';
-      add.onclick=()=>{
+      const setPressedState = (pressed)=>{
+        if(pressed){
+          div.dataset.pressed='true';
+        }else{
+          delete div.dataset.pressed;
+        }
+      };
+
+      const activate = ()=>{
+        if(disabled){ return; }
         const actives = state.guests.filter(g=>g.active);
         if(actives.length===0){ alert('Toggle at least one guest pill before assigning.'); return; }
         const d = getOrCreateDay(dateK);
@@ -500,7 +548,44 @@
         renderActivities(); markPreviewDirty(); renderPreview();
       };
 
-      div.appendChild(left); div.appendChild(add);
+      // Guard against accidental scroll taps via shared pointer controller.
+      attachRowPressInteractions(div, {
+        onActivate: activate,
+        isDisabled: () => disabled,
+        onPressChange: setPressedState
+      });
+
+      let keyboardPress = false;
+      div.addEventListener('keydown', (event)=>{
+        if(disabled) return;
+        if(event.key===' ' || event.key==='Spacebar'){
+          event.preventDefault();
+          if(!keyboardPress){
+            keyboardPress = true;
+            setPressedState(true);
+          }
+        }else if(event.key==='Enter'){
+          event.preventDefault();
+          activate();
+        }
+      });
+
+      div.addEventListener('keyup', (event)=>{
+        if(!keyboardPress) return;
+        if(event.key===' ' || event.key==='Spacebar'){
+          event.preventDefault();
+          keyboardPress = false;
+          setPressedState(false);
+          if(!disabled){ activate(); }
+        }
+      });
+
+      div.addEventListener('blur', ()=>{
+        keyboardPress = false;
+        setPressedState(false);
+      });
+
+      div.appendChild(body);
       activitiesEl.appendChild(div);
     });
 
@@ -517,8 +602,6 @@
         return;
       }
 
-      // Derive the chip presentation mode (single chips vs Both/Everyone pill) so dynamic guest
-      // changes immediately reflect in the UI without touching the rendering branch below.
       const plan = getAssignmentChipRenderPlan({
         totalGuestsInStay: state.guests.length,
         assignedGuests
@@ -529,8 +612,6 @@
       }
 
       if(plan.type===AssignmentChipMode.GROUP_BOTH || plan.type===AssignmentChipMode.GROUP_EVERYONE){
-        // Share the existing pill styles for both group cases; aria-label communicates the guest
-        // count so screen readers announce "Both"/"Everyone" with the matching total.
         const pill=document.createElement('button');
         pill.type='button';
         pill.className='tag-everyone';
@@ -538,6 +619,8 @@
         pill.setAttribute('aria-label', plan.pillAriaLabel || plan.pillLabel || 'Assigned guests');
         pill.setAttribute('aria-haspopup','true');
         pill.setAttribute('aria-expanded','false');
+        pill.dataset.pressExempt='true';
+        pill.addEventListener('pointerdown', e=> e.stopPropagation());
 
         const label=document.createElement('span');
         label.textContent=plan.pillLabel || '';
@@ -581,6 +664,8 @@
       x.setAttribute('aria-label', `Remove ${guest.name}`);
       x.title=`Remove ${guest.name}`;
       x.textContent='×';
+      x.dataset.pressExempt='true';
+      x.addEventListener('pointerdown', e=> e.stopPropagation());
       x.onclick=(e)=>{
         e.stopPropagation();
         if(!entry) return;
@@ -606,23 +691,32 @@
       const msg=document.createElement('div');
       msg.className='data-status';
       msg.textContent=text;
-      msg.style.padding='1rem';
-      msg.style.background='#fef3c7';
-      msg.style.border='1px solid #f59e0b';
-      msg.style.borderRadius='0.75rem';
-      msg.style.color='#92400e';
+      msg.style.padding='16px';
+      msg.style.background='var(--panel)';
+      msg.style.border='1px solid var(--border)';
+      msg.style.borderRadius='14px';
+      msg.style.color='var(--muted)';
       msg.style.textAlign='center';
+      msg.style.boxShadow='0 1px 2px rgba(12,18,32,.06)';
       activitiesEl.appendChild(msg);
     }
 
     function renderDinner(entry){
       const div=document.createElement('div');
-      div.className='item dinner-item';
-      const left=document.createElement('div');
-      left.className='item-left';
-      const text=document.createElement('div');
-      text.textContent = `${fmt12(entry.start)} | ${entry.title}`;
-      left.appendChild(text);
+      div.className='activity-row dinner-item';
+      const body=document.createElement('div');
+      body.className='activity-row-body';
+      const headline=document.createElement('div');
+      headline.className='activity-row-headline';
+      const time=document.createElement('span');
+      time.className='activity-row-time';
+      time.textContent = fmt12(entry.start);
+      const title=document.createElement('span');
+      title.className='activity-row-title';
+      title.textContent = entry.title;
+      headline.appendChild(time);
+      headline.appendChild(title);
+      body.appendChild(headline);
 
       const tagWrap=document.createElement('div');
       tagWrap.className='tag-row';
@@ -633,11 +727,13 @@
       chip.innerHTML = `<span class="chip-icon">${dinnerIconSvg}</span><span class="chip-pencil">${pencilSvg}</span><span class="sr-only">Edit dinner time</span>`;
       chip.setAttribute('aria-label','Edit dinner time');
       chip.title='Edit dinner time';
+      chip.dataset.pressExempt='true';
+      chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openDinnerPicker({ mode:'edit', dateKey: dateK }));
       tagWrap.appendChild(chip);
 
-      left.appendChild(tagWrap);
-      div.appendChild(left);
+      body.appendChild(tagWrap);
+      div.appendChild(body);
       activitiesEl.appendChild(div);
     }
   }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,63 @@
+@media (prefers-color-scheme: dark){
+  .dinner-item{
+    background:linear-gradient(135deg,rgba(99,127,255,0.22),rgba(99,127,255,0.08));
+    box-shadow:inset 0 0 0 1px rgba(148,163,255,0.32);
+  }
+}
+body[data-theme='dark'] .dinner-item{
+  background:linear-gradient(135deg,rgba(99,127,255,0.22),rgba(99,127,255,0.08));
+  box-shadow:inset 0 0 0 1px rgba(148,163,255,0.32);
+}
 :root{
-  --bg:#f6f7fb; --panel:#fff; --ink:#0c1220; --muted:#6b7280; --border:#e2e8f0;
-  --brand:#2a6bff; --stayBand:#e9efff; --stayEdge:#d7e3ff;
-  --chip:#eef2ff; --chipBorder:#c7d2fe; --chipText:#1e1b4b;
+  --bg:#f6f7fb;
+  --panel:#fff;
+  --ink:#0c1220;
+  --muted:#6b7280;
+  --border:#e2e8f0;
+  --brand:#2a6bff;
+  --stayBand:#e9efff;
+  --stayEdge:#d7e3ff;
+  --chip:#eef2ff;
+  --chipBorder:#c7d2fe;
+  --chipText:#1e1b4b;
+  --activity-divider:rgba(12,18,32,0.08);
+  --activity-hover:rgba(42,107,255,0.06);
+  --activity-pressed:rgba(42,107,255,0.12);
+  --activity-focus-ring:rgba(42,107,255,0.55);
+  --activity-focus-glow:rgba(42,107,255,0.16);
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#0b0f19;
+    --panel:#111827;
+    --ink:#f1f5f9;
+    --muted:#9ca3af;
+    --border:rgba(148,163,184,0.28);
+    --chip:#1f2937;
+    --chipBorder:rgba(148,163,184,0.45);
+    --chipText:#e0e7ff;
+    --activity-divider:rgba(148,163,184,0.28);
+    --activity-hover:rgba(255,255,255,0.06);
+    --activity-pressed:rgba(255,255,255,0.1);
+    --activity-focus-ring:rgba(148,163,255,0.7);
+    --activity-focus-glow:rgba(148,163,255,0.35);
+  }
+}
+body[data-theme='dark']{
+  color-scheme:dark;
+  --bg:#0b0f19;
+  --panel:#111827;
+  --ink:#f1f5f9;
+  --muted:#9ca3af;
+  --border:rgba(148,163,184,0.28);
+  --chip:#1f2937;
+  --chipBorder:rgba(148,163,184,0.45);
+  --chipText:#e0e7ff;
+  --activity-divider:rgba(148,163,184,0.28);
+  --activity-hover:rgba(255,255,255,0.06);
+  --activity-pressed:rgba(255,255,255,0.1);
+  --activity-focus-ring:rgba(148,163,255,0.7);
+  --activity-focus-glow:rgba(148,163,255,0.35);
 }
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.45 -apple-system,system-ui,Segoe UI,Roboto}
@@ -58,9 +114,24 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .guest-pill .x{width:20px;height:20px;border-radius:50%;display:inline-grid;place-items:center;margin-left:2px;opacity:0;transition:opacity .12s ease;cursor:pointer;border:1px solid var(--border);background:#fff;font-size:12px;line-height:1}
 @media(hover:hover){.guest-pill:hover .x{opacity:.9}}
 @media(hover:none){.guest-pill .x{opacity:.7}}
-.item{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:#fff}
-.item-left{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
-.item .add{min-width:40px}
+#activities{display:flex;flex-direction:column;padding:4px 0;}
+.activity-row{position:relative;display:flex;flex-direction:column;gap:8px;padding:14px 16px;border-radius:14px;background:transparent;cursor:pointer;touch-action:pan-y;transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;}
+.activity-row::after{content:"";position:absolute;left:16px;right:16px;bottom:0;height:1px;background:var(--activity-divider);transform-origin:center;transform:scaleY(.5);}
+.activity-row:last-of-type::after{content:none;}
+.activity-row[data-disabled='true']{cursor:default;opacity:.55;}
+.activity-row[data-disabled='true']::after{opacity:.5;}
+.activity-row[data-pressed='true']{transform:scale(0.995);background:var(--activity-pressed);box-shadow:0 8px 18px rgba(12,18,32,.08);}
+@media(prefers-reduced-motion:reduce){.activity-row{transition:none;}.activity-row[data-pressed='true']{transform:none;}}
+@media(hover:hover){.activity-row:not([data-disabled='true']):hover{background:var(--activity-hover);box-shadow:0 14px 32px rgba(12,18,32,.14);}}
+.activity-row:focus-visible{outline:none;box-shadow:0 0 0 2px var(--activity-focus-ring),0 0 0 6px var(--activity-focus-glow);background:var(--activity-hover);}
+.activity-row-body{display:flex;flex-direction:column;gap:6px;min-width:0;}
+.activity-row-headline{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;font-weight:500;letter-spacing:.01em;color:var(--ink);}
+.activity-row-time{font-weight:600;font-variant-numeric:tabular-nums;}
+.activity-row-title{flex:1 1 auto;min-width:0;}
+.activity-row .tag-row{margin-top:2px;}
+.dinner-item{cursor:default;background:linear-gradient(135deg,rgba(42,107,255,.08),rgba(42,107,255,.02));box-shadow:inset 0 0 0 1px rgba(42,107,255,.16);border-radius:16px;}
+.dinner-item::after{content:none;}
+.dinner-item .tag-row{margin-top:6px;}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:4px 12px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;color:var(--chipText);cursor:pointer;appearance:none;font:inherit;line-height:1;transition:box-shadow .2s ease;}
 .tag-everyone:focus{outline:2px solid var(--brand);outline-offset:2px;}
 .tag-everyone .popover{position:absolute;transform:translate(-50%,0);bottom:calc(100% - 4px);left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;z-index:10;min-width:0;width:max-content;max-width:min(360px,90vw);justify-content:flex-start}
@@ -78,7 +149,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .calendar-actions{display:flex;gap:6px;margin-top:8px;flex-wrap:wrap;align-items:center}
 .calendar-actions button{height:32px;padding:0 10px;border-radius:10px}
 #actions{margin:8px 0 12px}
-.dinner-item{border:1px dashed rgba(42,107,255,.4);background:linear-gradient(135deg,rgba(240,244,255,.9),#fff);}
+
 .dinner-chip{width:26px;height:26px;border-radius:50%;border:1px solid var(--chipBorder);background:#fff;display:inline-flex;align-items:center;justify-content:center;color:var(--ink);position:relative;padding:0;cursor:pointer;transition:box-shadow .2s ease,transform .2s ease;}
 .dinner-chip:focus{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 4px 12px rgba(12,18,32,.16);transform:translateY(-1px);}
 .dinner-chip .chip-icon,.dinner-chip .chip-pencil{display:flex;align-items:center;justify-content:center;width:100%;height:100%;}

--- a/tests/activities-interactions.test.js
+++ b/tests/activities-interactions.test.js
@@ -1,0 +1,115 @@
+const assert = require('assert');
+const { attachRowPressInteractions, DEFAULT_THRESHOLD } = require('../activities-interactions');
+
+class StubElement {
+  constructor(){
+    this.listeners = new Map();
+    this.captured = new Set();
+  }
+  addEventListener(type, handler){
+    if(!this.listeners.has(type)){
+      this.listeners.set(type, []);
+    }
+    this.listeners.get(type).push(handler);
+  }
+  removeEventListener(type, handler){
+    const list = this.listeners.get(type);
+    if(!list) return;
+    const idx = list.indexOf(handler);
+    if(idx>-1){
+      list.splice(idx,1);
+    }
+  }
+  dispatch(type, event){
+    const list = this.listeners.get(type) || [];
+    list.slice().forEach(handler => handler(event));
+  }
+  setPointerCapture(id){
+    this.captured.add(id);
+  }
+  releasePointerCapture(id){
+    this.captured.delete(id);
+  }
+}
+
+const makeEvent = (overrides = {}) => ({
+  pointerId: 1,
+  pointerType: 'touch',
+  button: 0,
+  clientX: 0,
+  clientY: 0,
+  target: { closest: () => null },
+  ...overrides
+});
+
+(function activatesWithinThreshold(){
+  const element = new StubElement();
+  const changes = [];
+  let activated = 0;
+  attachRowPressInteractions(element, {
+    onActivate: () => activated++,
+    onPressChange: value => changes.push(value)
+  });
+
+  element.dispatch('pointerdown', makeEvent());
+  element.dispatch('pointerup', makeEvent());
+
+  assert.strictEqual(activated, 1, 'Row press should trigger activation when pointer does not move');
+  assert.deepStrictEqual(changes, [true, false], 'Press state should emit true on down and false on release');
+})();
+
+(function suppressesWhenMovedBeyondThreshold(){
+  const element = new StubElement();
+  let activated = 0;
+  attachRowPressInteractions(element, { onActivate: () => activated++ });
+
+  element.dispatch('pointerdown', makeEvent());
+  element.dispatch('pointermove', makeEvent({ clientX: DEFAULT_THRESHOLD + 1 }));
+  element.dispatch('pointerup', makeEvent());
+
+  assert.strictEqual(activated, 0, 'Movement beyond the threshold should cancel activation');
+})();
+
+(function respectsDisabledState(){
+  const element = new StubElement();
+  let activated = 0;
+  let pressSignals = 0;
+  attachRowPressInteractions(element, {
+    onActivate: () => activated++,
+    isDisabled: () => true,
+    onPressChange: () => { pressSignals++; }
+  });
+
+  element.dispatch('pointerdown', makeEvent());
+  element.dispatch('pointerup', makeEvent());
+
+  assert.strictEqual(activated, 0, 'Disabled rows should never activate');
+  assert.strictEqual(pressSignals, 0, 'Disabled rows should not emit pressed state changes');
+})();
+
+(function ignoresPressExemptTargets(){
+  const element = new StubElement();
+  let activated = 0;
+  attachRowPressInteractions(element, { onActivate: () => activated++ });
+
+  const exemptTarget = { closest: (selector) => selector === '[data-press-exempt="true"]' ? {} : null };
+
+  element.dispatch('pointerdown', makeEvent({ target: exemptTarget }));
+  element.dispatch('pointerup', makeEvent({ target: exemptTarget }));
+
+  assert.strictEqual(activated, 0, 'Elements flagged as press exempt should block activation');
+})();
+
+(function detachesCleanly(){
+  const element = new StubElement();
+  let activated = 0;
+  const controller = attachRowPressInteractions(element, { onActivate: () => activated++ });
+
+  element.dispatch('pointerdown', makeEvent());
+  controller.dispose();
+  element.dispatch('pointerup', makeEvent());
+
+  assert.strictEqual(activated, 0, 'Disposing the controller should remove listeners');
+})();
+
+console.log('Activities interaction tests passed.');


### PR DESCRIPTION
## Summary
- update the activities list so each row acts as the add trigger with hover, press, and keyboard affordances driven by a shared pointer guard helper
- refresh the column visuals with hairline separators, focus styling, dark-mode tokens, and a new sandbox that showcases normal, disabled, and pill states
- add automated coverage for the press interaction controller to guard against accidental activation and ensure clean teardown

## Testing
- node tests/assignment-chip-logic.test.js
- node tests/activities-interactions.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dded342ed483309b3d9fcaec2f0ea8