### PR TITLE
Center activities header title with pinned controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -316,13 +316,22 @@ body{
  * Activities header uses a dedicated grid so the navigation buttons occupy
  * fixed edge columns while the title sits in an independent center column.
  * This keeps the title mathematically centered regardless of button width.
+ *
+ * The header rails are further constrained with an inline max-size so the
+ * arrows stay visually connected to the title. Padding provides a consistent
+ * buffer that prevents the title from ever colliding with the controls even
+ * as copy length changes.
  */
 .day-header{
   display:grid;
   grid-template-columns:auto minmax(0,1fr) auto;
   align-items:center;
-  column-gap:12px;
+  column-gap:clamp(0.5rem,1.5vw,0.75rem);
   row-gap:8px;
+  margin-inline:auto;
+  inline-size:100%;
+  max-inline-size:min(100%,26rem);
+  padding-inline:clamp(0.5rem,2vw,0.75rem);
 }
 .day-header-details{
   display:flex;

--- a/style.css
+++ b/style.css
@@ -312,8 +312,32 @@ body{
   min-block-size:0;
 }
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-.day-header{align-items:flex-start;gap:8px}
-.day-header-details{display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;min-width:0}
+/*
+ * Activities header uses a dedicated grid so the navigation buttons occupy
+ * fixed edge columns while the title sits in an independent center column.
+ * This keeps the title mathematically centered regardless of button width.
+ */
+.day-header{
+  display:grid;
+  grid-template-columns:auto minmax(0,1fr) auto;
+  align-items:center;
+  column-gap:12px;
+  row-gap:8px;
+}
+.day-header-details{
+  display:flex;
+  align-items:center;
+  gap:0.75rem;
+  flex-wrap:wrap;
+  min-width:0;
+  /* Center the title block within its grid column so copy length can't pull it off axis. */
+  justify-self:center;
+  justify-content:center;
+  text-align:center;
+}
+/* Pin the navigation buttons to the grid edges so they never drift with title width. */
+#prevDay{justify-self:start}
+#nextDay{justify-self:end}
 .season-indicator{display:inline-flex;align-items:center;font-size:0.75rem;color:var(--text-muted);opacity:0;transform:translateY(-2px);transition:opacity 120ms ease,transform 120ms ease}
 .season-indicator[hidden]{display:none}
 .season-indicator[data-visible="true"]{opacity:1;transform:translateY(0)}


### PR DESCRIPTION
## Summary
- restyle the Activities header to use a three-column grid so navigation buttons stay fixed on the edges
- center the day title within its dedicated column and ensure text wraps gracefully without shifting controls
- add documentation comments to clarify how the layout guarantees centering and pinned positions

## Testing
- Manual QA in Chromium (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68df7632cd188330a18a5579f3c37001