### PR TITLE
Implement responsive three-column layout

### DIFF
--- a/layout-demo.html
+++ b/layout-demo.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Layout Preview · CHS Itinerary Builder</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .layout-demo-toolbar{display:flex;flex-wrap:wrap;gap:12px;align-items:center;}
+    .layout-demo-copy{margin:0;color:var(--muted);font-size:14px;}
+    .layout-demo-grid{min-block-size:60vh;}
+    .layout-demo-cardlist{display:flex;flex-direction:column;gap:8px;margin:0;padding:0;list-style:none;}
+    .layout-demo-cardlist li{padding:10px 12px;border-radius:10px;background:var(--surface-elevated);border:1px solid var(--border);color:var(--text-primary);font-size:14px;}
+    .layout-demo-cardlist li strong{display:block;font-size:15px;margin-bottom:2px;}
+    .layout-demo-pillrow{display:flex;flex-wrap:wrap;gap:6px;margin-top:12px;}
+    .layout-demo-pill{padding:6px 12px;border-radius:999px;border:1px solid var(--border);background:var(--surface-elevated);font-size:13px;letter-spacing:.02em;text-transform:uppercase;}
+    .layout-demo-divider{height:1px;background:var(--border-hairline);margin-block:12px;}
+  </style>
+</head>
+<body class="demo-page">
+  <div class="demo-container">
+    <header class="demo-header">
+      <h1>Three-column layout preview</h1>
+      <p class="demo-section-copy">Use this sandbox to verify the responsive grid at mobile, tablet, and desktop widths. The markup below mirrors the production rails so interactions remain unchanged.</p>
+    </header>
+
+    <section class="demo-section">
+      <div class="layout-demo-toolbar">
+        <button id="layoutDemoTheme" type="button">Toggle dark mode</button>
+        <p id="layoutDemoWidth" class="layout-demo-copy" aria-live="polite">Viewport width: <span data-width>—</span>px</p>
+      </div>
+      <div class="app layout-demo-grid">
+        <section class="left card" aria-labelledby="layout-left-title">
+          <h2 id="layout-left-title">Calendar rail</h2>
+          <p class="layout-demo-copy">Navigation, guest chips, and stay actions live here. Resize the window to watch the column stay proportionate to the others.</p>
+          <div class="layout-demo-divider" role="presentation"></div>
+          <ul class="layout-demo-cardlist">
+            <li><strong>Guests</strong>Manage toggles and quick add.</li>
+            <li><strong>Stay controls</strong>Arrival, departure, and stay markers.</li>
+            <li><strong>Calendar</strong>7-column grid with keyboard navigation.</li>
+          </ul>
+        </section>
+        <section class="center card" aria-labelledby="layout-center-title">
+          <h2 id="layout-center-title">Activities rail</h2>
+          <p class="layout-demo-copy">All interactions, list dividers, and hover/press states are unchanged. The column simply scales with its siblings.</p>
+          <div class="layout-demo-divider" role="presentation"></div>
+          <div class="layout-demo-pillrow" role="list">
+            <span class="layout-demo-pill" role="listitem">Dinner</span>
+            <span class="layout-demo-pill" role="listitem">Spa</span>
+            <span class="layout-demo-pill" role="listitem">Custom</span>
+            <span class="layout-demo-pill" role="listitem">Wave One</span>
+          </div>
+          <ul class="layout-demo-cardlist" aria-label="Sample day plan">
+            <li><strong>3:30 PM · Arrival</strong>Guests settle in and drop bags.</li>
+            <li><strong>5:00 PM · Welcome cocktails</strong>Courtyard gathering with live music.</li>
+            <li><strong>7:30 PM · Dinner</strong>Private dining room in the manor.</li>
+          </ul>
+        </section>
+        <section class="right card" aria-labelledby="layout-right-title">
+          <h2 id="layout-right-title">Preview rail</h2>
+          <p class="layout-demo-copy">Email preview retains typography, hairlines, and copy controls. This rail remains focusable last so keyboard order matches production.</p>
+          <div class="layout-demo-divider" role="presentation"></div>
+          <ul class="layout-demo-cardlist" aria-label="Preview highlights">
+            <li><strong>Live email</strong>Editable content with copy + edit actions.</li>
+            <li><strong>Guest context</strong>Auto-populated recipients and notes.</li>
+            <li><strong>Accessibility</strong>Tab order mirrors the live app.</li>
+          </ul>
+        </section>
+      </div>
+    </section>
+  </div>
+
+  <script src="layout-demo.js"></script>
+</body>
+</html>

