### PR TITLE
Pad section headers to align with calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,9 @@
         </div>
         <!-- Guest tools sit in the calendar flow so iPad can stack header → nav → grid → controls → guests without JS shuffles. -->
         <div class="section guest-section">
-          <h2>Guests</h2>
+          <div class="card-section-header">
+            <h2>Guests</h2>
+          </div>
           <div class="row">
             <input id="guestName" class="guest-input" type="text" placeholder="Add guest" aria-label="Guest name">
             <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
@@ -57,15 +59,16 @@
 
     <!-- Activities -->
     <section class="center card">
-      <div class="row space-between">
+      <div class="card-section-header">
         <h2>Activities</h2>
-        <div class="row day-header">
-          <button id="prevDay" title="Previous Day" aria-label="Previous Day">‹</button>
-          <div class="day-header-details">
-            <div id="dayTitle" class="muted" aria-live="polite"></div>
-          </div>
-          <button id="nextDay" title="Next Day" aria-label="Next Day">›</button>
+      </div>
+
+      <div class="row day-header">
+        <button id="prevDay" title="Previous Day" aria-label="Previous Day">‹</button>
+        <div class="day-header-details">
+          <div id="dayTitle" class="muted" aria-live="polite"></div>
         </div>
+        <button id="nextDay" title="Next Day" aria-label="Next Day">›</button>
       </div>
 
       <div id="actions" class="row">
@@ -80,7 +83,9 @@
 
     <!-- Preview -->
     <section class="right card preview-card">
-      <h2>Preview</h2>
+      <div class="card-section-header">
+        <h2>Preview</h2>
+      </div>
       <div id="email" class="email" spellcheck="false"></div>
       <div class="row stick-right">
         <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>

--- a/style.css
+++ b/style.css
@@ -324,8 +324,9 @@ body{
 .day-header-details #dayTitle{margin:0}
 .space-between{justify-content:space-between}
 h2{margin:0 0 12px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
-.calendar-header{display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin:0 0 12px;padding-bottom:12px;border-bottom:1px solid var(--border-hairline)}
-.calendar-header h2{margin:0}
+.calendar-header,.card-section-header{display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin:0 0 12px;padding-bottom:12px;border-bottom:1px solid var(--border-hairline);inline-size:100%}
+.card-section-header{padding-top:0.4375rem}
+.calendar-header h2,.card-section-header h2{margin:0}
 .calendar-header .season-indicator{margin-inline-start:auto}
 @media(max-width:640px){
   .calendar-header{align-items:flex-start}


### PR DESCRIPTION
## Summary
- add top padding to shared section headers so Activities and Preview dividers sit level with Calendar

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df7077f6cc8330b4f4d55d031328ef