### PR TITLE
Adjust SPA modal layout to respect viewport height

### DIFF
--- a/script.js
+++ b/script.js
@@ -1311,12 +1311,16 @@
     header.appendChild(closeBtn);
     dialog.appendChild(header);
 
+    const body = document.createElement('div');
+    body.className='spa-body';
+    dialog.appendChild(body);
+
     // Compose the SPA flow left-to-right so each decision feeds the next stage:
     // service → duration → start time → therapist → location. Mutating one
     // step immediately cascades the data updates so the preview stays in sync.
     const layout=document.createElement('div');
     layout.className='spa-layout';
-    dialog.appendChild(layout);
+    body.appendChild(layout);
 
     const serviceSection=document.createElement('section');
     serviceSection.className='spa-section spa-section-services';
@@ -1486,7 +1490,7 @@
     guestHelper.className='spa-helper-text';
     guestSection.appendChild(guestHelper);
 
-    dialog.appendChild(guestSection);
+    body.appendChild(guestSection);
 
     const actions=document.createElement('div');
     actions.className='spa-actions';

--- a/script.js
+++ b/script.js
@@ -111,28 +111,115 @@
   const defaultSpaStartTime = '14:00';
   const generateSpaEntryId = () => (crypto.randomUUID ? crypto.randomUUID() : `spa_${Date.now()}_${Math.random().toString(16).slice(2)}`);
 
+  const SPA_CATEGORY_BLUEPRINT = [
+    {
+      id: 'massages',
+      label: 'Massages',
+      match(entry){
+        return entry.category === 'Massages';
+      }
+    },
+    {
+      id: 'treatments',
+      label: 'Treatments',
+      subcategories: [
+        {
+          id: 'treatments-facials',
+          label: 'Facials',
+          match(entry){
+            return entry.category === 'Facials';
+          }
+        },
+        {
+          id: 'treatments-full-body',
+          label: 'Full Body',
+          match(entry){
+            return entry.category === 'Treatments';
+          }
+        }
+      ]
+    },
+    {
+      id: 'therapies',
+      label: 'Therapies',
+      match(entry){
+        return entry.category === 'Therapies';
+      }
+    },
+    {
+      id: 'intentional',
+      label: 'Intentional Wellness Sessions',
+      match(entry){
+        return entry.category === 'Intentional Wellness';
+      }
+    }
+  ];
+
   function buildSpaCatalog(dataset){
     const services = Array.isArray(dataset?.services) ? dataset.services : [];
-    const byCategory = new Map();
+    const entries = [];
     const byName = new Map();
+
     services.forEach(service => {
       const entry = {
         name: service.name,
         category: service.category,
         subcategory: service.subcategory,
         durations: Array.isArray(service.durations) ? service.durations.slice() : Array.isArray(service.durations_minutes) ? service.durations_minutes.slice() : [],
-        supportsInRoom: service.supportsInRoom ?? service.supports_in_room ?? null
+        supportsInRoom: service.supportsInRoom ?? service.supports_in_room ?? null,
+        displayCategoryId: null,
+        displayCategoryLabel: null,
+        displaySubcategoryId: null,
+        displaySubcategoryLabel: null
       };
+      entries.push(entry);
       byName.set(entry.name, entry);
-      if(!byCategory.has(entry.category)){
-        byCategory.set(entry.category, []);
-      }
-      byCategory.get(entry.category).push(entry);
     });
-    const categories = Array.from(byCategory.entries()).map(([category, list]) => ({
-      category,
-      services: list.slice().sort((a,b)=> a.name.localeCompare(b.name))
-    })).sort((a,b)=> a.category.localeCompare(b.category));
+
+    const categories = [];
+    SPA_CATEGORY_BLUEPRINT.forEach(categoryBlueprint => {
+      const category = {
+        id: categoryBlueprint.id,
+        label: categoryBlueprint.label,
+        services: [],
+        subcategories: []
+      };
+
+      if(Array.isArray(categoryBlueprint.subcategories) && categoryBlueprint.subcategories.length){
+        categoryBlueprint.subcategories.forEach(subBlueprint => {
+          const matched = entries.filter(entry => subBlueprint.match(entry));
+          if(matched.length === 0) return;
+          const subcategoryId = subBlueprint.id;
+          const subcategory = {
+            id: subcategoryId,
+            label: subBlueprint.label,
+            services: matched.slice().sort((a,b)=> a.name.localeCompare(b.name))
+          };
+          subcategory.services.forEach(entry => {
+            entry.displayCategoryId = categoryBlueprint.id;
+            entry.displayCategoryLabel = categoryBlueprint.label;
+            entry.displaySubcategoryId = subcategoryId;
+            entry.displaySubcategoryLabel = subBlueprint.label;
+          });
+          category.subcategories.push(subcategory);
+        });
+      }else{
+        const matched = entries.filter(entry => categoryBlueprint.match(entry));
+        if(matched.length === 0) return;
+        category.services = matched.slice().sort((a,b)=> a.name.localeCompare(b.name));
+        category.services.forEach(entry => {
+          entry.displayCategoryId = categoryBlueprint.id;
+          entry.displayCategoryLabel = categoryBlueprint.label;
+          entry.displaySubcategoryId = null;
+          entry.displaySubcategoryLabel = null;
+        });
+      }
+
+      if(category.services.length || category.subcategories.length){
+        categories.push(category);
+      }
+    });
+
     return { categories, byName };
   }
 