--- a/layout-demo.js
+++ b/layout-demo.js
@@ -1,0 +1,19 @@
+(() => {
+  const toggle = document.getElementById('layoutDemoTheme');
+  const widthLabel = document.querySelector('#layoutDemoWidth [data-width]');
+
+  const updateWidth = () => {
+    if (!widthLabel) return;
+    widthLabel.textContent = Math.round(window.innerWidth);
+  };
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const next = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+      document.body.dataset.theme = next;
+    });
+  }
+
+  updateWidth();
+  window.addEventListener('resize', updateWidth);
+})();

--- a/style.css
+++ b/style.css
@@ -27,11 +27,10 @@
   --activity-shadow-pressed:0 8px 18px rgba(12,18,32,0.08);
   --activity-focus-ring:rgba(42,107,255,0.55);
   --activity-focus-glow:rgba(42,107,255,0.16);
-  /* Responsive layout tokens keep rails full-bleed while retaining a polished gutter. */
-  --layout-gutter:clamp(0.75rem,3vw,2rem);
+  /* Responsive layout tokens keep columns balanced and gutters subtle across breakpoints. */
+  --space-edge:clamp(1rem,3vw,2.5rem);
   --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
-  --layout-rail-min:clamp(18rem,28vw,22rem);
-  --layout-center-max:clamp(32rem,45vw,48rem);
+  --layout-column-min:clamp(16rem,25vw,22rem);
   /* Legacy aliases maintained for untouched UI pieces */
   --bg:var(--color-bg);
   --panel:var(--surface);
@@ -59,10 +58,9 @@
     --activity-focus-ring:rgba(148,163,255,0.7);
     --activity-focus-glow:rgba(148,163,255,0.35);
     --border:rgba(148,163,184,0.28);
-    --layout-gutter:clamp(0.75rem,3vw,2rem);
+    --space-edge:clamp(1rem,3vw,2.5rem);
     --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
