### PR TITLE
Polish spa modal controls and styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -569,7 +569,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   background:#fff;
   border-radius:24px;
   padding:24px;
-  max-width:940px;
+  max-width:1160px;
   width:100%;
   box-shadow:0 26px 54px rgba(12,18,32,.2);
   border:1px solid rgba(226,232,240,.85);
@@ -593,19 +593,16 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   }
 }
 /*
- * The body section becomes the scrolling container so content scrolls while
- * header + footer stay anchored; overscroll containment keeps gestures local.
+ * The body now leans on the internal grid to keep every control visible while
+ * the services list handles any overflow; the shell itself no longer scrolls.
  */
 .spa-body{
   display:flex;
   flex-direction:column;
   gap:24px;
   flex:1 1 auto;
-  overflow:auto;
+  overflow:hidden;
   min-height:0;
-  overscroll-behavior:contain;
-  -webkit-overflow-scrolling:touch;
-  scrollbar-gutter:stable;
 }
 .spa-header,
 .spa-actions{
@@ -614,15 +611,26 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
 .spa-title{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
 .spa-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:#f1f5f9;font-size:22px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;}
-.spa-layout{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:24px;align-items:start;}
+.spa-layout{
+  display:grid;
+  grid-template-columns:minmax(0,1.25fr) minmax(0,1fr);
+  grid-template-rows:auto auto;
+  grid-template-areas:
+    "services details"
+    "services guests";
+  gap:24px;
+  align-items:start;
+}
 .spa-section{display:flex;flex-direction:column;gap:16px;}
 .spa-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;}
-.spa-section-guests{grid-column:1 / -1;}
+.spa-section-services{grid-area:services;}
+.spa-section-details{grid-area:details;}
+.spa-section-guests{grid-area:guests;}
 .spa-section-services{flex:1 1 auto;min-block-size:0;max-block-size:100%;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
 .spa-guest-card{gap:14px;}
 .spa-guest-list{display:flex;flex-wrap:wrap;gap:12px;}
 .spa-guest-chip{position:relative;display:inline-flex;align-items:center;}
-.spa-guest-chip.has-confirm .guest-pill{padding-inline-end:30px;}
+.spa-guest-chip.has-confirm .guest-pill{padding-inline-end:42px;}
 .spa-guest-chip-static .guest-pill{cursor:default;}
 .spa-guest-chip.needs-confirm .guest-pill{border-color:var(--brand);color:var(--brand);box-shadow:0 6px 14px rgba(42,107,255,.18);}
 .spa-guest-chip.active .guest-pill{border-color:var(--brand);box-shadow:0 0 0 2px var(--activity-focus-glow),0 6px 16px rgba(42,107,255,.16);}
@@ -630,8 +638,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-guest-pill{font:inherit;font-size:inherit;font-weight:inherit;}
 .spa-guest-pill-static{cursor:default;pointer-events:none;}
 .spa-guest-pill:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.spa-guest-confirm-toggle{position:absolute;inset-block-start:50%;inset-inline-end:6px;transform:translateY(-50%);width:20px;height:20px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);display:inline-grid;place-items:center;opacity:0;cursor:pointer;transition:opacity .12s ease,background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;z-index:1;}
-.spa-guest-confirm-toggle svg{width:12px;height:12px;}
+/* Center the confirmation affordance within the chip so the checkmark stays
+ * perfectly aligned with the pill visuals pulled in from the roster. */
+.spa-guest-confirm-toggle{position:absolute;inset-block-start:50%;inset-inline-end:14px;transform:translateY(-50%);width:22px;height:22px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);display:flex;align-items:center;justify-content:center;line-height:0;opacity:0;cursor:pointer;transition:opacity .12s ease,background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;z-index:1;}
+.spa-guest-confirm-toggle svg{width:12px;height:12px;display:block;}
 .spa-guest-chip.needs-confirm .spa-guest-confirm-toggle{opacity:1;border-color:var(--brand);color:var(--brand);}
 .spa-guest-chip.confirmed .spa-guest-confirm-toggle{opacity:1;background:var(--brand);border-color:var(--brand);color:#fff;box-shadow:0 6px 14px rgba(42,107,255,.25);}
 .spa-guest-chip:focus-within .spa-guest-confirm-toggle{opacity:1;}
@@ -676,6 +686,12 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   .spa-cascade-chevron{transition:none;}
 }
 .spa-block{display:flex;flex-direction:column;gap:12px;padding:18px;border-radius:18px;background:var(--panel);border:1px solid var(--border-hairline);}
