### PR TITLE
Refine SPA appointment modal layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -2151,7 +2151,13 @@
       locationList.appendChild(btn);
     });
     const locationHelper=document.createElement('p');
-    locationHelper.className='spa-helper-text';
+    locationHelper.className='spa-helper-text sr-only';
+    locationHelper.id='spa-location-inroom-helper';
+    locationHelper.setAttribute('aria-live','polite');
+    // Keep the helper text sr-only so the gating reason is announced for assistive
+    // tech without reserving vertical space, preventing layout shifts when
+    // availability toggles.
+    locationList.setAttribute('aria-describedby', locationHelper.id);
     locationGroup.appendChild(locationList);
     locationGroup.appendChild(locationHelper);
     secondaryColumn.appendChild(timeGroup);
@@ -2575,6 +2581,8 @@
         btn.setAttribute('aria-pressed', selection?.location===value ? 'true' : 'false');
         btn.disabled = disabled;
       });
+      // The helper content remains present for screen readers only; visually the
+      // layout stays fixed because the element never takes up space.
       if(!supportsInRoom){
         locationHelper.textContent='In-Room service is unavailable for this treatment.';
       }else{
@@ -2727,6 +2735,8 @@
       // Location gating mirrors the data model: if the current service blocks in-room,
       // surface the helper text and ignore attempts to re-enable the option.
       if(id==='in-room' && canonicalService?.supportsInRoom===false){
+        // Surface the same helper copy for assistive tech without revealing
+        // a visual banner so the modal never jumps.
         locationHelper.textContent='In-Room service is unavailable for this treatment.';
         return;
       }

--- a/script.js
+++ b/script.js
@@ -2051,10 +2051,20 @@
     const detailsSection=document.createElement('section');
     detailsSection.className='spa-section spa-section-details';
     const detailsGrid=document.createElement('div');
-    // 2×4 grid map: col1 rows 1-3 host duration/therapist/location, col2 rows 1-3
-    // hold the start time picker, and row 4 spans both columns for the guests.
+    // Right-half layout: the grid owns two column subgrids stacked above the
+    // full-width guests row. Column 1 (therapist/location) splits its height
+    // 50/50, while column 2 (start time/duration) reserves roughly 3/4 for the
+    // picker and 1/4 for duration so the controls stay proportionally balanced.
     detailsGrid.className='spa-details-grid';
     detailsSection.appendChild(detailsGrid);
+
+    const primaryColumn=document.createElement('div');
+    primaryColumn.className='spa-detail-column spa-detail-column-primary';
+    detailsGrid.appendChild(primaryColumn);
+
+    const secondaryColumn=document.createElement('div');
+    secondaryColumn.className='spa-detail-column spa-detail-column-secondary';
+    detailsGrid.appendChild(secondaryColumn);
     layout.appendChild(detailsSection);
 
     const durationGroup=document.createElement('div');
@@ -2067,7 +2077,6 @@
     durationList.setAttribute('role','radiogroup');
     durationList.setAttribute('aria-label','Duration');
     durationGroup.appendChild(durationList);
-    detailsGrid.appendChild(durationGroup);
 
     const timeGroup=document.createElement('div');
     timeGroup.className='spa-block spa-detail-card spa-detail-card-time';
@@ -2122,7 +2131,6 @@
       therapistList.appendChild(btn);
     });
     therapistGroup.appendChild(therapistList);
-    detailsGrid.appendChild(therapistGroup);
 
     const locationGroup=document.createElement('div');
     locationGroup.className='spa-block spa-detail-card spa-detail-card-location';
@@ -2146,8 +2154,10 @@
     locationHelper.className='spa-helper-text';
     locationGroup.appendChild(locationList);
     locationGroup.appendChild(locationHelper);