-    --layout-rail-min:clamp(18rem,28vw,22rem);
-    --layout-center-max:clamp(32rem,45vw,48rem);
+    --layout-column-min:clamp(16rem,25vw,22rem);
   }
 }
 body[data-theme='dark']{
@@ -84,10 +82,9 @@ body[data-theme='dark']{
   --activity-focus-ring:rgba(148,163,255,0.7);
   --activity-focus-glow:rgba(148,163,255,0.35);
   --border:rgba(148,163,184,0.28);
-  --layout-gutter:clamp(0.75rem,3vw,2rem);
+  --space-edge:clamp(1rem,3vw,2.5rem);
   --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
-  --layout-rail-min:clamp(18rem,28vw,22rem);
-  --layout-center-max:clamp(32rem,45vw,48rem);
+  --layout-column-min:clamp(16rem,25vw,22rem);
 }
 body[data-theme='light']{
   color-scheme:light;
@@ -109,10 +106,9 @@ body[data-theme='light']{
   --activity-focus-ring:rgba(42,107,255,0.55);
   --activity-focus-glow:rgba(42,107,255,0.16);
   /* Responsive layout tokens keep rails full-bleed while retaining a polished gutter. */
-  --layout-gutter:clamp(0.75rem,3vw,2rem);
+  --space-edge:clamp(1rem,3vw,2.5rem);
   --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
-  --layout-rail-min:clamp(18rem,28vw,22rem);
-  --layout-center-max:clamp(32rem,45vw,48rem);
+  --layout-column-min:clamp(16rem,25vw,22rem);
 }
 @media (prefers-color-scheme: dark){
   body[data-theme='light']{
@@ -150,47 +146,44 @@ body[data-theme='dark'] .dinner-item{
 body{margin:0;background:var(--color-bg);color:var(--text-primary);font:15px/1.45 -apple-system,system-ui,Segoe UI,Roboto}
 .app{
   /*
-   * Clamp-based gutters add safe-area padding so the rails can stretch to the
-   * viewport edge without causing x-scroll, even on devices with notches.
+   * Desktop columns use an even 1fr grid so every rail shares the width.
+   * Safe-area aware gutters keep the layout full-bleed without risking x-scroll.
    */
   display:grid;
   grid-template-columns:minmax(0,1fr);
   gap:var(--layout-gap);
-  padding-block:var(--layout-gutter);
-  padding-inline:var(--layout-gutter);
-  padding-inline-start:calc(var(--layout-gutter) + env(safe-area-inset-left));
-  padding-inline-end:calc(var(--layout-gutter) + env(safe-area-inset-right));
+  align-items:start;
+  padding-block:var(--layout-gap);
+  padding-inline:var(--space-edge);
+  padding-inline-start:calc(var(--space-edge) + env(safe-area-inset-left));
+  padding-inline-end:calc(var(--space-edge) + env(safe-area-inset-right));
   margin:0;
 }
 
-/*
- * The rails no longer inherit global width clamps; each column stretches to
- * fill its grid track so the outer cards can reach the viewport edge.
- */
-.left,.center,.right{width:100%;}
-
-.center{
-  /* Center content remains readable by capping only this column, not the rails. */
-  max-inline-size:var(--layout-center-max);
-  justify-self:center;
+.left,.center,.right{
+  /* Allow cards to shrink within their tracks so content wraps instead of overflowing. */
+  min-inline-size:0;
 }
 
-@media(min-width:820px){
+/*
+ * Medium breakpoints present two equal columns while the third spans the full row.
+ * This keeps visible tracks balanced and avoids awkward stacking during the transition.
+ */
+@media(min-width:960px){
   .app{
-    /* Two-column stage keeps the right rail below while left rail hugs the edge. */
-    grid-template-columns:minmax(0,1fr) minmax(0,var(--layout-center-max));
+    grid-template-columns:repeat(2,minmax(0,1fr));
   }
-  .left,.right{min-inline-size:var(--layout-rail-min);} /* Rails can grow beyond their preferred size. */
   .right{grid-column:1/-1;}
 }
+
+/* Desktop/full-screen: enforce three equal columns that fill the viewport width. */
 @media(min-width:1280px){
   .app{
-    /* Full desktop spread: both rails reach outward while the center stays readable. */
-    grid-template-columns:minmax(0,1fr) minmax(0,var(--layout-center-max)) minmax(0,1fr);
+    grid-template-columns:repeat(3,minmax(var(--layout-column-min),1fr));
   }
   .right{grid-column:auto;}
 }
-.card{background:var(--surface);border:1px solid var(--border);border-radius:16px;padding:16px}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:16px;padding:16px;min-inline-size:0}
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 .space-between{justify-content:space-between}
 h2{margin:0 0 12px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}


### PR DESCRIPTION
## Summary
- update layout spacing tokens and grid structure so the three desktop rails share equal width with safe-area-aware gutters
- document the responsive breakpoints directly in the stylesheet and preserve card wrapping so existing interactions stay intact
- add a dedicated layout-demo route with a theme toggle for quick visual QA of the desktop and narrow fallbacks

## Testing
- Manual QA via layout-demo.html at 1440px, 1024px, and 768px

------
https://chatgpt.com/codex/tasks/task_e_68de240c3ca48330aa244b4f48fd9f33