### PR TITLE
Improve dinner time picker scrolling experience

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,10 +252,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .dinner-wheels{display:flex;align-items:center;gap:12px;}
 .dinner-wheel-col{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}
 .dinner-wheel-col::after{content:"";position:absolute;left:8px;right:8px;top:50%;height:44px;margin-top:-22px;border-radius:12px;border:1px solid rgba(42,107,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);pointer-events:none;}
-.wheel-viewport{width:72px;height:176px;overflow-y:auto;scroll-snap-type:y mandatory;position:relative;border-radius:12px;padding:0 2px;scrollbar-width:none;-ms-overflow-style:none;}
+.wheel-viewport{width:72px;height:176px;overflow:hidden;position:relative;border-radius:12px;padding:0 2px;scrollbar-width:none;-ms-overflow-style:none;}
 .wheel-viewport::-webkit-scrollbar{display:none;}
 .wheel-list{position:relative;}
-.wheel-option{height:44px;display:flex;align-items:center;justify-content:center;font-size:24px;font-weight:600;scroll-snap-align:center;color:var(--ink);opacity:.82;transition:opacity .2s ease,transform .2s ease;}
+.wheel-option{height:44px;display:flex;align-items:center;justify-content:center;font-size:24px;font-weight:600;color:var(--ink);opacity:.82;transition:opacity .2s ease,transform .2s ease;}
 .wheel-option.selected{opacity:1;transform:scale(1.05);color:var(--brand);}
 .wheel-option.disabled{opacity:.28;}
 .wheel-viewport::before,.wheel-viewport::after{content:"";position:absolute;left:0;right:0;height:44px;pointer-events:none;z-index:2;}


### PR DESCRIPTION
## Summary
- Rebuilt the dinner time wheels with transform-based animations, normalized wheel input, hysteresis, and bounce/snap handling for precise scrolling.
- Added cleanup when dismissing the picker so wheel listeners are disposed with the dialog.
- Updated wheel styling to rely on transform positioning rather than native overflow scrolling.

## Testing
- Not run (project has no automated tests)

![Dinner picker showing 5:30 selection with disabled minutes](browser:/invocations/wnaayzga/artifacts/artifacts/dinner-picker.png)


------
https://chatgpt.com/codex/tasks/task_e_68de0ddd37288330b1aa710ae868436a