-    detailsGrid.appendChild(locationGroup);
-    detailsGrid.appendChild(timeGroup);
+    secondaryColumn.appendChild(timeGroup);
+    secondaryColumn.appendChild(durationGroup);
+    primaryColumn.appendChild(therapistGroup);
+    primaryColumn.appendChild(locationGroup);
     detailsGrid.appendChild(guestSection);
 
     const actions=document.createElement('div');

--- a/script.js
+++ b/script.js
@@ -1452,7 +1452,7 @@
     header.className='spa-header';
     const title=document.createElement('h2');
     title.className='spa-title';
-    title.textContent = mode==='edit' ? 'Edit Spa Appointment' : 'Add Spa Appointment';
+    title.textContent='SPA Appointment';
     const closeBtn=document.createElement('button');
     closeBtn.type='button';
     closeBtn.className='spa-close';
@@ -1475,24 +1475,20 @@
     body.appendChild(layout);
 
     const guestSection=document.createElement('section');
-    guestSection.className='spa-section spa-section-guests';
-    const guestCard=document.createElement('div');
-    guestCard.className='spa-block spa-guest-card';
+    guestSection.className='spa-section spa-section-guests spa-block spa-guest-card spa-detail-card spa-detail-card-guests';
     const guestHeading=document.createElement('h3');
     guestHeading.textContent='Guests';
-    guestCard.appendChild(guestHeading);
+    guestSection.appendChild(guestHeading);
     const guestList=document.createElement('div');
     guestList.className='spa-guest-list';
     guestList.setAttribute('role','group');
-    guestCard.appendChild(guestList);
+    guestSection.appendChild(guestList);
     const guestHint=document.createElement('p');
     guestHint.className='spa-helper-text spa-guest-hint';
     guestHint.id='spa-guest-hint';
     guestHint.setAttribute('aria-live','polite');
     guestHint.hidden=true;
-    guestCard.appendChild(guestHint);
-    guestSection.appendChild(guestCard);
-    layout.appendChild(guestSection);
+    guestSection.appendChild(guestHint);
 
     const buildGuestLabel = guest => guest.name;
 
@@ -1750,8 +1746,31 @@
     serviceList.className='spa-service-list';
     serviceList.setAttribute('role','tree');
     serviceList.setAttribute('aria-label','Spa services');
-    serviceCard.appendChild(serviceList);
+    const serviceScroll=document.createElement('div');
+    serviceScroll.className='spa-service-scroll';
+    serviceScroll.appendChild(serviceList);
+    serviceCard.appendChild(serviceScroll);
     serviceSection.appendChild(serviceCard);
+
+    // Auto-hide scrollbar: apply a class while the user scrolls or hovers so we
+    // can expose a thin thumb, then clear it after a short idle period.
+    let serviceScrollTimer=null;
+    const queueServiceScrollReset=()=>{
+      if(serviceScrollTimer) clearTimeout(serviceScrollTimer);
+      serviceScrollTimer=setTimeout(()=>{
+        serviceScroll.classList.remove('is-scrolling');
+      }, 650);
+    };
+    const activateServiceScroll=()=>{
+      serviceScroll.classList.add('is-scrolling');
+      queueServiceScrollReset();
+    };
+    serviceScroll.addEventListener('scroll', activateServiceScroll, { passive:true });
+    serviceScroll.addEventListener('wheel', activateServiceScroll, { passive:true });
+    serviceScroll.addEventListener('pointermove', activateServiceScroll);
+    serviceScroll.addEventListener('pointerdown', activateServiceScroll);
+    serviceScroll.addEventListener('pointerenter', activateServiceScroll);
+    serviceScroll.addEventListener('pointerleave', queueServiceScrollReset);
 
     // Category/subcategory accordions share a single state object so only one path
     // stays open at a time. This keeps the vertical stack compact, aligns the
@@ -2032,8 +2051,8 @@
     const detailsSection=document.createElement('section');
     detailsSection.className='spa-section spa-section-details';
     const detailsGrid=document.createElement('div');