@@ -1329,33 +1416,274 @@
     serviceSection.appendChild(serviceHeading);
     const serviceList=document.createElement('div');
     serviceList.className='spa-service-list';
-    serviceList.setAttribute('role','listbox');
+    serviceList.setAttribute('role','tree');
     serviceList.setAttribute('aria-label','Spa services');
     serviceSection.appendChild(serviceList);
 
-    catalog.categories.forEach(group => {
-      const cat=document.createElement('div');
-      cat.className='spa-service-category';
-      const catTitle=document.createElement('h4');
-      catTitle.textContent=group.category;
-      cat.appendChild(catTitle);
-      const list=document.createElement('div');
-      list.className='spa-service-options';
-      group.services.forEach(service => {
-        const option=document.createElement('button');
-        option.type='button';
-        option.className='spa-service-option';
-        option.dataset.serviceName = service.name;
-        option.setAttribute('role','option');
-        option.textContent = service.name;
-        option.addEventListener('click',()=>{
-          selectService(service.name);
-        });
-        list.appendChild(option);
+    // Category/subcategory accordions share a single state object so only one path
+    // stays open at a time. This keeps the vertical stack compact, aligns the
+    // hairline separators with the Activities column, and lets the scrollable
+    // services pane live entirely inside the modal body.
+    const cascadeState = {
+      expandedCategoryId: null,
+      expandedSubcategoryId: null
+    };
+    const categoryRows = new Map();
+    const categoryPanels = new Map();
+    const subcategoryRows = new Map();
+    const subcategoryPanels = new Map();
+    const serviceOptionButtons = new Map();
+
+    const chevronSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M5.22 2.97a.75.75 0 0 0 0 1.06L9.19 8l-3.97 3.97a.75.75 0 1 0 1.06 1.06l4.5-4.5a.75.75 0 0 0 0-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0Z" fill="currentColor"/></svg>';
+    const createChevron = () => {
+      const span=document.createElement('span');
+      span.className='spa-cascade-chevron';
+      span.innerHTML=chevronSvg;
+      span.setAttribute('aria-hidden','true');
+      return span;
+    };
+
+    const setPanelState = (panel, open) => {
+      if(!panel) return;
+      panel.dataset.open = open ? 'true' : 'false';
+      panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+    };
+
+    const applyCascadeState = () => {
+      const activeCategoryId = cascadeState.expandedCategoryId;
+      if(activeCategoryId && !categoryRows.has(activeCategoryId)){
+        cascadeState.expandedCategoryId = null;
+      }
+      const activeSubId = cascadeState.expandedSubcategoryId;
+      if(activeSubId && (!cascadeState.expandedCategoryId || !subcategoryPanels.has(`${cascadeState.expandedCategoryId}::${activeSubId}`))){
+        cascadeState.expandedSubcategoryId = null;
+      }
+
+      categoryRows.forEach((row, id) => {
+        const open = cascadeState.expandedCategoryId === id;
+        row.setAttribute('aria-expanded', open ? 'true' : 'false');
+        row.setAttribute('aria-label', `${open ? 'Collapse' : 'Open'} category: ${row.dataset.label}`);
+        row.classList.toggle('open', open);
+        setPanelState(categoryPanels.get(id), open);
+        if(!open && activeSubId && subcategoryPanels.has(`${id}::${activeSubId}`)){
+          cascadeState.expandedSubcategoryId = null;
+        }
       });
-      cat.appendChild(list);
-      serviceList.appendChild(cat);
+      subcategoryRows.forEach((row, key) => {
+        const catId = row.dataset.categoryId;
+        const subId = row.dataset.subcategoryId;
+        const categoryOpen = cascadeState.expandedCategoryId === catId;
+        const open = categoryOpen && cascadeState.expandedSubcategoryId === subId;
+        row.setAttribute('aria-expanded', open ? 'true' : 'false');
+        row.setAttribute('aria-label', `${open ? 'Collapse' : 'Open'} sub-category: ${row.dataset.label}`);
+        row.classList.toggle('open', open);
+        row.tabIndex = categoryOpen ? 0 : -1;
+        setPanelState(subcategoryPanels.get(key), open);
+      });
+      serviceOptionButtons.forEach(meta => {
+        const { button, categoryId, subcategoryId } = meta;
+        const categoryOpen = cascadeState.expandedCategoryId === categoryId;
+        const subOpen = subcategoryId ? cascadeState.expandedSubcategoryId === subcategoryId : true;
+        const visible = categoryOpen && subOpen;
+        button.tabIndex = visible ? 0 : -1;
+      });
+    };
+
+    const ensureCascadeForService = serviceName => {
+      const meta = catalog.byName.get(serviceName);
+      if(!meta) return;
+      cascadeState.expandedCategoryId = meta.displayCategoryId || cascadeState.expandedCategoryId;
+      if(meta.displaySubcategoryId){
+        cascadeState.expandedSubcategoryId = meta.displaySubcategoryId;
+      }else if(cascadeState.expandedCategoryId === meta.displayCategoryId){
+        cascadeState.expandedSubcategoryId = null;
+      }
+    };
+
+    catalog.categories.forEach(category => {
+      const categoryRow=document.createElement('button');
+      categoryRow.type='button';
+      categoryRow.className='spa-cascade-row spa-category-row';
+      categoryRow.dataset.label = category.label;
+      categoryRow.dataset.categoryId = category.id;
+      categoryRow.id = `spa-category-trigger-${category.id}`;
+      categoryRow.setAttribute('aria-expanded','false');
+      categoryRow.setAttribute('aria-controls', `spa-category-panel-${category.id}`);
+      categoryRow.setAttribute('aria-label',`Open category: ${category.label}`);
+      categoryRow.tabIndex = 0;
+      const categoryLabel=document.createElement('span');
+      categoryLabel.className='spa-cascade-label';
+      categoryLabel.textContent=category.label;
+      categoryRow.appendChild(categoryLabel);
+      categoryRow.appendChild(createChevron());
+      serviceList.appendChild(categoryRow);
+      categoryRows.set(category.id, categoryRow);
+
+      const categoryPanel=document.createElement('div');
+      categoryPanel.className='spa-cascade-panel spa-category-panel';
+      categoryPanel.id = `spa-category-panel-${category.id}`;
+      categoryPanel.setAttribute('role','group');
+      categoryPanel.dataset.categoryPanel = category.id;
+      const categoryPanelInner=document.createElement('div');
+      categoryPanelInner.className='spa-cascade-panel-inner';
+      categoryPanel.appendChild(categoryPanelInner);
+      serviceList.appendChild(categoryPanel);
+      categoryPanels.set(category.id, categoryPanel);
+
+      const expandCategory = () => {
+        const isOpen = cascadeState.expandedCategoryId === category.id;
+        cascadeState.expandedCategoryId = isOpen ? null : category.id;
+        if(isOpen){
+          cascadeState.expandedSubcategoryId = null;
+        }
+        applyCascadeState();
+      };
+
+      categoryRow.addEventListener('click', expandCategory);
+      categoryRow.addEventListener('keydown', e => {
+        if(e.key==='ArrowRight'){
+          e.preventDefault();
+          if(cascadeState.expandedCategoryId !== category.id){
+            cascadeState.expandedCategoryId = category.id;
+            applyCascadeState();
+          }else if(category.subcategories && category.subcategories.length){
+            const first = category.subcategories[0];
+            if(first){
+              cascadeState.expandedSubcategoryId = first.id;
+              applyCascadeState();
+              const key = `${category.id}::${first.id}`;
+              subcategoryRows.get(key)?.focus();
+            }
+          }else if(category.services.length){
+            const firstService = serviceOptionButtons.get(category.services[0].name);
+            firstService?.button.focus();
+          }
+        }
+        if(e.key==='ArrowLeft'){
+          e.preventDefault();
+          if(category.subcategories && category.subcategories.length && cascadeState.expandedSubcategoryId){
+            cascadeState.expandedSubcategoryId = null;
+            applyCascadeState();
+          }else if(cascadeState.expandedCategoryId === category.id){
+            cascadeState.expandedCategoryId = null;
+            cascadeState.expandedSubcategoryId = null;
+            applyCascadeState();
+          }
+        }
+      });
+
+      if(category.subcategories && category.subcategories.length){
+        category.subcategories.forEach(subcategory => {
+          const subKey = `${category.id}::${subcategory.id}`;
+          const subRow=document.createElement('button');
+          subRow.type='button';
+          subRow.className='spa-cascade-row spa-subcategory-row';
+          subRow.dataset.categoryId = category.id;
+          subRow.dataset.subcategoryId = subcategory.id;
+          subRow.dataset.label = subcategory.label;
+          subRow.id = `spa-subcategory-trigger-${subcategory.id}`;
+          subRow.setAttribute('aria-expanded','false');
+          subRow.setAttribute('aria-controls',`spa-subcategory-panel-${subcategory.id}`);
+          subRow.setAttribute('aria-label',`Open sub-category: ${subcategory.label}`);
+          subRow.tabIndex = -1;
+          const subLabel=document.createElement('span');
+          subLabel.className='spa-cascade-label';
+          subLabel.textContent=subcategory.label;
+          subRow.appendChild(subLabel);
+          subRow.appendChild(createChevron());
+          categoryPanelInner.appendChild(subRow);
+          subcategoryRows.set(subKey, subRow);
+
+          const subPanel=document.createElement('div');
+          subPanel.className='spa-cascade-panel spa-subcategory-panel';
+          subPanel.id = `spa-subcategory-panel-${subcategory.id}`;
+          subPanel.setAttribute('role','group');
+          subPanel.dataset.subcategoryPanel = subcategory.id;
+          const subPanelInner=document.createElement('div');
+          subPanelInner.className='spa-cascade-panel-inner';
+          subPanel.appendChild(subPanelInner);
+          categoryPanelInner.appendChild(subPanel);
+          subcategoryPanels.set(subKey, subPanel);
+
+          const expandSub = () => {
+            const categoryOpen = cascadeState.expandedCategoryId === category.id;
+            const isOpen = categoryOpen && cascadeState.expandedSubcategoryId === subcategory.id;
+            cascadeState.expandedCategoryId = category.id;
+            cascadeState.expandedSubcategoryId = isOpen ? null : subcategory.id;
+            applyCascadeState();
+          };
+
+          subRow.addEventListener('click', expandSub);
+          subRow.addEventListener('keydown', e => {
+            if(e.key==='ArrowRight'){
+              e.preventDefault();
+              cascadeState.expandedCategoryId = category.id;
+              cascadeState.expandedSubcategoryId = subcategory.id;
+              applyCascadeState();
+              const firstService = subcategory.services[0];
+              if(firstService){
+                serviceOptionButtons.get(firstService.name)?.button.focus();
+              }
+            }
+            if(e.key==='ArrowLeft'){
+              e.preventDefault();
+              cascadeState.expandedSubcategoryId = null;
+              applyCascadeState();
+              categoryRow.focus();
+            }
+          });
+
+          subcategory.services.forEach(service => {
+            const option=document.createElement('button');
+            option.type='button';
+            option.className='spa-service-button';
+            option.dataset.serviceName = service.name;
+            option.dataset.categoryId = category.id;
+            option.dataset.subcategoryId = subcategory.id;
+            option.textContent=service.name;
+            option.setAttribute('aria-pressed','false');
+            option.setAttribute('aria-label',`Select service: ${service.name}`);
+            option.tabIndex = -1;
+            option.addEventListener('click',()=>{
+              selectService(service.name);
+            });
+            option.addEventListener('keydown', e => {
+              if(e.key==='ArrowLeft'){
+                e.preventDefault();
+                subRow.focus();
+              }
+            });
+            subPanelInner.appendChild(option);
+            serviceOptionButtons.set(service.name, { button: option, categoryId: category.id, subcategoryId: subcategory.id });
+          });
+        });
+      }else{
+        category.services.forEach(service => {
+          const option=document.createElement('button');
+          option.type='button';
+          option.className='spa-service-button';
+          option.dataset.serviceName = service.name;
+          option.dataset.categoryId = category.id;
+          option.textContent=service.name;
+          option.setAttribute('aria-pressed','false');
+          option.setAttribute('aria-label',`Select service: ${service.name}`);
+          option.tabIndex = -1;
+          option.addEventListener('click',()=>{
+            selectService(service.name);
+          });
+          option.addEventListener('keydown', e => {
+            if(e.key==='ArrowLeft'){
+              e.preventDefault();
+              categoryRow.focus();
+            }
+          });
+          categoryPanelInner.appendChild(option);
+          serviceOptionButtons.set(service.name, { button: option, categoryId: category.id, subcategoryId: null });
+        });
+      }
     });
+
+    applyCascadeState();
 
     layout.appendChild(serviceSection);
 
@@ -1515,28 +1843,104 @@
     document.body.appendChild(overlay);
     document.body.classList.add('spa-lock');
 
+    const initialTimeValue = from24Time(getCanonicalSelection()?.start || defaultSpaStartTime);
+    // Replace the AM/PM wheel with a segmented toggle so SPA flows keep the
+    // shared hour/minute physics while presenting a two-state, radiogroup-driven
+    // control for keyboard and screen reader users.
+    const MERIDIEM_VALUES = ['AM','PM'];
+    const meridiemButtons = new Map();
+    const syncMeridiemToggle = meridiem => {
+      const normalized = meridiem === 'PM' ? 'PM' : 'AM';
+      meridiemButtons.forEach((btn, value) => {
+        const selected = value === normalized;
+        btn.classList.toggle('selected', selected);
+        btn.setAttribute('aria-checked', selected ? 'true' : 'false');
+        btn.tabIndex = selected ? 0 : -1;
+      });
+    };
+
+    const handleTimeChange = value => {
+      const targets = resolveEditableTargets();
+      const nextStart = to24Time(value);
+      targets.forEach(id => {
+        const selection = getSelectionFor(id);
+        selection.start = nextStart;
+        // Duration drives end time: recompute whenever start shifts so preview stays live.
+        selection.end = addMinutesToTime(selection.start, selection.durationMinutes);
+      });
+      const sourceId = targets[0] || TEMPLATE_ID;
+      syncTemplateFromSourceId(sourceId);
+      refreshEndPreview();
+      syncMeridiemToggle(value.meridiem);
+    };
+
     const timePicker = createTimePicker ? createTimePicker({
       hourRange:[1,12],
       minuteStep:5,
       showAmPm:true,
-      defaultValue: from24Time(getCanonicalSelection()?.start || defaultSpaStartTime),
+      defaultValue: initialTimeValue,
       ariaLabels:{ hours:'Spa hour', minutes:'Spa minutes', meridiem:'AM or PM' },
-      onChange(value){
-        const targets = resolveEditableTargets();
-        const nextStart = to24Time(value);
-        targets.forEach(id => {
-          const selection = getSelectionFor(id);
-          selection.start = nextStart;
-          // Duration drives end time: recompute whenever start shifts so preview stays live.
-          selection.end = addMinutesToTime(selection.start, selection.durationMinutes);
-        });
-        const sourceId = targets[0] || TEMPLATE_ID;
-        syncTemplateFromSourceId(sourceId);
-        refreshEndPreview();
-      }
+      onChange: handleTimeChange
     }) : null;
+
+    const handleMeridiemInput = (value, { focus } = {}) => {
+      if(!timePicker) return;
+      const normalized = value === 'PM' ? 'PM' : 'AM';
+      if(typeof timePicker.setMeridiem === 'function'){
+        timePicker.setMeridiem(normalized);
+      }else{
+        timePicker.meridiemWheel?.setValue?.(normalized);
+      }
+      const snapshot = timePicker.getValue?.();
+      const active = snapshot?.meridiem || normalized;
+      syncMeridiemToggle(active);
+      if(focus){
+        const btn = meridiemButtons.get(active);
+        if(btn){
+          btn.focus();
+        }
+      }
+    };
+
     if(timePicker){
       timeContainer.appendChild(timePicker.element);
+      if(timePicker.meridiemWheel?.element){
+        timePicker.meridiemWheel.element.setAttribute('tabindex','-1');
+        const parent = timePicker.meridiemWheel.element.parentElement;
+        if(parent){
+          parent.setAttribute('aria-hidden','true');
+        }
+      }
+      const toggle=document.createElement('div');
+      toggle.className='spa-meridiem-toggle';
+      toggle.setAttribute('role','radiogroup');
+      toggle.setAttribute('aria-label','Select AM or PM');
+      MERIDIEM_VALUES.forEach(value => {
+        const radio=document.createElement('button');
+        radio.type='button';
+        radio.className='spa-meridiem-option';
+        radio.dataset.value = value;
+        radio.setAttribute('role','radio');
+        radio.setAttribute('aria-checked','false');
+        radio.tabIndex = -1;
+        radio.textContent = value;
+        radio.addEventListener('click',()=>{
+          handleMeridiemInput(value);
+        });
+        radio.addEventListener('keydown',e=>{
+          if(e.key==='ArrowLeft' || e.key==='ArrowRight'){
+            e.preventDefault();
+            const direction = e.key==='ArrowLeft' ? -1 : 1;
+            const index = MERIDIEM_VALUES.indexOf(value);
+            const nextIndex = (index + direction + MERIDIEM_VALUES.length) % MERIDIEM_VALUES.length;
+            handleMeridiemInput(MERIDIEM_VALUES[nextIndex], { focus:true });
+          }
+        });
+        toggle.appendChild(radio);
+        meridiemButtons.set(value, radio);
+      });
+      timeContainer.appendChild(toggle);
+      syncMeridiemToggle(initialTimeValue.meridiem);
     }else{
       const fallback=document.createElement('div');
       fallback.className='time-picker-fallback';
@@ -1547,11 +1951,16 @@
     function refreshServiceOptions(){
       const selection = getCanonicalSelection();
       const activeName = selection?.serviceName || defaultService?.name || '';
-      serviceList.querySelectorAll('.spa-service-option').forEach(btn => {
-        const selected = btn.dataset.serviceName===activeName;
-        btn.classList.toggle('selected', selected);
-        btn.setAttribute('aria-selected', selected ? 'true' : 'false');
+      if(activeName){
+        ensureCascadeForService(activeName);
+      }
+      serviceOptionButtons.forEach(({ button }, name) => {
+        const selected = name===activeName;
+        button.classList.toggle('selected', selected);
+        button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        button.setAttribute('aria-label', selected ? `Selected service: ${name}` : `Select service: ${name}`);
       });
+      applyCascadeState();
     }
 
     function refreshDurationOptions(){
@@ -1683,7 +2092,12 @@
       const { hour, minute, meridiem } = from24Time(selection.start);
       timePicker.hourWheel?.setValue?.(hour);
       timePicker.minuteWheel?.setValue?.(minute);
-      timePicker.meridiemWheel?.setValue?.(meridiem);
+      if(typeof timePicker.setMeridiem === 'function'){
+        timePicker.setMeridiem(meridiem);
+      }else{
+        timePicker.meridiemWheel?.setValue?.(meridiem);
+      }
+      syncMeridiemToggle(meridiem);
     }
 
     function refreshEndPreview(){

--- a/spa-demo.js
+++ b/spa-demo.js
@@ -134,7 +134,7 @@
     api.openSpaEditor({ mode:'edit', dateKey, entryId: entry.id });
     const doc = frame.contentWindow.document;
     await waitForSelector('.spa-overlay');
-    const cbdBtn = doc.querySelector('.spa-service-option[data-service-name="CBD Massage"]');
+    const cbdBtn = doc.querySelector('.spa-service-button[data-service-name="CBD Massage"]');
     cbdBtn?.click();
     await wait(200);
     const helper = doc.querySelector('.spa-helper-text');

--- a/style.css
+++ b/style.css
@@ -613,24 +613,46 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-layout{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:24px;align-items:start;}
 .spa-section{display:flex;flex-direction:column;gap:16px;}
 .spa-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;}
-.spa-section-services{max-height:480px;overflow:auto;padding-right:4px;}
-.spa-service-list{display:flex;flex-direction:column;gap:18px;}
-.spa-service-category{display:flex;flex-direction:column;gap:8px;}
-.spa-service-category h4{margin:0;font-size:13px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
-.spa-service-options{display:flex;flex-direction:column;gap:8px;}
-.spa-service-option{border-radius:14px;border:1px solid var(--border);background:var(--surface);padding:12px 14px;text-align:left;font:inherit;font-size:15px;color:var(--ink);cursor:pointer;transition:box-shadow .18s ease,transform .18s ease,border-color .18s ease;background-clip:padding-box;}
+.spa-section-services{flex:1 1 auto;min-block-size:0;max-height:480px;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
+.spa-service-list{display:flex;flex-direction:column;border:1px solid var(--border-hairline);border-radius:18px;background:var(--surface);overflow:hidden;box-shadow:0 1px 0 rgba(15,23,42,.02);}
+.spa-cascade-row{display:flex;align-items:center;justify-content:space-between;gap:12px;min-height:48px;padding:14px 20px;border:0;background:transparent;font:inherit;font-size:15px;color:var(--ink);cursor:pointer;text-align:left;transition:background-color .18s ease,color .18s ease;}
+.spa-category-row{font-weight:600;}
+.spa-subcategory-row{padding-inline-start:32px;font-weight:500;}
+.spa-cascade-label{flex:1 1 auto;min-width:0;}
+.spa-cascade-row + .spa-cascade-panel,
+.spa-cascade-panel + .spa-cascade-row,
+.spa-cascade-panel + .spa-cascade-panel{border-top:1px solid var(--border-hairline);}
+.spa-cascade-chevron{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;color:var(--muted);transition:transform .2s ease,color .2s ease;}
+.spa-cascade-row.open .spa-cascade-chevron{transform:rotate(90deg);color:var(--brand);}
+.spa-cascade-panel{display:grid;grid-template-rows:0fr;opacity:0;transition:grid-template-rows .22s ease,opacity .22s ease;pointer-events:none;}
+.spa-cascade-panel[data-open='true']{grid-template-rows:1fr;opacity:1;pointer-events:auto;}
+.spa-cascade-panel-inner{overflow:hidden;display:flex;flex-direction:column;background:var(--surface);}
+.spa-service-button{border:0;background:transparent;padding:12px 20px 12px 56px;text-align:left;font:inherit;font-size:14px;letter-spacing:.01em;color:var(--ink);cursor:pointer;min-height:44px;transition:background-color .18s ease,color .18s ease;font-weight:500;}
+.spa-service-button + .spa-service-button{border-top:1px solid var(--border-hairline);}
+.spa-service-button.selected{color:var(--brand);font-weight:600;}
+.spa-cascade-row:focus-visible,.spa-service-button:focus-visible{outline:2px solid var(--brand);outline-offset:-2px;background:rgba(148,163,184,.16);background:color-mix(in srgb,var(--brand) 12%,var(--surface));}
 @media(hover:hover){
-  .spa-service-option:hover{box-shadow:0 8px 20px rgba(42,107,255,.12);transform:translateY(-1px);}
+  .spa-cascade-row:hover,.spa-service-button:hover{background:rgba(148,163,184,.12);background:color-mix(in srgb,var(--brand) 10%,var(--surface));}
 }
-.spa-service-option.selected{border-color:var(--brand);box-shadow:0 10px 24px rgba(42,107,255,.18);}
-.spa-service-option:focus{outline:2px solid var(--brand);outline-offset:2px;}
+@media(prefers-reduced-motion:reduce){
+  .spa-cascade-panel{transition:none;}
+  .spa-cascade-chevron{transition:none;}
+}
 .spa-block{display:flex;flex-direction:column;gap:12px;padding:18px;border-radius:18px;background:var(--panel);border:1px solid var(--border-hairline);}
 .spa-duration-list,.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
 .spa-radio{border-radius:999px;border:1px solid var(--border);background:#fff;color:var(--ink);padding:8px 16px;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,transform .18s ease,border-color .18s ease;}
 .spa-radio.selected{border-color:var(--brand);color:var(--brand);box-shadow:0 10px 20px rgba(42,107,255,.16);}
 .spa-radio:focus{outline:2px solid var(--brand);outline-offset:2px;}
 .spa-radio[disabled]{opacity:.35;cursor:not-allowed;box-shadow:none;}
-.spa-time-picker{display:flex;justify-content:center;}
+.spa-time-picker{display:flex;flex-direction:column;align-items:center;gap:12px;}
+.spa-time-picker .time-picker-meridiem{display:none;}
+.spa-meridiem-toggle{display:inline-flex;align-items:center;gap:4px;padding:4px;border-radius:999px;border:1px solid var(--border-hairline);background:var(--surface);box-shadow:inset 0 0 0 1px rgba(148,163,184,.06);}
+.spa-meridiem-option{border:0;border-radius:999px;padding:6px 18px;min-width:64px;font:inherit;font-size:14px;font-weight:600;color:var(--muted);background:transparent;cursor:pointer;transition:background-color .18s ease,color .18s ease,box-shadow .18s ease;}
+.spa-meridiem-option.selected{background:var(--brand);color:#fff;box-shadow:0 12px 24px rgba(42,107,255,.24);}
+.spa-meridiem-option:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+@media(hover:hover){
+  .spa-meridiem-option:not(.selected):hover{background:rgba(148,163,184,.12);background:color-mix(in srgb,var(--brand) 14%,var(--surface));color:var(--brand);}
+}
 .spa-end-preview{font-size:14px;color:var(--muted);text-align:center;}
 .spa-helper-text{margin:0;font-size:13px;color:var(--muted);}
 .spa-section-guests{gap:14px;}
@@ -658,7 +680,7 @@ body.spa-lock{overflow:hidden;}
 }
 @media (max-width:720px){
   .spa-dialog{padding:18px;gap:18px;}
-  .spa-service-option{padding:10px 12px;}
+  .spa-service-button{padding:10px 16px 10px 44px;}
   .spa-block{padding:16px;}
   .spa-actions{flex-wrap:wrap;justify-content:flex-start;}
 }

--- a/style.css
+++ b/style.css
@@ -527,8 +527,71 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .dinner-remove:focus{outline:2px solid var(--brand);outline-offset:2px;}
 .dinner-lock{overflow:hidden;}
 .spa-icon{display:block;}
-.spa-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:24px;z-index:2100;}
-.spa-dialog{background:#fff;border-radius:24px;padding:24px;max-width:940px;width:100%;box-shadow:0 26px 54px rgba(12,18,32,.2);border:1px solid rgba(226,232,240,.85);display:flex;flex-direction:column;gap:24px;}
+/*
+ * Modal overlay spacing uses a responsive gutter + safe-area insets so the
+ * dialog always breathes away from the viewport edges (including iOS chrome).
+ */
+.spa-overlay{
+  position:fixed;
+  inset:0;
+  background:rgba(12,18,32,.46);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:2100;
+  --spa-viewport-gutter:clamp(24px,5vh,64px);
+  padding-inline:var(--space-edge);
+  padding-inline-start:calc(var(--space-edge) + env(safe-area-inset-left));
+  padding-inline-end:calc(var(--space-edge) + env(safe-area-inset-right));
+  padding-block:var(--spa-viewport-gutter);
+  padding-block-start:calc(var(--spa-viewport-gutter) + env(safe-area-inset-top));
+  padding-block-end:calc(var(--spa-viewport-gutter) + env(safe-area-inset-bottom));
+}
+/*
+ * Cap the dialog height with viewport units (dvh/svh fallbacks) so it never
+ * exceeds the available vertical space while keeping header/actions visible.
+ */
+.spa-dialog{
+  background:#fff;
+  border-radius:24px;
+  padding:24px;
+  max-width:940px;
+  width:100%;
+  box-shadow:0 26px 54px rgba(12,18,32,.2);
+  border:1px solid rgba(226,232,240,.85);
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+  overflow:hidden;
+  max-height:calc(100vh - 2*var(--spa-viewport-gutter));
+}
+@supports (height:100svh){
+  .spa-dialog{
+    max-height:calc(100svh - 2*var(--spa-viewport-gutter));
+  }
+}
+@supports (height:100dvh){
+  .spa-dialog{
+    max-height:calc(100dvh - 2*var(--spa-viewport-gutter));
+  }
+}
+/*
+ * The body section becomes the scrolling container so content scrolls while
+ * header + footer stay anchored; overscroll containment keeps gestures local.
+ */
+.spa-body{
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+  overflow:auto;
+  min-height:0;
+  overscroll-behavior:contain;
+  -webkit-overflow-scrolling:touch;
+}
+.spa-header,
+.spa-actions{
+  flex-shrink:0;
+}
 .spa-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
 .spa-title{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
 .spa-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:#f1f5f9;font-size:22px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;}

--- a/style.css
+++ b/style.css
@@ -548,8 +548,21 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   padding-block-end:calc(var(--spa-viewport-gutter) + env(safe-area-inset-bottom));
 }
 /*
+ * Desktop browsers switch to a grid centering context so Safari/Chrome honor the
+ * viewport clamping while touch/iPad builds retain the flex alignment that was
+ * already tuned for tablet safe areas.
+ */
+@media (pointer:fine){
+  .spa-overlay{
+    display:grid;
+    place-items:center;
+    align-content:center;
+  }
+}
+/*
  * Cap the dialog height with viewport units (dvh/svh fallbacks) so it never
- * exceeds the available vertical space while keeping header/actions visible.
+ * exceeds the available vertical space; the shared overlay gutter covers the
+ * safe-area breathing room so header/actions always stay accessible.
  */
 .spa-dialog{
   background:#fff;
@@ -583,10 +596,12 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   display:flex;
   flex-direction:column;
   gap:24px;
+  flex:1 1 auto;
   overflow:auto;
   min-height:0;
   overscroll-behavior:contain;
   -webkit-overflow-scrolling:touch;
+  scrollbar-gutter:stable;
 }
 .spa-header,
 .spa-actions{


### PR DESCRIPTION
## Summary
- wrap the SPA editor content in a scrollable body container so header and footer stay fixed
- cap the modal height with viewport-aware sizing and add safe-area aware padding on the overlay
- add internal scrolling/overscroll containment for the modal body to avoid page scroll bleed

## Testing
- Manually verified SPA modal layout in browser (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68e0057896788330bb2cad474f6f72da