### PR TITLE
Ensure light override resets chip tokens

### DIFF
--- a/style.css
+++ b/style.css
@@ -84,6 +84,9 @@ body[data-theme='light']{
   --text-primary:#0c1220;
   --text-muted:#6b7280;
   --border-hairline:rgba(12,18,32,0.08);
+  --chip:#eef2ff;
+  --chipBorder:#c7d2fe;
+  --chipText:#1e1b4b;
   --border:#e2e8f0;
   --activity-divider:var(--border-hairline);
   --activity-hover:rgba(42,107,255,0.06);
@@ -102,6 +105,9 @@ body[data-theme='light']{
     --text-primary:#0c1220;
     --text-muted:#6b7280;
     --border-hairline:rgba(12,18,32,0.08);
+    --chip:#eef2ff;
+    --chipBorder:#c7d2fe;
+    --chipText:#1e1b4b;
     --border:#e2e8f0;
     --activity-divider:var(--border-hairline);
     --activity-hover:rgba(42,107,255,0.06);


### PR DESCRIPTION
## Summary
- ensure the light theme override explicitly reassigns chip-related tokens to the light palette
- keep chip styling consistent when forcing light mode over a dark system preference

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de031865408330b0c018ff130031e4