+.spa-details-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));grid-template-rows:auto auto;gap:16px;}
+.spa-detail-card{min-height:0;}
+.spa-detail-card-duration{grid-area:1 / 1 / 2 / 2;}
+.spa-detail-card-therapist{grid-area:1 / 2 / 2 / 3;}
+.spa-detail-card-location{grid-area:2 / 1 / 3 / 2;}
+.spa-detail-card-time{grid-area:2 / 2 / 3 / 3;}
 .spa-duration-list,.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
 .spa-radio{border-radius:999px;border:1px solid var(--border);background:#fff;color:var(--ink);padding:8px 16px;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,transform .18s ease,border-color .18s ease;}
 .spa-radio.selected{border-color:var(--brand);color:var(--brand);box-shadow:0 10px 20px rgba(42,107,255,.16);}
@@ -709,9 +725,15 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-remove svg{width:18px;height:18px;}
 .spa-remove:focus{outline:2px solid var(--brand);outline-offset:2px;}
 body.spa-lock{overflow:hidden;}
-@media (max-width:940px){
+@media (max-width:1100px){
+  .spa-dialog{max-width:980px;}
+  .spa-layout{grid-template-columns:minmax(0,1fr) minmax(0,1fr);}
+}
+@media (max-width:920px){
   .spa-dialog{max-width:720px;}
-  .spa-layout{grid-template-columns:1fr;}
+  .spa-layout{grid-template-columns:1fr;grid-template-areas:"guests" "services" "details";}
+  .spa-section-services,.spa-section-details,.spa-section-guests{grid-area:auto;}
+  .spa-details-grid{grid-template-columns:1fr;}
 }
 @media (max-width:720px){
   .spa-dialog{padding:18px;gap:18px;}

--- a/style.css
+++ b/style.css
@@ -621,18 +621,25 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-guest-card{gap:14px;}
 .spa-guest-list{display:flex;flex-wrap:wrap;gap:12px;}
 .spa-guest-chip{position:relative;display:inline-flex;align-items:center;}
+.spa-guest-chip-static .guest-pill{cursor:default;}
 .spa-guest-chip.needs-confirm .guest-pill{border-color:var(--brand);color:var(--brand);box-shadow:0 6px 14px rgba(42,107,255,.18);}
 .spa-guest-chip.active .guest-pill{border-color:var(--brand);box-shadow:0 0 0 2px var(--activity-focus-glow),0 6px 16px rgba(42,107,255,.16);}
 .spa-guest-chip.confirmed .guest-pill{border-color:color-mix(in srgb,var(--brand) 60%,var(--border));}
-.spa-guest-pill{font-size:14px;font-weight:600;}
+.spa-guest-pill{font:inherit;font-size:inherit;font-weight:inherit;}
+.spa-guest-pill-static{cursor:default;pointer-events:none;}
 .spa-guest-pill:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.spa-guest-confirm-toggle{position:absolute;top:-6px;right:-6px;width:24px;height:24px;border-radius:50%;border:1px solid var(--border);background:var(--surface);color:var(--muted);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;z-index:1;}
-.spa-guest-confirm-toggle svg{width:14px;height:14px;}
-.spa-guest-chip.needs-confirm .spa-guest-confirm-toggle{border-color:var(--brand);color:var(--brand);}
-.spa-guest-chip.confirmed .spa-guest-confirm-toggle{background:var(--brand);border-color:var(--brand);color:#fff;box-shadow:0 6px 14px rgba(42,107,255,.25);}
+.spa-guest-confirm-toggle{width:20px;height:20px;border-radius:50%;border:1px solid var(--border);background:var(--surface);color:var(--muted);display:inline-grid;place-items:center;margin-left:2px;opacity:0;cursor:pointer;transition:opacity .12s ease,background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;}
+.spa-guest-confirm-toggle svg{width:12px;height:12px;}
+.spa-guest-chip.needs-confirm .spa-guest-confirm-toggle{opacity:1;border-color:var(--brand);color:var(--brand);}
+.spa-guest-chip.confirmed .spa-guest-confirm-toggle{opacity:1;background:var(--brand);border-color:var(--brand);color:#fff;box-shadow:0 6px 14px rgba(42,107,255,.25);}
+.spa-guest-chip:focus-within .spa-guest-confirm-toggle{opacity:1;}
 .spa-guest-confirm-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 @media(hover:hover){
+  .spa-guest-chip.included:hover .spa-guest-confirm-toggle{opacity:.9;}
   .spa-guest-confirm-toggle:hover{border-color:var(--brand);color:var(--brand);}
+}
+@media(hover:none){
+  .spa-guest-chip.included .spa-guest-confirm-toggle{opacity:.85;}
 }
 .spa-guest-hint{margin-top:-4px;}
 .spa-helper-error{color:var(--brand);font-weight:600;}

--- a/style.css
+++ b/style.css
@@ -456,6 +456,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .dinner-item,.spa-item{cursor:default;background:linear-gradient(135deg,rgba(42,107,255,.08),rgba(42,107,255,.02));box-shadow:inset 0 0 0 1px rgba(42,107,255,.16);border-radius:16px;}
 .dinner-item::after,.spa-item::after{content:none;}
 .dinner-item .tag-row,.spa-item .tag-row{margin-top:6px;}
+.spa-item .spa-meta{margin-top:4px;font-size:13px;color:var(--muted);}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:4px 12px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;color:var(--chipText);cursor:pointer;appearance:none;font:inherit;line-height:1;transition:box-shadow .2s ease;}
 .tag-everyone:focus{outline:2px solid var(--brand);outline-offset:2px;}
 .tag-everyone .popover{position:absolute;transform:translate(-50%,0);bottom:calc(100% - 4px);left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;z-index:10;min-width:0;width:max-content;max-width:min(360px,90vw);justify-content:flex-start}
@@ -621,6 +622,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-guest-card{gap:14px;}
 .spa-guest-list{display:flex;flex-wrap:wrap;gap:12px;}
 .spa-guest-chip{position:relative;display:inline-flex;align-items:center;}
+.spa-guest-chip.has-confirm .guest-pill{padding-inline-end:30px;}
 .spa-guest-chip-static .guest-pill{cursor:default;}
 .spa-guest-chip.needs-confirm .guest-pill{border-color:var(--brand);color:var(--brand);box-shadow:0 6px 14px rgba(42,107,255,.18);}
 .spa-guest-chip.active .guest-pill{border-color:var(--brand);box-shadow:0 0 0 2px var(--activity-focus-glow),0 6px 16px rgba(42,107,255,.16);}
@@ -628,7 +630,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-guest-pill{font:inherit;font-size:inherit;font-weight:inherit;}
 .spa-guest-pill-static{cursor:default;pointer-events:none;}
 .spa-guest-pill:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.spa-guest-confirm-toggle{width:20px;height:20px;border-radius:50%;border:1px solid var(--border);background:var(--surface);color:var(--muted);display:inline-grid;place-items:center;margin-left:2px;opacity:0;cursor:pointer;transition:opacity .12s ease,background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;}
+.spa-guest-confirm-toggle{position:absolute;inset-block-start:50%;inset-inline-end:6px;transform:translateY(-50%);width:20px;height:20px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);display:inline-grid;place-items:center;opacity:0;cursor:pointer;transition:opacity .12s ease,background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;z-index:1;}
 .spa-guest-confirm-toggle svg{width:12px;height:12px;}
 .spa-guest-chip.needs-confirm .spa-guest-confirm-toggle{opacity:1;border-color:var(--brand);color:var(--brand);}
 .spa-guest-chip.confirmed .spa-guest-confirm-toggle{opacity:1;background:var(--brand);border-color:var(--brand);color:#fff;box-shadow:0 6px 14px rgba(42,107,255,.25);}

--- a/style.css
+++ b/style.css
@@ -619,24 +619,21 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-section-guests{grid-column:1 / -1;}
 .spa-section-services{flex:1 1 auto;min-block-size:0;max-block-size:100%;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
 .spa-guest-card{gap:14px;}
-.spa-guest-list{display:flex;flex-wrap:wrap;gap:10px;}
-.spa-guest-chip{display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;border:1px solid var(--activity-divider);background:var(--surface);box-shadow:0 1px 2px rgba(15,23,42,.04);transition:border-color .18s ease,box-shadow .18s ease,background-color .18s ease;}
-.spa-guest-chip.included{border-color:var(--chipBorder);background:var(--chip);}
-.spa-guest-chip.active{border-color:var(--brand);box-shadow:0 0 0 2px var(--activity-focus-glow),0 1px 8px rgba(42,107,255,.18);}
-.spa-guest-chip.needs-confirm{border-color:var(--brand);}
-.spa-guest-pill{border:0;background:transparent;padding:4px 10px;font:inherit;font-size:14px;font-weight:600;color:var(--muted);cursor:pointer;}
-.spa-guest-chip.included .spa-guest-pill{color:var(--ink);}
-.spa-guest-chip.active .spa-guest-pill{color:var(--brand);}
+.spa-guest-list{display:flex;flex-wrap:wrap;gap:12px;}
+.spa-guest-chip{position:relative;display:inline-flex;align-items:center;}
+.spa-guest-chip.needs-confirm .guest-pill{border-color:var(--brand);color:var(--brand);box-shadow:0 6px 14px rgba(42,107,255,.18);}
+.spa-guest-chip.active .guest-pill{border-color:var(--brand);box-shadow:0 0 0 2px var(--activity-focus-glow),0 6px 16px rgba(42,107,255,.16);}
+.spa-guest-chip.confirmed .guest-pill{border-color:color-mix(in srgb,var(--brand) 60%,var(--border));}
+.spa-guest-pill{font-size:14px;font-weight:600;}
 .spa-guest-pill:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.spa-guest-remove{border:1px solid var(--activity-divider);border-radius:999px;width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:var(--surface);color:var(--muted);cursor:pointer;transition:color .18s ease,border-color .18s ease,background-color .18s ease;}
-.spa-guest-remove:hover,.spa-guest-remove:focus-visible{color:var(--ink);border-color:var(--brand);outline:none;}
-.spa-guest-confirm{border-radius:999px;border:1px solid var(--activity-divider);background:var(--surface);padding:4px 12px;font:inherit;font-size:13px;font-weight:600;color:var(--muted);cursor:pointer;transition:background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;}
-.spa-guest-confirm.needs-confirm{border-color:var(--brand);color:var(--brand);background:rgba(42,107,255,0.08);box-shadow:0 6px 14px rgba(42,107,255,0.18);}
-.spa-guest-confirm:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.spa-guest-sync{display:flex;align-items:center;gap:10px;font-size:13px;color:var(--muted);}
-.spa-guest-sync.disabled{opacity:.6;}
-.spa-guest-sync-input{width:16px;height:16px;}
-.spa-guest-sync-label{user-select:none;}
+.spa-guest-confirm-toggle{position:absolute;top:-6px;right:-6px;width:24px;height:24px;border-radius:50%;border:1px solid var(--border);background:var(--surface);color:var(--muted);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;z-index:1;}
+.spa-guest-confirm-toggle svg{width:14px;height:14px;}
+.spa-guest-chip.needs-confirm .spa-guest-confirm-toggle{border-color:var(--brand);color:var(--brand);}
+.spa-guest-chip.confirmed .spa-guest-confirm-toggle{background:var(--brand);border-color:var(--brand);color:#fff;box-shadow:0 6px 14px rgba(42,107,255,.25);}
+.spa-guest-confirm-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+@media(hover:hover){
+  .spa-guest-confirm-toggle:hover{border-color:var(--brand);color:var(--brand);}
+}
 .spa-guest-hint{margin-top:-4px;}
 .spa-helper-error{color:var(--brand);font-weight:600;}
 .spa-service-card{gap:16px;}

--- a/style.css
+++ b/style.css
@@ -577,15 +577,18 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   gap:24px;
   overflow:hidden;
   max-height:calc(100vh - 2*var(--spa-viewport-gutter));
+  max-block-size:min(90vh, calc(100vh - 2*var(--spa-viewport-gutter)));
 }
 @supports (height:100svh){
   .spa-dialog{
     max-height:calc(100svh - 2*var(--spa-viewport-gutter));
+    max-block-size:min(90svh, calc(100svh - 2*var(--spa-viewport-gutter)));
   }
 }
 @supports (height:100dvh){
   .spa-dialog{
     max-height:calc(100dvh - 2*var(--spa-viewport-gutter));
+    max-block-size:min(90dvh, calc(100dvh - 2*var(--spa-viewport-gutter)));
   }
 }
 /*
@@ -613,22 +616,28 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-layout{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:24px;align-items:start;}
 .spa-section{display:flex;flex-direction:column;gap:16px;}
 .spa-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;}
-.spa-section-services{flex:1 1 auto;min-block-size:0;max-height:480px;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
-.spa-service-list{display:flex;flex-direction:column;border:1px solid var(--border-hairline);border-radius:18px;background:var(--surface);overflow:hidden;box-shadow:0 1px 0 rgba(15,23,42,.02);}
+.spa-section-services{flex:1 1 auto;min-block-size:0;max-block-size:100%;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
+.spa-service-card{gap:16px;}
+.spa-service-list{display:flex;flex-direction:column;border:1px solid var(--activity-divider);border-radius:18px;background:var(--surface);overflow:hidden;box-shadow:0 1px 0 rgba(15,23,42,.02);}
 .spa-cascade-row{display:flex;align-items:center;justify-content:space-between;gap:12px;min-height:48px;padding:14px 20px;border:0;background:transparent;font:inherit;font-size:15px;color:var(--ink);cursor:pointer;text-align:left;transition:background-color .18s ease,color .18s ease;}
 .spa-category-row{font-weight:600;}
 .spa-subcategory-row{padding-inline-start:32px;font-weight:500;}
 .spa-cascade-label{flex:1 1 auto;min-width:0;}
-.spa-cascade-row + .spa-cascade-panel,
-.spa-cascade-panel + .spa-cascade-row,
-.spa-cascade-panel + .spa-cascade-panel{border-top:1px solid var(--border-hairline);}
 .spa-cascade-chevron{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;color:var(--muted);transition:transform .2s ease,color .2s ease;}
 .spa-cascade-row.open .spa-cascade-chevron{transform:rotate(90deg);color:var(--brand);}
-.spa-cascade-panel{display:grid;grid-template-rows:0fr;opacity:0;transition:grid-template-rows .22s ease,opacity .22s ease;pointer-events:none;}
+/* Hairline separators mirror the Activities column (half-pixel scale) so the
+ * service cascade aligns visually with the main list. */
+.spa-cascade-row,.spa-service-button{position:relative;}
+.spa-cascade-row::after,.spa-service-button::after{content:"";position:absolute;inset-inline:20px;bottom:0;height:1px;background:var(--activity-divider);transform-origin:center;transform:scaleY(.5);}
+.spa-subcategory-row::after{left:32px;right:20px;}
+.spa-service-button::after{left:56px;right:20px;}
+.spa-cascade-row:last-of-type::after,.spa-service-button:last-of-type::after{content:none;}
+.spa-cascade-panel{position:relative;display:grid;grid-template-rows:0fr;opacity:0;transition:grid-template-rows .22s ease,opacity .22s ease;pointer-events:none;}
+.spa-cascade-panel::before{content:"";position:absolute;left:20px;right:20px;top:0;height:1px;background:var(--activity-divider);transform-origin:center;transform:scaleY(.5);opacity:0;}
 .spa-cascade-panel[data-open='true']{grid-template-rows:1fr;opacity:1;pointer-events:auto;}
+.spa-cascade-panel[data-open='true']::before{opacity:1;}
 .spa-cascade-panel-inner{overflow:hidden;display:flex;flex-direction:column;background:var(--surface);}
 .spa-service-button{border:0;background:transparent;padding:12px 20px 12px 56px;text-align:left;font:inherit;font-size:14px;letter-spacing:.01em;color:var(--ink);cursor:pointer;min-height:44px;transition:background-color .18s ease,color .18s ease;font-weight:500;}
-.spa-service-button + .spa-service-button{border-top:1px solid var(--border-hairline);}
 .spa-service-button.selected{color:var(--brand);font-weight:600;}
 .spa-cascade-row:focus-visible,.spa-service-button:focus-visible{outline:2px solid var(--brand);outline-offset:-2px;background:rgba(148,163,184,.16);background:color-mix(in srgb,var(--brand) 12%,var(--surface));}
 @media(hover:hover){
@@ -653,18 +662,16 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 @media(hover:hover){
   .spa-meridiem-option:not(.selected):hover{background:rgba(148,163,184,.12);background:color-mix(in srgb,var(--brand) 14%,var(--surface));color:var(--brand);}
 }
-.spa-end-preview{font-size:14px;color:var(--muted);text-align:center;}
+.spa-end-preview{display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;color:var(--muted);}
+.spa-start-time-display{border:0;border-radius:10px;padding:6px 14px;font:inherit;font-size:18px;font-weight:600;color:var(--ink);background:transparent;cursor:text;transition:background-color .16s ease,color .16s ease,box-shadow .16s ease;}
+.spa-start-time-display:hover{background:color-mix(in srgb,var(--brand) 10%,var(--surface));color:var(--brand);}
+.spa-start-time-display:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.spa-start-time-input{border-radius:10px;border:1px solid var(--border);padding:6px 12px;font:inherit;font-size:16px;color:var(--ink);min-width:96px;box-shadow:0 2px 6px rgba(15,23,42,.08);}
+.spa-start-time-input[aria-invalid='true']{border-color:var(--brand);box-shadow:0 0 0 2px rgba(42,107,255,.16);}
+.spa-time-separator{color:var(--muted);font-weight:500;}
+.spa-end-time-value{font-size:14px;color:var(--muted);font-weight:500;}
+.spa-time-hint{margin-top:-6px;font-size:12px;text-align:center;color:var(--brand);}
 .spa-helper-text{margin:0;font-size:13px;color:var(--muted);}
-.spa-section-guests{gap:14px;}
-.spa-guest-list{display:flex;flex-direction:column;gap:8px;max-height:240px;overflow:auto;padding-right:4px;}
-.spa-guest-row{display:flex;align-items:center;gap:10px;font-size:14px;color:var(--ink);}
-.spa-guest-row input{width:16px;height:16px;accent-color:var(--brand);}
-.spa-guest-swatch{width:12px;height:12px;border-radius:50%;flex-shrink:0;}
-.spa-sync-row{display:flex;align-items:center;gap:8px;font-size:14px;color:var(--ink);}
-.spa-sync-row input{width:16px;height:16px;accent-color:var(--brand);}
-.spa-guest-editor-row{display:flex;align-items:center;gap:10px;}
-.spa-guest-editor-label{font-size:13px;color:var(--muted);}
-.spa-guest-select{flex:1;min-width:0;border-radius:10px;border:1px solid var(--border);background:var(--surface);padding:7px 12px;font:inherit;color:var(--ink);}
 .spa-actions{display:flex;justify-content:flex-end;gap:12px;margin-top:8px;}
 .spa-confirm{border-radius:999px;border:none;background:var(--brand);color:#fff;padding:10px 24px;font-weight:600;font-size:15px;cursor:pointer;box-shadow:0 16px 34px rgba(42,107,255,.26);transition:box-shadow .18s ease,transform .18s ease;}
 .spa-confirm:focus{outline:2px solid #fff;outline-offset:3px;}

--- a/style.css
+++ b/style.css
@@ -616,7 +616,29 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-layout{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:24px;align-items:start;}
 .spa-section{display:flex;flex-direction:column;gap:16px;}
 .spa-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;}
+.spa-section-guests{grid-column:1 / -1;}
 .spa-section-services{flex:1 1 auto;min-block-size:0;max-block-size:100%;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
+.spa-guest-card{gap:14px;}
+.spa-guest-list{display:flex;flex-wrap:wrap;gap:10px;}
+.spa-guest-chip{display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;border:1px solid var(--activity-divider);background:var(--surface);box-shadow:0 1px 2px rgba(15,23,42,.04);transition:border-color .18s ease,box-shadow .18s ease,background-color .18s ease;}
+.spa-guest-chip.included{border-color:var(--chipBorder);background:var(--chip);}
+.spa-guest-chip.active{border-color:var(--brand);box-shadow:0 0 0 2px var(--activity-focus-glow),0 1px 8px rgba(42,107,255,.18);}
+.spa-guest-chip.needs-confirm{border-color:var(--brand);}
+.spa-guest-pill{border:0;background:transparent;padding:4px 10px;font:inherit;font-size:14px;font-weight:600;color:var(--muted);cursor:pointer;}
+.spa-guest-chip.included .spa-guest-pill{color:var(--ink);}
+.spa-guest-chip.active .spa-guest-pill{color:var(--brand);}
+.spa-guest-pill:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.spa-guest-remove{border:1px solid var(--activity-divider);border-radius:999px;width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:var(--surface);color:var(--muted);cursor:pointer;transition:color .18s ease,border-color .18s ease,background-color .18s ease;}
+.spa-guest-remove:hover,.spa-guest-remove:focus-visible{color:var(--ink);border-color:var(--brand);outline:none;}
+.spa-guest-confirm{border-radius:999px;border:1px solid var(--activity-divider);background:var(--surface);padding:4px 12px;font:inherit;font-size:13px;font-weight:600;color:var(--muted);cursor:pointer;transition:background-color .18s ease,border-color .18s ease,color .18s ease,box-shadow .18s ease;}
+.spa-guest-confirm.needs-confirm{border-color:var(--brand);color:var(--brand);background:rgba(42,107,255,0.08);box-shadow:0 6px 14px rgba(42,107,255,0.18);}
+.spa-guest-confirm:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.spa-guest-sync{display:flex;align-items:center;gap:10px;font-size:13px;color:var(--muted);}
+.spa-guest-sync.disabled{opacity:.6;}
+.spa-guest-sync-input{width:16px;height:16px;}
+.spa-guest-sync-label{user-select:none;}
+.spa-guest-hint{margin-top:-4px;}
+.spa-helper-error{color:var(--brand);font-weight:600;}
 .spa-service-card{gap:16px;}
 .spa-service-list{display:flex;flex-direction:column;border:1px solid var(--activity-divider);border-radius:18px;background:var(--surface);overflow:hidden;box-shadow:0 1px 0 rgba(15,23,42,.02);}
 .spa-cascade-row{display:flex;align-items:center;justify-content:space-between;gap:12px;min-height:48px;padding:14px 20px;border:0;background:transparent;font:inherit;font-size:15px;color:var(--ink);cursor:pointer;text-align:left;transition:background-color .18s ease,color .18s ease;}

--- a/time-picker.js
+++ b/time-picker.js
@@ -937,6 +937,7 @@
       const normalized = normalizeMeridiem(value);
       if(meridiemWheel && typeof meridiemWheel.setValue === 'function'){
         meridiemWheel.setValue(normalized);
+        syncMeridiem(normalized, { emitChange: false });
       }else{
         syncMeridiem(normalized);
       }

--- a/time-picker.js
+++ b/time-picker.js
@@ -630,7 +630,19 @@
         }
       },
       refresh,
-      focus(){ viewport.focus(); },
+      focus(options){
+        if(options){
+          try{
+            viewport.focus(options);
+            return;
+          }catch(err){/* Safari <15 */}
+        }
+        try{
+          viewport.focus({ preventScroll:true });
+        }catch(err){
+          viewport.focus();
+        }
+      },
       dispose(){
         cancelAnimation();
         stopFreeScroll();
@@ -921,8 +933,8 @@
     disabledMinutes = computeDisabledMinutes(currentHour, currentMeridiem);
     minuteWheel.setDisabledChecker(minuteDisabledChecker);
 
-    const focus = () => {
-      hourWheel.focus();
+    const focus = options => {
+      hourWheel.focus(options);
     };
 
     const dispose = () => {


### PR DESCRIPTION
## Summary
- ensure the service cascade renders inside its own card, opens collapsed by default, and reuses the activities hairline separators
- add a click-to-type start time input with AM/PM validation while keeping the meridiem toggle in sync with the wheel physics
- remove the modal guest controls, add the Couple’s Massage location option, and cap the dialog height with viewport units for tablets and desktop

## Testing
- Manual verification in the demo iframe

------
https://chatgpt.com/codex/tasks/task_e_68e411b46058833098e4239cbd329be0