### PR TITLE
Adjust itinerary time weight in email preview

### DIFF
--- a/script.js
+++ b/script.js
@@ -3342,7 +3342,9 @@
         totalGuestsInStay: state.guests.length
       });
       const guestLabel = guestNames.length ? ` | ${guestNames.map(name => escapeHtml(name)).join(' | ')}` : '';
-      lines.push(`${escapeHtml(fmt12(base.start))} – ${escapeHtml(fmt12(base.end))} | ${escapeHtml(serviceTitle)} | ${escapeHtml(therapist)} | ${escapeHtml(location)}${guestLabel}`);
+      const timeRange = `<span class="email-activity-time">${escapeHtml(fmt12(base.start))} – ${escapeHtml(fmt12(base.end))}</span>`;
+      // Wrap the spa time range so we can normalize its weight in the preview email.
+      lines.push(`${timeRange} | ${escapeHtml(serviceTitle)} | ${escapeHtml(therapist)} | ${escapeHtml(location)}${guestLabel}`);
       return lines;
     }
     const orderedIds = state.guests.map(g=>g.id).filter(id => appointments.some(app=>app.guestId===id));
@@ -3354,7 +3356,9 @@
       const therapist = spaTherapistLabel(app.therapist);
       const location = spaLocationLabel(app.location);
       const guestLabel = guest ? ` | ${escapeHtml(guest.name)}` : '';
-      lines.push(`${escapeHtml(fmt12(app.start))} – ${escapeHtml(fmt12(app.end))} | ${escapeHtml(serviceTitle)} | ${escapeHtml(therapist)} | ${escapeHtml(location)}${guestLabel}`);
+      const timeRange = `<span class="email-activity-time">${escapeHtml(fmt12(app.start))} – ${escapeHtml(fmt12(app.end))}</span>`;
+      // Wrap the per-guest spa time so its font weight matches the rest of the itinerary line.
+      lines.push(`${timeRange} | ${escapeHtml(serviceTitle)} | ${escapeHtml(therapist)} | ${escapeHtml(location)}${guestLabel}`);
     });
     return lines;
   }
@@ -3489,12 +3493,14 @@
         }else if(endTime){
           timeSegment = endTime;
         }
+        // Wrap generic itinerary times so we can remove bold styling without affecting other text.
+        const timeMarkup = timeSegment ? `<span class="email-activity-time">${timeSegment}</span>` : '';
         const title = escapeHtml(it.title||'');
         daySection.appendChild(
           makeEl(
             'div',
             'email-activity',
-            `${timeSegment}${timeSegment && title ? ' | ' : ''}${title}${tag}`,
+            `${timeMarkup}${timeMarkup && title ? ' | ' : ''}${title}${tag}`,
             {html:true}
           )
         );

--- a/style.css
+++ b/style.css
@@ -392,6 +392,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email sup{font-size:0.65em;vertical-align:super;line-height:0}
 #dayTitle sup{font-size:0.65em;vertical-align:super;line-height:0}
 .email .email-activity{margin:6px 0;font-size:16px}
+.email .email-activity .email-activity-time{
+  /* Reset itinerary times to regular weight without touching other bold treatments. */
+  font-weight:400;
+}
 .email .email-activity .email-activity-parenthetical-time{
   /* Reset the parenthetical arrival/stay window to normal weight without affecting other bold text. */
   font-weight:400;


### PR DESCRIPTION
## Summary
- wrap itinerary time ranges in the email preview with a span so the copy can use regular weight
- add styling to reset the itinerary time span to the base font weight without affecting other typography

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a23c42348330b768cc8373b65e8e