### PR TITLE
Adjust check-in email times weight

### DIFF
--- a/script.js
+++ b/script.js
@@ -1078,14 +1078,16 @@
         makeEl(
           'div',
           'email-activity',
-          `<strong>${escapeHtml(fmt12('11:00'))}</strong> Check-Out | Welcome to stay on property until <strong>${escapeHtml(fmt12('13:00'))}</strong>`,
+          // Wrap the parenthetical stay window in a neutral span so only that time drops out of the bold styling.
+          `<strong>${escapeHtml(fmt12('11:00'))}</strong> Check-Out | Welcome to stay on property until <span class="email-activity-parenthetical-time">${escapeHtml(fmt12('13:00'))}</span>`,
           {html:true}
         );
       const checkinLine = () =>
         makeEl(
           'div',
           'email-activity',
-          `<strong>${escapeHtml(fmt12('16:00'))}</strong> Guaranteed Check-In | Welcome to arrive as early as <strong>${escapeHtml(fmt12('12:00'))}</strong>`,
+          // Same wrapper keeps the early arrival window unbolded while preserving surrounding emphasis.
+          `<strong>${escapeHtml(fmt12('16:00'))}</strong> Guaranteed Check-In | Welcome to arrive as early as <span class="email-activity-parenthetical-time">${escapeHtml(fmt12('12:00'))}</span>`,
           {html:true}
         );
 

--- a/style.css
+++ b/style.css
@@ -162,6 +162,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email sup{font-size:0.65em;vertical-align:super;line-height:0}
 #dayTitle sup{font-size:0.65em;vertical-align:super;line-height:0}
 .email .email-activity{margin:6px 0;font-size:16px}
+.email .email-activity .email-activity-parenthetical-time{
+  /* Reset the parenthetical arrival/stay window to normal weight without affecting other bold text. */
+  font-weight:400;
+}
 .email .email-empty{margin:12px 0 0;font-size:15px;color:var(--muted)}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 


### PR DESCRIPTION
## Summary
- wrap the parenthetical check-in and check-out window times in a neutral span so only those values lose the inherited bold styling
- add a scoped email preview style that resets the parenthetical time weight without affecting other emphasized text

## Testing
- Manual visual QA (light/dark themes)

![Preview of check-in and check-out times](browser:/invocations/rgkbxobo/artifacts/artifacts/checkin-times.png)

------
https://chatgpt.com/codex/tasks/task_e_68de05ef52508330893aa3e9cb0380af