### PR TITLE
Ensure wheel line deltas release one step at a time

### DIFF
--- a/time-picker.js
+++ b/time-picker.js
@@ -245,7 +245,7 @@
     let pendingRowDelta = 0;
     let microRowDelta = 0;
     let rowAccumulator = 0;
-    let lineModeScale = ITEM_HEIGHT;
+    let lineRemainder = 0;
     let wheelFrame = null;
     let snapTimer = null;
     let activeGestureId = 0;
@@ -383,15 +383,10 @@
 
     const normalizeDelta = e => {
       if(e.deltaMode === DOM_DELTA_LINE){
-        const lines = Math.max(1, Math.round(Math.abs(e.deltaY)));
-        const candidate = ITEM_HEIGHT / lines;
-        if(lineModeScale === ITEM_HEIGHT){
-          lineModeScale = candidate;
-        }else{
-          const maxDelta = lineModeScale * 0.25;
-          lineModeScale = Math.max(lineModeScale - maxDelta, Math.min(lineModeScale + maxDelta, candidate));
-        }
-        return Math.sign(e.deltaY) * lineModeScale * lines;
+        lineRemainder += e.deltaY;
+        const lines = Math.sign(lineRemainder) * Math.min(1, Math.trunc(Math.abs(lineRemainder)));
+        lineRemainder -= lines;
+        return lines * ITEM_HEIGHT;
       }
       if(e.deltaMode === DOM_DELTA_PAGE){
         return e.deltaY * ITEM_HEIGHT * 3;


### PR DESCRIPTION
## Summary
- add per-wheel line remainder tracking for wheel normalization
- update DOM_DELTA_LINE handling to emit at most one row per event without smoothing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0862984c8330856f03ebae08dbd2