-    // The detail grid squeezes the remaining controls into two columns so the
-    // dialog fits within its fixed height without requiring a vertical scroll.
+    // 2×4 grid map: col1 rows 1-3 host duration/therapist/location, col2 rows 1-3
+    // hold the start time picker, and row 4 spans both columns for the guests.
     detailsGrid.className='spa-details-grid';
     detailsSection.appendChild(detailsGrid);
     layout.appendChild(detailsSection);
@@ -2129,6 +2148,7 @@
     locationGroup.appendChild(locationHelper);
     detailsGrid.appendChild(locationGroup);
     detailsGrid.appendChild(timeGroup);
+    detailsGrid.appendChild(guestSection);
 
     const actions=document.createElement('div');
     actions.className='spa-actions';
@@ -2150,7 +2170,10 @@
       removeBtn.innerHTML=`${trashSvg}<span class="sr-only">Remove spa appointment</span>`;
       actions.appendChild(removeBtn);
     }
-    dialog.appendChild(actions);
+    // Floating action cluster: the container anchors the + pill to the modal's
+    // bottom-right corner while keeping the optional delete button alongside it,
+    // and the shared aria-label keeps the accessible add/update copy intact.
+    body.appendChild(actions);
 
     const previousFocus=document.activeElement;
 

--- a/script.js
+++ b/script.js
@@ -57,7 +57,11 @@
     const nextMinute = normalized % 60;
     return `${pad(nextHour)}:${pad(nextMinute)}`;
   };
+  // Duration buttons show compact numerals so the three-option case still fits
+  // inside the fixed grid cell; downstream outputs continue to call the full
+  // label helper so confirmation copy retains the "-Minute" suffix.
   const formatDurationLabel = minutes => `${minutes}-Minute`;
+  const formatDurationButtonLabel = minutes => String(minutes);
   const keyDate = d => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
 
   // Utility focus helper so we can safely focus elements without the browser
@@ -2552,7 +2556,10 @@
         btn.type='button';
         btn.className='spa-radio';
         btn.dataset.value=String(minutes);
-        btn.textContent=formatDurationLabel(minutes);
+        // Buttons surface numerals only while the aria-label keeps the
+        // descriptive "-Minute" phrasing for assistive tech parity.
+        btn.textContent=formatDurationButtonLabel(minutes);
+        btn.setAttribute('aria-label', formatDurationLabel(minutes));
         const selected = selection?.durationMinutes===minutes;
         btn.classList.toggle('selected', selected);
         btn.setAttribute('aria-pressed', selected ? 'true' : 'false');

