### PR TITLE
Remove parentheses around preview check-in/out times

### DIFF
--- a/script.js
+++ b/script.js
@@ -1081,7 +1081,9 @@
         const row = makeEl('div', 'email-activity');
         row.appendChild(makeEl('strong', undefined, fmt12('11:00')));
         row.appendChild(document.createTextNode(' Check-Out | Welcome to stay on property until '));
-        const stayWindow = makeEl('span', 'email-activity-parenthetical-time', `(${fmt12('13:00')})`);
+        // Parentheses previously came from the template literal around fmt12(); removing them here keeps the
+        // scoped font-weight styling while limiting the change to this specific time string.
+        const stayWindow = makeEl('span', 'email-activity-parenthetical-time', fmt12('13:00'));
         row.appendChild(stayWindow);
         return row;
       };
@@ -1089,8 +1091,8 @@
         const row = makeEl('div', 'email-activity');
         row.appendChild(makeEl('strong', undefined, fmt12('16:00')));
         row.appendChild(document.createTextNode(' Guaranteed Check-In | Welcome to arrive as early as '));
-        // Apply the same scoped span so the early-arrival window stays regular weight.
-        const arrivalWindow = makeEl('span', 'email-activity-parenthetical-time', `(${fmt12('12:00')})`);
+        // Apply the same scoped span so the early-arrival window stays regular weight without reinstating parentheses.
+        const arrivalWindow = makeEl('span', 'email-activity-parenthetical-time', fmt12('12:00'));
         row.appendChild(arrivalWindow);
         return row;
       };


### PR DESCRIPTION
## Summary
- drop the hard-coded parentheses around the preview check-out and check-in time tokens while keeping their scoped font weight styling
- document why the new span text excludes parentheses so the change stays isolated to these two strings

## Testing
- Manual QA in browser to verify check-in/out lines render without parentheses or bolded times

## Preview
![Preview of check-in and check-out lines without parentheses](browser:/invocations/gsxubpge/artifacts/artifacts/checkin-checkout-final.png)

------
https://chatgpt.com/codex/tasks/task_e_68de0c5795388330a084bd9878ea7ed6