### PR TITLE
Fix Preview sticky containment on iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,11 +73,21 @@
 
     <!-- Preview -->
     <section class="right card">
-      <h2>Preview</h2>
-      <div id="email" class="email" spellcheck="false"></div>
-      <div class="row stick-right">
-        <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>
-        <button id="copy" title="Copy">⧉</button>
+      <!--
+        iPad layout regression fix: keep the Preview title and body in the same scroll
+        container so Safari no longer detaches the sticky header from its content.
+      -->
+      <div class="preview-shell" role="presentation">
+        <header class="preview-header">
+          <h2>Preview</h2>
+        </header>
+        <div class="preview-body">
+          <div id="email" class="email" spellcheck="false"></div>
+          <div class="row stick-right">
+            <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>
+            <button id="copy" title="Copy">⧉</button>
+          </div>
+        </div>
       </div>
     </section>
   </div>

--- a/style.css
+++ b/style.css
@@ -270,7 +270,27 @@ body{
   .right.card{
     block-size:auto;
     min-block-size:0;
-    overflow:visible;
+    /*
+     * overflow:visible let the heading's top margin collapse with the card so Safari
+     * treated it as detached from the preview body. Clipping hands scroll control to the
+     * preview-shell so sticky behaves locally.
+     */
+    overflow:hidden;
+  }
+  .right.card .preview-shell{
+    /* Scroll containment keeps the header + body travelling together within Preview. */
+    block-size:100%;
+    min-block-size:0;
+    overflow:auto;
+    overscroll-behavior:contain;
+    scrollbar-gutter:stable both-edges;
+    -webkit-overflow-scrolling:touch;
+  }
+  .preview-header{
+    /* Sticky title now anchors to the Preview container rather than the viewport. */
+    position:sticky;
+    top:0;
+    z-index:1;
   }
 }
 
@@ -300,6 +320,26 @@ body{
   display:flex;
   flex-direction:column;
   block-size:100%;
+  min-block-size:0;
+}
+.preview-shell{
+  /* Shared structure keeps the Preview header + body in a single flex column. */
+  display:flex;
+  flex-direction:column;
+  flex:1 1 auto;
+  min-block-size:0;
+}
+.preview-header{
+  /* Convert the old margin gap to padding so sticky backgrounds stay filled. */
+  padding-block-end:12px;
+  background:var(--surface);
+}
+.preview-header h2{margin:0;}
+.preview-body{
+  display:flex;
+  flex-direction:column;
+  flex:1 1 auto;
+  gap:12px;
   min-block-size:0;
 }
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- wrap the Preview header and body in a dedicated flex shell so they live inside the same grid area
- make the Preview shell the scroll container on iPad so the sticky heading stays with its content
- document the margin collapse root cause directly in the markup and styles

## Testing
- Manual - Playwright iPad (WebKit)


------
https://chatgpt.com/codex/tasks/task_e_68decccfc8888330bf6901d3057ba221