### PR TITLE
Adjust iPad preview card scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
     </section>
 
     <!-- Preview -->
-    <section class="right card">
+    <section class="right card preview-card">
       <h2>Preview</h2>
       <div id="email" class="email" spellcheck="false"></div>
       <div class="row stick-right">

--- a/style.css
+++ b/style.css
@@ -270,7 +270,16 @@ body{
   .right.card{
     block-size:auto;
     min-block-size:0;
-    overflow:visible;
+  }
+  .right.card.preview-card{
+    overflow:auto;
+    overscroll-behavior:contain;
+    scrollbar-gutter:stable both-edges;
+    -webkit-overflow-scrolling:touch;
+    block-size:calc(100vh - var(--app-block-padding));
+    block-size:calc(100svh - var(--app-block-padding));
+    block-size:calc(100dvh - var(--app-block-padding));
+    min-block-size:260px;
   }
 }
 


### PR DESCRIPTION
## Summary
- tag the preview section with a dedicated class so tablet overrides can target it directly
- update the iPad media query to give the preview card its own scroll container with viewport-aware sizing

## Testing
- Manual Playwright viewport verification (iPad portrait, landscape, split view)


------
https://chatgpt.com/codex/tasks/task_e_68ded68a2c108330bc9021050e0f53be