--- a/style.css
+++ b/style.css
@@ -561,9 +561,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   }
 }
 /*
- * Cap the dialog height with viewport units (dvh/svh fallbacks) so it never
- * exceeds the available vertical space; the shared overlay gutter covers the
- * safe-area breathing room so header/actions always stay accessible.
+ * Clamp the dialog to a viewport-aware block size so every open uses the same
+ * frame. The min/max pairing keeps the sheet feeling anchored while the
+ * overlay gutter + viewport units ensure it still respects safe areas.
  */
 .spa-dialog{
   background:#fff;
@@ -577,17 +577,23 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   flex-direction:column;
   gap:24px;
   overflow:hidden;
+  height:min(clamp(560px, 88vh, 920px), calc(100vh - 2*var(--spa-viewport-gutter)));
+  block-size:min(clamp(560px, 88vh, 920px), calc(100vh - 2*var(--spa-viewport-gutter)));
   max-height:calc(100vh - 2*var(--spa-viewport-gutter));
   max-block-size:min(90vh, calc(100vh - 2*var(--spa-viewport-gutter)));
 }
 @supports (height:100svh){
   .spa-dialog{
+    height:min(clamp(560px, 88svh, 920px), calc(100svh - 2*var(--spa-viewport-gutter)));
+    block-size:min(clamp(560px, 88svh, 920px), calc(100svh - 2*var(--spa-viewport-gutter)));
     max-height:calc(100svh - 2*var(--spa-viewport-gutter));
     max-block-size:min(90svh, calc(100svh - 2*var(--spa-viewport-gutter)));
   }
 }
 @supports (height:100dvh){
   .spa-dialog{
+    height:min(clamp(560px, 88dvh, 920px), calc(100dvh - 2*var(--spa-viewport-gutter)));
+    block-size:min(clamp(560px, 88dvh, 920px), calc(100dvh - 2*var(--spa-viewport-gutter)));
     max-height:calc(100dvh - 2*var(--spa-viewport-gutter));
     max-block-size:min(90dvh, calc(100dvh - 2*var(--spa-viewport-gutter)));
   }
@@ -613,12 +619,18 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
 .spa-title{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
 .spa-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:#f1f5f9;font-size:22px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;}
+/*
+ * The layout grid flexes to fill the fixed dialog height so the service column
+ * can own all vertical overflow without forcing the shell to resize.
+ */
 .spa-layout{
   display:grid;
   grid-template-columns:repeat(2,minmax(0,1fr));
   gap:24px;
   align-items:stretch;
   min-height:0;
+  flex:1 1 auto;
+  grid-auto-rows:1fr;
 }
 .spa-section{display:flex;flex-direction:column;gap:16px;min-height:0;}
 .spa-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;}
@@ -789,7 +801,7 @@ body.spa-lock{overflow:hidden;}
 }
 @media (max-width:920px){
   .spa-dialog{max-width:760px;}
-  .spa-layout{grid-template-columns:1fr;gap:20px;}
+  .spa-layout{grid-template-columns:1fr;grid-template-rows:auto;grid-auto-rows:auto;gap:20px;}
   .spa-details-grid{
     grid-template-columns:1fr;
     grid-template-rows:auto;

--- a/style.css
+++ b/style.css
@@ -692,22 +692,33 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .spa-block{display:flex;flex-direction:column;gap:12px;padding:18px;border-radius:18px;background:var(--panel);border:1px solid var(--border-hairline);}
 .spa-details-grid{
+  /*
+   * Right-hand controls: two equal columns host subgrids above a shared guests
+   * row so proportions stay consistent regardless of content length.
+   */
   display:grid;
   grid-template-columns:repeat(2,minmax(0,1fr));
-  grid-template-rows:repeat(4,minmax(0,1fr));
-  grid-template-areas:
-    "duration time"
-    "therapist time"
-    "location time"
-    "guests guests";
+  grid-template-rows:minmax(0,1fr) auto;
   gap:16px;
   min-height:0;
 }
+.spa-detail-column{
+  display:grid;
+  gap:16px;
+  min-height:0;
+}
+.spa-detail-column-primary{
+  grid-column:1;
+  grid-row:1;
+  grid-template-rows:repeat(2,minmax(0,1fr));
+}
+.spa-detail-column-secondary{
+  grid-column:2;
+  grid-row:1;
+  grid-template-rows:3fr 1fr;
+}
 .spa-detail-card{display:flex;flex-direction:column;gap:12px;min-height:0;height:100%;}
-.spa-detail-card-duration{grid-area:duration;}
-.spa-detail-card-therapist{grid-area:therapist;}
-.spa-detail-card-location{grid-area:location;}
-.spa-detail-card-time{grid-area:time;}
+.spa-detail-card-guests{grid-column:1/-1;grid-row:2;}
 .spa-duration-list,.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
 .spa-radio{border-radius:999px;border:1px solid var(--border);background:#fff;color:var(--ink);padding:8px 16px;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,transform .18s ease,border-color .18s ease;}
 .spa-radio.selected{border-color:var(--brand);color:var(--brand);box-shadow:0 10px 20px rgba(42,107,255,.16);}
@@ -782,13 +793,15 @@ body.spa-lock{overflow:hidden;}
   .spa-details-grid{
     grid-template-columns:1fr;
     grid-template-rows:auto;
-    grid-template-areas:
-      "duration"
-      "therapist"
-      "location"
-      "time"
-      "guests";
   }
+  .spa-detail-column{
+    grid-column:1;
+    grid-row:auto;
+    display:flex;
+    flex-direction:column;
+    gap:16px;
+  }
+  .spa-detail-card-guests{grid-column:1;grid-row:auto;}
   .spa-body{padding-block-end:calc(96px + env(safe-area-inset-bottom));}
 }
 @media (max-width:720px){

--- a/style.css
+++ b/style.css
@@ -731,7 +731,19 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .spa-detail-card{display:flex;flex-direction:column;gap:12px;min-height:0;height:100%;}
 .spa-detail-card-guests{grid-column:1/-1;grid-row:2;}
-.spa-duration-list,.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
+.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
+/*
+ * The duration row always reserves space for the three-option case so the
+ * modal frame never needs to grow when Castle Hot Springs exposes its third
+ * length.
+ */
+.spa-duration-list{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(64px,1fr));
+  grid-auto-rows:minmax(44px,auto);
+  gap:10px;
+  align-content:start;
+}
 .spa-radio{border-radius:999px;border:1px solid var(--border);background:#fff;color:var(--ink);padding:8px 16px;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,transform .18s ease,border-color .18s ease;}
 .spa-radio.selected{border-color:var(--brand);color:var(--brand);box-shadow:0 10px 20px rgba(42,107,255,.16);}
 .spa-radio:focus{outline:2px solid var(--brand);outline-offset:2px;}

--- a/style.css
+++ b/style.css
@@ -597,12 +597,14 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
  * the services list handles any overflow; the shell itself no longer scrolls.
  */
 .spa-body{
+  position:relative;
   display:flex;
   flex-direction:column;
   gap:24px;
   flex:1 1 auto;
   overflow:hidden;
   min-height:0;
+  padding-block-end:calc(88px + env(safe-area-inset-bottom));
 }
 .spa-header,
 .spa-actions{
@@ -613,21 +615,15 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:#f1f5f9;font-size:22px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;}
 .spa-layout{
   display:grid;
-  grid-template-columns:minmax(0,1.25fr) minmax(0,1fr);
-  grid-template-rows:auto auto;
-  grid-template-areas:
-    "services details"
-    "services guests";
+  grid-template-columns:repeat(2,minmax(0,1fr));
   gap:24px;
-  align-items:start;
+  align-items:stretch;
+  min-height:0;
 }
-.spa-section{display:flex;flex-direction:column;gap:16px;}
+.spa-section{display:flex;flex-direction:column;gap:16px;min-height:0;}
 .spa-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;}
-.spa-section-services{grid-area:services;}
-.spa-section-details{grid-area:details;}
-.spa-section-guests{grid-area:guests;}
-.spa-section-services{flex:1 1 auto;min-block-size:0;max-block-size:100%;overflow:auto;padding-inline-end:4px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
-.spa-guest-card{gap:14px;}
+.spa-section-services{min-block-size:0;}
+.spa-guest-card{grid-area:guests;gap:14px;}
 .spa-guest-list{display:flex;flex-wrap:wrap;gap:12px;}
 .spa-guest-chip{position:relative;display:inline-flex;align-items:center;}
 .spa-guest-chip.has-confirm .guest-pill{padding-inline-end:42px;}
@@ -655,8 +651,13 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .spa-guest-hint{margin-top:-4px;}
 .spa-helper-error{color:var(--brand);font-weight:600;}
-.spa-service-card{gap:16px;}
+.spa-service-card{display:grid;grid-template-rows:auto 1fr;gap:16px;min-height:0;overflow:hidden;}
 .spa-service-list{display:flex;flex-direction:column;border:1px solid var(--activity-divider);border-radius:18px;background:var(--surface);overflow:hidden;box-shadow:0 1px 0 rgba(15,23,42,.02);}
+.spa-service-scroll{min-height:0;overflow:auto;padding-inline-end:6px;scrollbar-gutter:stable;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;scrollbar-width:none;}
+.spa-service-scroll::-webkit-scrollbar{width:0;height:0;}
+.spa-service-scroll.is-scrolling,.spa-service-scroll:hover{scrollbar-width:thin;}
+.spa-service-scroll.is-scrolling::-webkit-scrollbar,.spa-service-scroll:hover::-webkit-scrollbar{width:6px;height:6px;}
+.spa-service-scroll.is-scrolling::-webkit-scrollbar-thumb,.spa-service-scroll:hover::-webkit-scrollbar-thumb{background:color-mix(in srgb,var(--muted) 48%,transparent);border-radius:999px;}
 .spa-cascade-row{display:flex;align-items:center;justify-content:space-between;gap:12px;min-height:48px;padding:14px 20px;border:0;background:transparent;font:inherit;font-size:15px;color:var(--ink);cursor:pointer;text-align:left;transition:background-color .18s ease,color .18s ease;}
 .spa-category-row{font-weight:600;}
 .spa-subcategory-row{padding-inline-start:32px;font-weight:500;}
@@ -685,13 +686,28 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   .spa-cascade-panel{transition:none;}
   .spa-cascade-chevron{transition:none;}
 }
+@media(prefers-reduced-motion:reduce){
+  .spa-confirm,
+  .spa-remove{transition:none;}
+}
 .spa-block{display:flex;flex-direction:column;gap:12px;padding:18px;border-radius:18px;background:var(--panel);border:1px solid var(--border-hairline);}
-.spa-details-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));grid-template-rows:auto auto;gap:16px;}
-.spa-detail-card{min-height:0;}
-.spa-detail-card-duration{grid-area:1 / 1 / 2 / 2;}
-.spa-detail-card-therapist{grid-area:1 / 2 / 2 / 3;}
-.spa-detail-card-location{grid-area:2 / 1 / 3 / 2;}
-.spa-detail-card-time{grid-area:2 / 2 / 3 / 3;}
+.spa-details-grid{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  grid-template-rows:repeat(4,minmax(0,1fr));
+  grid-template-areas:
+    "duration time"
+    "therapist time"
+    "location time"
+    "guests guests";
+  gap:16px;
+  min-height:0;
+}
+.spa-detail-card{display:flex;flex-direction:column;gap:12px;min-height:0;height:100%;}
+.spa-detail-card-duration{grid-area:duration;}
+.spa-detail-card-therapist{grid-area:therapist;}
+.spa-detail-card-location{grid-area:location;}
+.spa-detail-card-time{grid-area:time;}
 .spa-duration-list,.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
 .spa-radio{border-radius:999px;border:1px solid var(--border);background:#fff;color:var(--ink);padding:8px 16px;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,transform .18s ease,border-color .18s ease;}
 .spa-radio.selected{border-color:var(--brand);color:var(--brand);box-shadow:0 10px 20px rgba(42,107,255,.16);}
@@ -716,30 +732,72 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-end-time-value{font-size:14px;color:var(--muted);font-weight:500;}
 .spa-time-hint{margin-top:-6px;font-size:12px;text-align:center;color:var(--brand);}
 .spa-helper-text{margin:0;font-size:13px;color:var(--muted);}
-.spa-actions{display:flex;justify-content:flex-end;gap:12px;margin-top:8px;}
-.spa-confirm{border-radius:999px;border:none;background:var(--brand);color:#fff;padding:10px 24px;font-weight:600;font-size:15px;cursor:pointer;box-shadow:0 16px 34px rgba(42,107,255,.26);transition:box-shadow .18s ease,transform .18s ease;}
+.spa-actions{
+  position:absolute;
+  inset-inline-end:calc(24px + env(safe-area-inset-right));
+  inset-block-end:calc(24px + env(safe-area-inset-bottom));
+  display:flex;
+  gap:12px;
+  align-items:flex-end;
+  pointer-events:none;
+  z-index:2;
+}
+.spa-actions > *{pointer-events:auto;}
+.spa-confirm{
+  width:60px;
+  height:60px;
+  min-width:60px;
+  min-height:60px;
+  border-radius:999px;
+  border:none;
+  background:var(--brand);
+  color:#fff;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:600;
+  font-size:28px;
+  line-height:1;
+  cursor:pointer;
+  box-shadow:0 20px 38px rgba(42,107,255,.28);
+  transition:box-shadow .2s ease,transform .2s ease;
+}
+.spa-confirm span[aria-hidden="true"]{display:block;line-height:1;font-size:28px;}
 .spa-confirm:focus{outline:2px solid #fff;outline-offset:3px;}
+.spa-confirm:hover{box-shadow:0 24px 46px rgba(42,107,255,.3);}
 .spa-confirm:active{transform:translateY(1px);}
 .spa-confirm:disabled{opacity:.5;cursor:not-allowed;box-shadow:none;}
-.spa-remove{width:44px;height:44px;border-radius:50%;border:1px solid var(--border);background:#fff;color:var(--muted);display:flex;align-items:center;justify-content:center;padding:0;}
+.spa-remove{width:44px;height:44px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);display:flex;align-items:center;justify-content:center;padding:0;box-shadow:0 10px 20px rgba(15,23,42,.12);transition:box-shadow .2s ease,transform .2s ease;}
 .spa-remove svg{width:18px;height:18px;}
 .spa-remove:focus{outline:2px solid var(--brand);outline-offset:2px;}
+.spa-remove:hover{box-shadow:0 12px 24px rgba(15,23,42,.16);}
+.spa-remove:active{transform:translateY(1px);}
 body.spa-lock{overflow:hidden;}
 @media (max-width:1100px){
   .spa-dialog{max-width:980px;}
-  .spa-layout{grid-template-columns:minmax(0,1fr) minmax(0,1fr);}
 }
 @media (max-width:920px){
-  .spa-dialog{max-width:720px;}
-  .spa-layout{grid-template-columns:1fr;grid-template-areas:"guests" "services" "details";}
-  .spa-section-services,.spa-section-details,.spa-section-guests{grid-area:auto;}
-  .spa-details-grid{grid-template-columns:1fr;}
+  .spa-dialog{max-width:760px;}
+  .spa-layout{grid-template-columns:1fr;gap:20px;}
+  .spa-details-grid{
+    grid-template-columns:1fr;
+    grid-template-rows:auto;
+    grid-template-areas:
+      "duration"
+      "therapist"
+      "location"
+      "time"
+      "guests";
+  }
+  .spa-body{padding-block-end:calc(96px + env(safe-area-inset-bottom));}
 }
 @media (max-width:720px){
   .spa-dialog{padding:18px;gap:18px;}
   .spa-service-button{padding:10px 16px 10px 44px;}
   .spa-block{padding:16px;}
-  .spa-actions{flex-wrap:wrap;justify-content:flex-start;}
+  .spa-actions{inset-inline-end:calc(16px + env(safe-area-inset-right));inset-block-end:calc(20px + env(safe-area-inset-bottom));}
+  .spa-confirm{width:56px;height:56px;min-width:56px;min-height:56px;font-size:26px;}
+  .spa-confirm span[aria-hidden="true"]{font-size:26px;}
 }
 .demo-page{background:var(--bg);padding:24px;}
 .demo-container{max-width:960px;margin:0 auto;display:flex;flex-direction:column;gap:24px;}


### PR DESCRIPTION
## Summary
- split the SPA modal into a fixed-height service pane and a right-hand 2×4 details grid with updated header copy
- add an auto-hiding scrollbar to the services list and float the primary “+” action within the modal safe area
- refresh the detail card styling and responsive rules to keep controls balanced across breakpoints

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e472a34eec8330a9c3d0937ea934f8