### PR TITLE
Add custom activity builder flow

### DIFF
--- a/custom-demo.html
+++ b/custom-demo.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Custom Activities Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="demo-container" style="padding:24px 24px 0;margin:0 auto 16px;">
+    <section class="demo-section">
+      <div class="demo-section-header">
+        <h2>QA scenarios for Custom Activities</h2>
+      </div>
+      <p class="demo-section-copy">
+        The itinerary below is preloaded with three Custom examples. Verify the free-text flow, catalog title + location, and the edit/delete path.
+      </p>
+      <ol class="demo-list">
+        <li class="demo-row">
+          <span class="demo-row-title">Sunrise Journaling</span>
+          <span class="demo-row-preview">Free-text title with start time only. Assigned to Alex.</span>
+        </li>
+        <li class="demo-row">
+          <span class="demo-row-title">Sound Bath Session</span>
+          <span class="demo-row-preview">Catalog title, start/end, and Stone House location. Assigned to Alex &amp; Bailey (toggle down to two guests to see the Both pill).</span>
+        </li>
+        <li class="demo-row">
+          <span class="demo-row-title">Evening Stargazing</span>
+          <span class="demo-row-preview">Everyone assigned. Use the custom chip to edit, then delete.</span>
+        </li>
+      </ol>
+    </section>
+  </div>
+  <div class="app">
+    <!-- Calendar -->
+    <section class="left card">
+      <div class="calendar-header">
+        <h2>Calendar</h2>
+        <div id="seasonIndicator" class="season-indicator" hidden>
+          <span id="seasonValue" class="season-indicator-pill"></span>
+        </div>
+      </div>
+      <div id="calendar">
+        <div class="toolbar">
+          <div class="nav-row">
+            <button id="yPrev" class="nav-btn" title="Previous Year" aria-label="Previous Year">«</button>
+            <button id="mPrev" class="nav-btn" title="Previous Month" aria-label="Previous Month">‹</button>
+            <div class="monthyear-col">
+              <span id="calMonth"></span>
+              <span id="calYear"></span>
+            </div>
+            <button id="mNext" class="nav-btn" title="Next Month" aria-label="Next Month">›</button>
+            <button id="yNext" class="nav-btn" title="Next Year" aria-label="Next Year">»</button>
+          </div>
+        </div>
+
+        <div id="dow" class="grid dow" aria-hidden="true"></div>
+        <div id="calGrid" class="grid days" role="grid" aria-label="Calendar grid"></div>
+        <div class="calendar-actions">
+          <button id="btnToday" title="Today" aria-label="Today">Today</button>
+          <button id="btnArrival" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
+          <button id="btnDeparture" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
+        </div>
+        <!-- Guest tools -->
+        <div class="section guest-section">
+          <div class="card-section-header">
+            <h2>Guests</h2>
+          </div>
+          <div class="row">
+            <input id="guestName" class="guest-input" type="text" placeholder="Add guest" aria-label="Guest name">
+            <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
+              <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+                <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>
+                <rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/>
+              </svg>
+            </button>
+          </div>
+          <div id="guests" class="chips" aria-label="Guests"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Activities -->
+    <section class="center card">
+      <div class="card-section-header">
+        <h2>Activities</h2>
+      </div>
+
+      <div class="row day-header">
+        <button id="prevDay" title="Previous Day" aria-label="Previous Day">‹</button>
+        <div class="day-header-details">
+          <div id="dayTitle" class="muted" aria-live="polite"></div>
+        </div>
+        <button id="nextDay" title="Next Day" aria-label="Next Day">›</button>
+      </div>
+
+      <div id="actions" class="row">
+        <button id="addDinner" title="Add Dinner" disabled>Dinner</button>
+        <button id="addSpa" title="Add Spa" disabled>Spa</button>
+        <button id="addCustom" title="Add Custom" disabled>Custom</button>
+        <button id="clearAll" title="Clear all itinerary data">Clear</button>
+      </div>
+
+      <div id="activities" class="list" aria-label="Available activities"></div>
+    </section>
+
+    <!-- Preview -->
+    <section class="right card preview-card">
+      <div class="card-section-header">
+        <h2>Preview</h2>
+      </div>
+      <div id="email" class="email" spellcheck="false"></div>
+      <div class="row stick-right">
+        <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>
+        <button id="copy" title="Copy">⧉</button>
+      </div>
+    </section>
+  </div>
+
+  <script src="data/data-layer.js"></script>
+  <script src="assignment-chip-logic.js"></script>
+  <script src="activities-interactions.js"></script>
+  <script src="time-picker.js"></script>
+  <script src="script.js"></script>
+  <script>
+    (function initCustomDemo(){
+      const attemptSetup = () => {
+        const debug = window.CHSBuilderDebug;
+        if(!debug || typeof debug.createCustomEntry !== 'function'){
+          requestAnimationFrame(attemptSetup);
+          return;
+        }
+        debug.addGuest('Alex');
+        debug.addGuest('Bailey');
+        debug.addGuest('Casey');
+        debug.focusDate(new Date(2025, 9, 20));
+        debug.setArrival();
+        debug.focusDate(new Date(2025, 9, 21));
+        debug.setDeparture();
+        debug.focusDate(new Date(2025, 9, 20));
+        const state = debug.getState();
+        const guestIds = state.guests.map(g => g.id);
+        const [alexId, baileyId, caseyId] = guestIds;
+        debug.createCustomEntry({
+          dateKey: '2025-10-20',
+          title: 'Sunrise Journaling',
+          start: '08:00',
+          guestIds: alexId ? [alexId] : []
+        });
+        debug.createCustomEntry({
+          dateKey: '2025-10-20',
+          title: 'Sound Bath Session',
+          start: '15:00',
+          end: '16:00',
+          location: 'Stone House',
+          guestIds: [alexId, baileyId].filter(Boolean)
+        });
+        debug.createCustomEntry({
+          dateKey: '2025-10-20',
+          title: 'Evening Stargazing',
+          start: '21:00',
+          end: '22:00',
+          location: 'Lodge',
+          guestIds: guestIds
+        });
+        debug.focusDate(new Date(2025, 9, 20));
+      };
+      attemptSetup();
+    })();
+  </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1085,11 +1085,10 @@
 
       const chip=document.createElement('button');
       chip.type='button';
-      chip.className='dinner-chip custom-chip';
-      // Default state shows the circular custom icon; CSS swaps in the pencil
-      // on hover or :focus-visible so keyboard users see the edit affordance
-      // without changing the pill's shared sizing.
-      chip.innerHTML = `<span class="chip-icon custom-chip-icon">${customChipIconSvg}</span><span class="chip-pencil">${customEditSvg}</span><span class="sr-only">Edit custom activity</span>`;
+      chip.className='chip chip--custom';
+      // Layer both icons so the default slider glyph renders immediately and we
+      // can flip to the pencil via hover/:focus-visible without resizing the pill.
+      chip.innerHTML = `<span class="icon icon-custom" aria-hidden="true">${customChipIconSvg}</span><span class="icon icon-pencil" aria-hidden="true">${customEditSvg}</span>`;
       chip.dataset.pressExempt='true';
       chip.setAttribute('aria-label','Edit custom activity');
       chip.title='Edit custom activity';

--- a/script.js
+++ b/script.js
@@ -114,7 +114,9 @@
   const spaIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class="spa-icon"><path fill="currentColor" d="M12 2c-.4 0-.78.2-1 .53C9.5 4.63 6 10.22 6 13.5 6 17.64 8.86 20 12 20s6-2.36 6-6.5c0-3.28-3.5-8.87-5-10.97A1.2 1.2 0 0 0 12 2Zm0 16c-2.37 0-4-1.4-4-4.5 0-1.58 1.57-4.68 4-8.08 2.43 3.4 4 6.5 4 8.08 0 3.1-1.63 4.5-4 4.5Zm-5.5 1a.75.75 0 0 0 0 1.5h11a.75.75 0 0 0 0-1.5Z"/></svg>';
   const customSetStartSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6.16 4.6c1.114.734 1.84 1.979 1.84 3.394 0 0 0 0 0 .006 0-1.415.726-2.66 1.825-3.384.573-.385.984-.939 1.17-1.589l-5.995-.02c.191.67.603 1.225 1.15 1.594Zm5.02 1.46c1.107-.808 1.819-2.101 1.82-3.56v-.5h1v-2h-12v2h1v.5c.001 1.459.713 2.752 1.808 3.551.672.43 1.121 1.13 1.192 1.939-.093.848-.551 1.564-1.209 2.003-1.081.814-1.772 2.078-1.79 3.503l-.003.503h-1v2h12v-2h-1v-.5c-.018-1.429-.709-2.692-1.769-3.492-.68-.454-1.138-1.169-1.23-1.996.071-.831.52-1.532 1.169-1.946ZM9 8c.072 1.142.655 2.136 1.519 2.763.877.623 1.445 1.61 1.481 2.732l.003.505h-8v-.5c.036-1.127.604-2.114 1.459-2.723.886-.642 1.468-1.635 1.54-2.766-.063-1.124-.641-2.091-1.498-2.683-.914-.633-1.499-1.662-1.502-2.827v-.5h8v.5c-.003 1.166-.587 2.195-1.479 2.813C9.64 5.794 9.062 6.761 8.999 7.865Z"/></svg>';
   const customSetEndSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M11.18 6.06c1.107-.808 1.819-2.101 1.82-3.56v-.5h1v-2h-12v2h1v.5c.001 1.459.713 2.752 1.808 3.551.672.43 1.121 1.13 1.192 1.939-.093.848-.551 1.564-1.209 2.003-1.081.814-1.772 2.078-1.79 3.503l-.003.503h-1v2h12v-2h-1v-.5c-.018-1.429-.709-2.692-1.769-3.492-.68-.454-1.138-1.169-1.23-1.996.071-.831.52-1.532 1.169-1.946ZM9 8c.072 1.142.655 2.136 1.519 2.763.877.623 1.445 1.61 1.481 2.732l.003.505h-1s-1.62-3.5-3-3.5-3 3.5-3 3.5h-1v-.5c.036-1.127.604-2.114 1.459-2.723.886-.642 1.468-1.635 1.54-2.766-.063-1.124-.641-2.091-1.498-2.683-.914-.633-1.499-1.662-1.502-2.827v-.5h8v.5c-.003 1.166-.587 2.195-1.479 2.813-.88.607-1.458 1.574-1.521 2.678Z"/></svg>';
-  const customChipIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 3.75 13.78 8.2l4.72.39c.6.05.84.83.39 1.23l-3.58 3.12 1.08 4.57c.14.59-.51 1.05-1.05.74L12 15.97l-3.34 1.98c-.54.31-1.19-.15-1.05-.74l1.08-4.57-3.58-3.12c-.45-.39-.21-1.18.39-1.23l4.72-.39L12 3.75Z"/></svg>';
+  // Spec-supplied custom chip icon (slider motif) so the default pill speaks to
+  // personalization rather than starring.
+  const customChipIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 5a2 2 0 1 1 4 0h8a1 1 0 1 1 0 2h-8a2 2 0 1 1-4 0H4a1 1 0 1 1 0-2h4Zm10 7a2 2 0 1 1 0 4H9a2 2 0 1 1-4 0H4a1 1 0 1 1 0-2h1a2 2 0 1 1 4 0h9a2 2 0 1 1 0-2Zm-5 7a2 2 0 1 1 0 4H6a2 2 0 1 1-4 0H4a1 1 0 1 1 0-2h2a2 2 0 1 1 4 0h3a2 2 0 1 1 0-2Z"/></svg>';
   const customEditSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 22V16L12 14M12 14L13 8M12 14H10M13 8C14 9.16667 15.6 11 18 11M13 8L12.8212 7.82124C12.2565 7.25648 11.2902 7.54905 11.1336 8.33223L10 14M10 14L8 22M18 9.5V22M8 7H7.72076C7.29033 7 6.90819 7.27543 6.77208 7.68377L5.5 11.5L7 12L8 7ZM14.5 3.5C14.5 4.05228 14.0523 4.5 13.5 4.5C12.9477 4.5 12.5 4.05228 12.5 3.5C12.5 2.94772 12.9477 2.5 13.5 2.5C14.0523 2.5 14.5 2.94772 14.5 3.5Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
   const pencilSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4.5 16.75 3 21l4.25-1.5L19.5 7.25 16.75 4.5 4.5 16.75Zm12.5-12.5 2.75 2.75 1-1a1.88 1.88 0 0 0 0-2.62l-.88-.88a1.88 1.88 0 0 0-2.62 0l-1 1Z" fill="currentColor"/></svg>';
   const trashSvg = `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><g fill="currentColor"><path d="M0.982,5.073 L2.007,15.339 C2.007,15.705 2.314,16 2.691,16 L10.271,16 C10.648,16 10.955,15.705 10.955,15.339 L11.98,5.073 L0.982,5.073 L0.982,5.073 Z M7.033,14.068 L5.961,14.068 L5.961,6.989 L7.033,6.989 L7.033,14.068 L7.033,14.068 Z M9.033,14.068 L7.961,14.068 L8.961,6.989 L10.033,6.989 L9.033,14.068 L9.033,14.068 Z M5.033,14.068 L3.961,14.068 L2.961,6.989 L4.033,6.989 L5.033,14.068 L5.033,14.068 Z"/><path d="M12.075,2.105 L8.937,2.105 L8.937,0.709 C8.937,0.317 8.481,0 8.081,0 L4.986,0 C4.586,0 4.031,0.225 4.031,0.615 L4.031,2.011 L0.886,2.105 C0.485,2.105 0.159,2.421 0.159,2.813 L0.159,3.968 L12.8,3.968 L12.8,2.813 C12.801,2.422 12.477,2.105 12.075,2.105 L12.075,2.105 Z M4.947,1.44 C4.947,1.128 5.298,0.875 5.73,0.875 L7.294,0.875 C7.726,0.875 8.076,1.129 8.076,1.44 L8.076,2.105 L4.946,2.105 L4.946,1.44 L4.947,1.44 Z"/></g></svg>`;
@@ -1084,8 +1086,8 @@
       const chip=document.createElement('button');
       chip.type='button';
       chip.className='dinner-chip custom-chip';
-      // Default state shows the bespoke icon; hover/focus swap to the pencil so
-      // the affordance mirrors dinner/spa chips.
+      // Default state shows the circular custom icon; hover/focus swap to the
+      // pencil so the affordance mirrors dinner/spa chips.
       chip.innerHTML = `<span class="chip-icon custom-chip-icon">${customChipIconSvg}</span><span class="chip-pencil">${customEditSvg}</span><span class="sr-only">Edit custom activity</span>`;
       chip.dataset.pressExempt='true';
       chip.setAttribute('aria-label','Edit custom activity');
@@ -3167,7 +3169,7 @@
 
     const initialTitle = existing?.title || '';
     const matchingActivity = catalog.titles.find(opt => opt.title === initialTitle) || null;
-    let titleMode = matchingActivity ? 'existing' : 'free';
+    let titleMode = 'free';
     let selectedActivity = matchingActivity;
     let freeTitleValue = initialTitle;
     let locationValue = existing?.location || selectedActivity?.location || '';
@@ -3232,6 +3234,7 @@
     existingToggle.className='custom-title-toggle';
     existingToggle.dataset.mode='existing';
     existingToggle.textContent='Choose existing';
+    existingToggle.setAttribute('aria-haspopup','listbox');
     if(!catalog.titles.length){ existingToggle.disabled = true; }
     toggleGroup.appendChild(existingToggle);
 
@@ -3247,24 +3250,30 @@
     freePane.appendChild(freeInput);
 
     const existingPane=document.createElement('div');
-    existingPane.className='custom-title-pane';
-    const existingInput=document.createElement('input');
-    existingInput.type='search';
-    existingInput.className='custom-title-input';
-    existingInput.placeholder='Search activities';
-    const datalistId = `custom-activities-${Date.now()}`;
-    existingInput.setAttribute('list', datalistId);
-    existingInput.value = selectedActivity ? selectedActivity.title : '';
-    existingPane.appendChild(existingInput);
+    existingPane.className='custom-title-pane custom-existing-pane';
+    const existingField=document.createElement('div');
+    existingField.className='custom-existing-field';
+    const existingHeader=document.createElement('div');
+    existingHeader.className='custom-existing-header';
+    const typeInsteadBtn=document.createElement('button');
+    typeInsteadBtn.type='button';
+    typeInsteadBtn.className='custom-existing-back';
+    typeInsteadBtn.textContent='Type instead';
+    typeInsteadBtn.setAttribute('aria-label','Return to typing');
+    typeInsteadBtn.addEventListener('click',()=> setTitleMode('free'));
+    existingHeader.appendChild(typeInsteadBtn);
+    existingField.appendChild(existingHeader);
 
-    const datalist=document.createElement('datalist');
-    datalist.id=datalistId;
-    catalog.titles.forEach(opt=>{
-      const option=document.createElement('option');
-      option.value = opt.title;
-      datalist.appendChild(option);
-    });
-    dialog.appendChild(datalist);
+    // Inline list lives inside the field wrapper so the modal height stays fixed
+    // while still surfacing catalog titles without a separate popover.
+    const existingList=document.createElement('div');
+    existingList.className='custom-existing-list';
+    existingList.setAttribute('role','listbox');
+    const existingListId = `custom-existing-list-${Date.now()}`;
+    existingList.id = existingListId;
+    existingToggle.setAttribute('aria-controls', existingListId);
+    existingField.appendChild(existingList);
+    existingPane.appendChild(existingField);
 
     titleSection.appendChild(freePane);
     titleSection.appendChild(existingPane);
@@ -3465,65 +3474,202 @@
       }
     };
 
-    const resolveTitle=()=>{
-      if(titleMode==='existing'){
-        return selectedActivity?.title || '';
-      }
-      return freeTitleValue.trim();
+    const findCatalogIndex=title=>{
+      if(!title) return -1;
+      const normalized=String(title).trim().toLowerCase();
+      if(!normalized) return -1;
+      return catalog.titles.findIndex(opt=> opt.title.toLowerCase()===normalized);
     };
+
+    const existingRows=[];
+    let existingActiveIndex = selectedActivity ? findCatalogIndex(selectedActivity.title) : 0;
+    if(existingActiveIndex<0) existingActiveIndex = 0;
+
+    const resolveTitle=()=> freeTitleValue.trim();
+
+    const syncSelectedActivityFromTitle=value=>{
+      const matchIndex = findCatalogIndex(value);
+      if(matchIndex>=0){
+        selectedActivity = catalog.titles[matchIndex];
+        if(!locationManual && selectedActivity.location){
+          locationValue = selectedActivity.location;
+          locationSelect.value = selectedActivity.location;
+        }
+        existingActiveIndex = matchIndex;
+      }else{
+        selectedActivity = null;
+        existingActiveIndex = 0;
+      }
+    };
+
+    // Roving focus keeps the embedded list keyboardable without moving the
+    // surrounding shell, and we reuse the same helper for pointer + key input.
+    const setExistingActive=(index,{focus=true,fromPointer=false}={})=>{
+      if(!existingRows.length) return;
+      const bounded = Math.max(0, Math.min(index, existingRows.length-1));
+      existingActiveIndex = bounded;
+      existingRows.forEach((row,i)=>{
+        const isActive = i===bounded;
+        row.classList.toggle('active', isActive);
+        row.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        row.tabIndex = isActive ? 0 : -1;
+      });
+      const target = existingRows[bounded];
+      if(target){
+        if(focus){
+          focusWithoutScroll(target);
+        }
+        if(!fromPointer){
+          target.scrollIntoView({ block:'nearest', inline:'nearest' });
+        }
+      }
+    };
+
+    // Selecting a catalog row writes the title back into the text field so the
+    // builder returns to its normal state without losing the dataset link.
+    const chooseExistingByIndex=index=>{
+      if(index<0 || index>=catalog.titles.length) return;
+      const option = catalog.titles[index];
+      if(!option) return;
+      existingActiveIndex = index;
+      selectedActivity = option;
+      freeTitleValue = option.title;
+      freeInput.value = option.title;
+      if(!locationManual && option.location){
+        locationValue = option.location;
+        locationSelect.value = option.location;
+      }
+      setExistingActive(index,{ focus:false, fromPointer:true });
+      setTitleMode('free');
+      refreshSaveState();
+    };
+
+    catalog.titles.forEach((opt,index)=>{
+      const row=document.createElement('button');
+      row.type='button';
+      row.className='custom-existing-row';
+      row.dataset.index=String(index);
+      row.setAttribute('role','option');
+      row.setAttribute('aria-selected','false');
+      row.tabIndex=-1;
+      const titleLine=document.createElement('span');
+      titleLine.className='custom-existing-title';
+      titleLine.textContent = opt.title;
+      row.appendChild(titleLine);
+      if(opt.location){
+        const locationLine=document.createElement('span');
+        locationLine.className='custom-existing-sub';
+        locationLine.textContent = opt.location;
+        row.appendChild(locationLine);
+        row.setAttribute('aria-label', `${opt.title} – ${opt.location}`);
+      }else{
+        row.setAttribute('aria-label', opt.title);
+      }
+      row.addEventListener('click',()=> chooseExistingByIndex(index));
+      row.addEventListener('mouseenter',()=> setExistingActive(index,{ focus:false, fromPointer:true }));
+      row.addEventListener('focus',()=> setExistingActive(index,{ focus:false }));
+      existingList.appendChild(row);
+      existingRows.push(row);
+    });
+
+    if(existingRows.length){
+      setExistingActive(existingActiveIndex,{ focus:false, fromPointer:true });
+    }
 
     const refreshSaveState=()=>{
       const titleValue = resolveTitle();
-      const titleValid = titleValue.length>0 && (titleMode==='free' || !!selectedActivity);
+      const titleValid = titleValue.length>0;
       const startValid = !!startValue;
       const guestsValid = modalGuestIds.length>0;
-      freeInput.setAttribute('aria-invalid', titleMode==='free' && !titleValid ? 'true' : 'false');
-      existingInput.setAttribute('aria-invalid', titleMode==='existing' && !selectedActivity ? 'true' : 'false');
-      saveBtn.disabled = !(titleValid && startValid && guestsValid && !currentTimeError);
-    };
-
-    const applyActivitySelection=value=>{
-      const trimmed=(value||'').trim();
-      if(!trimmed){
-        selectedActivity = null;
+      if(titleMode==='free'){
+        if(titleValid){
+          freeInput.removeAttribute('aria-invalid');
+        }else{
+          freeInput.setAttribute('aria-invalid','true');
+        }
       }else{
-        const match = catalog.titles.find(opt => opt.title.toLowerCase() === trimmed.toLowerCase()) || null;
-        selectedActivity = match;
+        freeInput.removeAttribute('aria-invalid');
       }
-      if(selectedActivity && !locationManual && selectedActivity.location){
-        locationValue = selectedActivity.location;
-        locationSelect.value = selectedActivity.location;
-      }
-      refreshSaveState();
+      saveBtn.disabled = !(titleValid && startValid && guestsValid && !currentTimeError);
     };
 
     freeInput.addEventListener('input',()=>{
       freeTitleValue = freeInput.value;
+      syncSelectedActivityFromTitle(freeTitleValue);
       refreshSaveState();
-    });
-
-    existingInput.addEventListener('input',()=>{
-      applyActivitySelection(existingInput.value);
     });
 
     const setTitleMode=mode=>{
-      titleMode = (mode==='existing' && !existingToggle.disabled) ? 'existing' : 'free';
-      freePane.hidden = titleMode!=='free';
-      existingPane.hidden = titleMode!=='existing';
-      freeToggle.classList.toggle('selected', titleMode==='free');
-      existingToggle.classList.toggle('selected', titleMode==='existing');
-      freeToggle.setAttribute('aria-pressed', titleMode==='free' ? 'true' : 'false');
-      existingToggle.setAttribute('aria-pressed', titleMode==='existing' ? 'true' : 'false');
+      const nextMode = (mode==='existing' && !existingToggle.disabled) ? 'existing' : 'free';
+      titleMode = nextMode;
+      const listActive = titleMode==='existing';
+      freePane.hidden = listActive;
+      existingPane.hidden = !listActive;
+      freeToggle.classList.toggle('selected', !listActive);
+      existingToggle.classList.toggle('selected', listActive);
+      freeToggle.setAttribute('aria-pressed', !listActive ? 'true' : 'false');
+      existingToggle.setAttribute('aria-pressed', listActive ? 'true' : 'false');
+      existingToggle.setAttribute('aria-expanded', listActive ? 'true' : 'false');
       refreshSaveState();
-      if(titleMode==='free'){
-        requestAnimationFrame(()=> freeInput.focus());
+      if(listActive){
+        requestAnimationFrame(()=>{
+          if(existingRows.length){
+            const candidate = existingActiveIndex>=0 ? existingActiveIndex : 0;
+            setExistingActive(candidate,{ focus:true });
+          }else{
+            focusWithoutScroll(typeInsteadBtn);
+          }
+        });
       }else{
-        requestAnimationFrame(()=> existingInput.focus());
+        requestAnimationFrame(()=> focusWithoutScroll(freeInput));
       }
     };
 
     freeToggle.addEventListener('click',()=> setTitleMode('free'));
-    existingToggle.addEventListener('click',()=> setTitleMode('existing'));
+    existingToggle.addEventListener('click',()=>{
+      if(titleMode==='existing'){
+        setTitleMode('free');
+      }else{
+        setTitleMode('existing');
+      }
+    });
+
+    existingPane.addEventListener('keydown',event=>{
+      if(titleMode!=='existing') return;
+      const key=event.key;
+      if(key==='ArrowDown' || key==='Down'){
+        event.preventDefault();
+        setExistingActive(existingActiveIndex+1);
+        return;
+      }
+      if(key==='ArrowUp' || key==='Up'){
+        event.preventDefault();
+        setExistingActive(existingActiveIndex-1);
+        return;
+      }
+      if(key==='Home'){
+        event.preventDefault();
+        setExistingActive(0);
+        return;
+      }
+      if(key==='End'){
+        event.preventDefault();
+        setExistingActive(existingRows.length-1);
+        return;
+      }
+      if(key==='Escape'){
+        event.preventDefault();
+        setTitleMode('free');
+        event.stopPropagation();
+        return;
+      }
+      if((key==='Enter' || key===' ' || key==='Space' || key==='Spacebar') && document.activeElement && document.activeElement.classList.contains('custom-existing-row')){
+        // Space/Enter should commit the highlighted row even if the browser skips the implicit click.
+        event.preventDefault();
+        const idx = Number(document.activeElement.dataset.index || existingActiveIndex);
+        chooseExistingByIndex(Number.isFinite(idx) ? idx : existingActiveIndex);
+      }
+    });
 
     const applyStartValue=()=>{
       const snapshot = currentPickerValue || (typeof timePicker?.getValue==='function' ? timePicker.getValue() : null);
@@ -3625,6 +3771,11 @@
 
     const handleKeyDown=event=>{
       if(event.key==='Escape'){
+        if(titleMode==='existing' && existingPane.contains(document.activeElement)){
+          event.preventDefault();
+          setTitleMode('free');
+          return;
+        }
         event.preventDefault();
         closeCustomBuilder({returnFocus:true});
         return;
@@ -3663,12 +3814,12 @@
     refreshSaveState();
 
     const focusInitial=()=>{
-      if(titleMode==='free'){
-        freeInput.focus();
+      if(titleMode==='existing' && existingRows.length){
+        setExistingActive(existingActiveIndex>=0 ? existingActiveIndex : 0, { focus:true });
         return;
       }
-      if(titleMode==='existing' && !existingToggle.disabled){
-        existingInput.focus();
+      if(freeInput){
+        focusWithoutScroll(freeInput);
         return;
       }
       if(timePicker?.focus){

--- a/script.js
+++ b/script.js
@@ -1086,8 +1086,9 @@
       const chip=document.createElement('button');
       chip.type='button';
       chip.className='dinner-chip custom-chip';
-      // Default state shows the circular custom icon; hover/focus swap to the
-      // pencil so the affordance mirrors dinner/spa chips.
+      // Default state shows the circular custom icon; CSS swaps in the pencil
+      // on hover or :focus-visible so keyboard users see the edit affordance
+      // without changing the pill's shared sizing.
       chip.innerHTML = `<span class="chip-icon custom-chip-icon">${customChipIconSvg}</span><span class="chip-pencil">${customEditSvg}</span><span class="sr-only">Edit custom activity</span>`;
       chip.dataset.pressExempt='true';
       chip.setAttribute('aria-label','Edit custom activity');

--- a/script.js
+++ b/script.js
@@ -114,6 +114,7 @@
   const spaIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class="spa-icon"><path fill="currentColor" d="M12 2c-.4 0-.78.2-1 .53C9.5 4.63 6 10.22 6 13.5 6 17.64 8.86 20 12 20s6-2.36 6-6.5c0-3.28-3.5-8.87-5-10.97A1.2 1.2 0 0 0 12 2Zm0 16c-2.37 0-4-1.4-4-4.5 0-1.58 1.57-4.68 4-8.08 2.43 3.4 4 6.5 4 8.08 0 3.1-1.63 4.5-4 4.5Zm-5.5 1a.75.75 0 0 0 0 1.5h11a.75.75 0 0 0 0-1.5Z"/></svg>';
   const customSetStartSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6.16 4.6c1.114.734 1.84 1.979 1.84 3.394 0 0 0 0 0 .006 0-1.415.726-2.66 1.825-3.384.573-.385.984-.939 1.17-1.589l-5.995-.02c.191.67.603 1.225 1.15 1.594Zm5.02 1.46c1.107-.808 1.819-2.101 1.82-3.56v-.5h1v-2h-12v2h1v.5c.001 1.459.713 2.752 1.808 3.551.672.43 1.121 1.13 1.192 1.939-.093.848-.551 1.564-1.209 2.003-1.081.814-1.772 2.078-1.79 3.503l-.003.503h-1v2h12v-2h-1v-.5c-.018-1.429-.709-2.692-1.769-3.492-.68-.454-1.138-1.169-1.23-1.996.071-.831.52-1.532 1.169-1.946ZM9 8c.072 1.142.655 2.136 1.519 2.763.877.623 1.445 1.61 1.481 2.732l.003.505h-8v-.5c.036-1.127.604-2.114 1.459-2.723.886-.642 1.468-1.635 1.54-2.766-.063-1.124-.641-2.091-1.498-2.683-.914-.633-1.499-1.662-1.502-2.827v-.5h8v.5c-.003 1.166-.587 2.195-1.479 2.813C9.64 5.794 9.062 6.761 8.999 7.865Z"/></svg>';
   const customSetEndSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M11.18 6.06c1.107-.808 1.819-2.101 1.82-3.56v-.5h1v-2h-12v2h1v.5c.001 1.459.713 2.752 1.808 3.551.672.43 1.121 1.13 1.192 1.939-.093.848-.551 1.564-1.209 2.003-1.081.814-1.772 2.078-1.79 3.503l-.003.503h-1v2h12v-2h-1v-.5c-.018-1.429-.709-2.692-1.769-3.492-.68-.454-1.138-1.169-1.23-1.996.071-.831.52-1.532 1.169-1.946ZM9 8c.072 1.142.655 2.136 1.519 2.763.877.623 1.445 1.61 1.481 2.732l.003.505h-1s-1.62-3.5-3-3.5-3 3.5-3 3.5h-1v-.5c.036-1.127.604-2.114 1.459-2.723.886-.642 1.468-1.635 1.54-2.766-.063-1.124-.641-2.091-1.498-2.683-.914-.633-1.499-1.662-1.502-2.827v-.5h8v.5c-.003 1.166-.587 2.195-1.479 2.813-.88.607-1.458 1.574-1.521 2.678Z"/></svg>';
+  const customChipIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M12 3.75 13.78 8.2l4.72.39c.6.05.84.83.39 1.23l-3.58 3.12 1.08 4.57c.14.59-.51 1.05-1.05.74L12 15.97l-3.34 1.98c-.54.31-1.19-.15-1.05-.74l1.08-4.57-3.58-3.12c-.45-.39-.21-1.18.39-1.23l4.72-.39L12 3.75Z"/></svg>';
   const customEditSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 22V16L12 14M12 14L13 8M12 14H10M13 8C14 9.16667 15.6 11 18 11M13 8L12.8212 7.82124C12.2565 7.25648 11.2902 7.54905 11.1336 8.33223L10 14M10 14L8 22M18 9.5V22M8 7H7.72076C7.29033 7 6.90819 7.27543 6.77208 7.68377L5.5 11.5L7 12L8 7ZM14.5 3.5C14.5 4.05228 14.0523 4.5 13.5 4.5C12.9477 4.5 12.5 4.05228 12.5 3.5C12.5 2.94772 12.9477 2.5 13.5 2.5C14.0523 2.5 14.5 2.94772 14.5 3.5Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
   const pencilSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4.5 16.75 3 21l4.25-1.5L19.5 7.25 16.75 4.5 4.5 16.75Zm12.5-12.5 2.75 2.75 1-1a1.88 1.88 0 0 0 0-2.62l-.88-.88a1.88 1.88 0 0 0-2.62 0l-1 1Z" fill="currentColor"/></svg>';
   const trashSvg = `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><g fill="currentColor"><path d="M0.982,5.073 L2.007,15.339 C2.007,15.705 2.314,16 2.691,16 L10.271,16 C10.648,16 10.955,15.705 10.955,15.339 L11.98,5.073 L0.982,5.073 L0.982,5.073 Z M7.033,14.068 L5.961,14.068 L5.961,6.989 L7.033,6.989 L7.033,14.068 L7.033,14.068 Z M9.033,14.068 L7.961,14.068 L8.961,6.989 L10.033,6.989 L9.033,14.068 L9.033,14.068 Z M5.033,14.068 L3.961,14.068 L2.961,6.989 L4.033,6.989 L5.033,14.068 L5.033,14.068 Z"/><path d="M12.075,2.105 L8.937,2.105 L8.937,0.709 C8.937,0.317 8.481,0 8.081,0 L4.986,0 C4.586,0 4.031,0.225 4.031,0.615 L4.031,2.011 L0.886,2.105 C0.485,2.105 0.159,2.421 0.159,2.813 L0.159,3.968 L12.8,3.968 L12.8,2.813 C12.801,2.422 12.477,2.105 12.075,2.105 L12.075,2.105 Z M4.947,1.44 C4.947,1.128 5.298,0.875 5.73,0.875 L7.294,0.875 C7.726,0.875 8.076,1.129 8.076,1.44 L8.076,2.105 L4.946,2.105 L4.946,1.44 L4.947,1.44 Z"/></g></svg>`;
@@ -1083,7 +1084,9 @@
       const chip=document.createElement('button');
       chip.type='button';
       chip.className='dinner-chip custom-chip';
-      chip.innerHTML = `<span class="chip-icon custom-chip-label">Custom</span><span class="chip-pencil custom-chip-pencil">${customEditSvg}</span><span class="sr-only">Edit custom activity</span>`;
+      // Default state shows the bespoke icon; hover/focus swap to the pencil so
+      // the affordance mirrors dinner/spa chips.
+      chip.innerHTML = `<span class="chip-icon custom-chip-icon">${customChipIconSvg}</span><span class="chip-pencil">${customEditSvg}</span><span class="sr-only">Edit custom activity</span>`;
       chip.dataset.pressExempt='true';
       chip.setAttribute('aria-label','Edit custom activity');
       chip.title='Edit custom activity';
@@ -3203,6 +3206,8 @@
     dialog.appendChild(header);
 
     const body=document.createElement('div');
+    // Keep scrolling inside the content wrapper so the header/footer stay
+    // pinned while the dialog respects the viewport-safe max height.
     body.className='custom-body';
     dialog.appendChild(body);
 
@@ -3319,13 +3324,19 @@
     const setStartBtn=document.createElement('button');
     setStartBtn.type='button';
     setStartBtn.className='custom-time-action';
-    setStartBtn.innerHTML = `<span class="custom-time-icon">${customSetStartSvg}</span><span>Set start time</span>`;
+    setStartBtn.setAttribute('aria-label','Set start time');
+    setStartBtn.title='Set start time';
+    // Icon-only affordance keeps the control compact while the aria-label
+    // surfaces the accessible name after dropping the text caption.
+    setStartBtn.innerHTML = `<span class="custom-time-icon">${customSetStartSvg}</span>`;
     pickerActions.appendChild(setStartBtn);
 
     const setEndBtn=document.createElement('button');
     setEndBtn.type='button';
     setEndBtn.className='custom-time-action';
-    setEndBtn.innerHTML = `<span class="custom-time-icon">${customSetEndSvg}</span><span>Set end time</span>`;
+    setEndBtn.setAttribute('aria-label','Set end time');
+    setEndBtn.title='Set end time';
+    setEndBtn.innerHTML = `<span class="custom-time-icon">${customSetEndSvg}</span>`;
     pickerActions.appendChild(setEndBtn);
 
     timeSection.appendChild(pickerActions);
@@ -3394,6 +3405,12 @@
     overlay.appendChild(dialog);
     document.body.appendChild(overlay);
     document.body.classList.add('custom-lock');
+    body.scrollTop = 0;
+    body.scrollTo?.({ top:0, left:0, behavior:'auto' });
+    requestAnimationFrame(()=>{
+      body.scrollTop = 0;
+      body.scrollTo?.({ top:0, left:0, behavior:'auto' });
+    });
 
     const updateGuestSummary=()=>{
       const names=[];

--- a/script.js
+++ b/script.js
@@ -112,6 +112,9 @@
 
   const dinnerIconSvg = `<svg viewBox="-96 0 512 512" aria-hidden="true" focusable="false" class="dinner-icon"><path fill="currentColor" d="M16,0c-8.837,0 -16,7.163 -16,16l0,187.643c0,7.328 0.667,13.595 2,18.802c1.333,5.207 2.917,9.305 4.75,12.294c1.833,2.989 4.5,5.641 8,7.955c3.5,2.314 6.583,3.953 9.25,4.917c2.667,0.965 6.542,2.266 11.625,3.905c2.399,0.774 5.771,1.515 8.997,2.224c1.163,0.256 2.306,0.507 3.378,0.754l0,225.506c0,17.673 14.327,32 32,32c17.673,0 32,-14.327 32,-32l0,-225.506c1.072,-0.247 2.215,-0.499 3.377,-0.754c3.227,-0.709 6.599,-1.45 8.998,-2.224c5.083,-1.639 8.958,-2.94 11.625,-3.905c2.667,-0.964 5.75,-2.603 9.25,-4.917c3.5,-2.314 6.167,-4.966 8,-7.955c1.833,-2.989 3.417,-7.087 4.75,-12.294c1.333,-5.207 2,-11.474 2,-18.802l0,-187.643c0,-8.837 -7.163,-16 -16,-16c-8.837,0 -16,7.163 -16,16l0,128c0,8.837 -7.163,16 -16,16c-8.837,0 -16,-7.163 -16,-16l0,-128c0,-8.837 -7.163,-16 -16,-16c-8.837,0 -16,7.163 -16,16l0,128c0,8.837 -7.163,16 -16,16c-8.837,0 -16,-7.163 -16,-16l0,-128c0,-8.837 -7.163,-16 -16,-16Zm304,18.286l0,267.143c0,0.458 -0.007,0.913 -0.022,1.364c0.015,0.4 0.022,0.803 0.022,1.207l0,192c0,17.673 -14.327,32 -32,32c-17.673,0 -32,-14.327 -32,-32l0,-160l-69.266,0c-2.41,0 -4.449,-0.952 -6.118,-2.857c-3.523,-3.619 -3.377,-8.286 0.887,-32.286c0.741,-4.762 2.178,-14.428 4.31,-29c2.133,-14.571 4.126,-28.19 5.98,-40.857c1.854,-12.667 4.449,-28.048 7.787,-46.143c3.337,-18.095 6.767,-34.428 10.29,-49c3.522,-14.571 7.926,-29.619 13.21,-45.143c5.284,-15.523 10.8,-28.476 16.547,-38.857c5.748,-10.381 12.515,-18.952 20.302,-25.714c7.787,-6.762 15.945,-10.143 24.473,-10.143l17.799,0c4.821,0 8.992,1.81 12.515,5.429c3.523,3.619 5.284,7.904 5.284,12.857Z"></path></svg>`;
   const spaIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class="spa-icon"><path fill="currentColor" d="M12 2c-.4 0-.78.2-1 .53C9.5 4.63 6 10.22 6 13.5 6 17.64 8.86 20 12 20s6-2.36 6-6.5c0-3.28-3.5-8.87-5-10.97A1.2 1.2 0 0 0 12 2Zm0 16c-2.37 0-4-1.4-4-4.5 0-1.58 1.57-4.68 4-8.08 2.43 3.4 4 6.5 4 8.08 0 3.1-1.63 4.5-4 4.5Zm-5.5 1a.75.75 0 0 0 0 1.5h11a.75.75 0 0 0 0-1.5Z"/></svg>';
+  const customSetStartSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6.16 4.6c1.114.734 1.84 1.979 1.84 3.394 0 0 0 0 0 .006 0-1.415.726-2.66 1.825-3.384.573-.385.984-.939 1.17-1.589l-5.995-.02c.191.67.603 1.225 1.15 1.594Zm5.02 1.46c1.107-.808 1.819-2.101 1.82-3.56v-.5h1v-2h-12v2h1v.5c.001 1.459.713 2.752 1.808 3.551.672.43 1.121 1.13 1.192 1.939-.093.848-.551 1.564-1.209 2.003-1.081.814-1.772 2.078-1.79 3.503l-.003.503h-1v2h12v-2h-1v-.5c-.018-1.429-.709-2.692-1.769-3.492-.68-.454-1.138-1.169-1.23-1.996.071-.831.52-1.532 1.169-1.946ZM9 8c.072 1.142.655 2.136 1.519 2.763.877.623 1.445 1.61 1.481 2.732l.003.505h-8v-.5c.036-1.127.604-2.114 1.459-2.723.886-.642 1.468-1.635 1.54-2.766-.063-1.124-.641-2.091-1.498-2.683-.914-.633-1.499-1.662-1.502-2.827v-.5h8v.5c-.003 1.166-.587 2.195-1.479 2.813C9.64 5.794 9.062 6.761 8.999 7.865Z"/></svg>';
+  const customSetEndSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M11.18 6.06c1.107-.808 1.819-2.101 1.82-3.56v-.5h1v-2h-12v2h1v.5c.001 1.459.713 2.752 1.808 3.551.672.43 1.121 1.13 1.192 1.939-.093.848-.551 1.564-1.209 2.003-1.081.814-1.772 2.078-1.79 3.503l-.003.503h-1v2h12v-2h-1v-.5c-.018-1.429-.709-2.692-1.769-3.492-.68-.454-1.138-1.169-1.23-1.996.071-.831.52-1.532 1.169-1.946ZM9 8c.072 1.142.655 2.136 1.519 2.763.877.623 1.445 1.61 1.481 2.732l.003.505h-1s-1.62-3.5-3-3.5-3 3.5-3 3.5h-1v-.5c.036-1.127.604-2.114 1.459-2.723.886-.642 1.468-1.635 1.54-2.766-.063-1.124-.641-2.091-1.498-2.683-.914-.633-1.499-1.662-1.502-2.827v-.5h8v.5c-.003 1.166-.587 2.195-1.479 2.813-.88.607-1.458 1.574-1.521 2.678Z"/></svg>';
+  const customEditSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 22V16L12 14M12 14L13 8M12 14H10M13 8C14 9.16667 15.6 11 18 11M13 8L12.8212 7.82124C12.2565 7.25648 11.2902 7.54905 11.1336 8.33223L10 14M10 14L8 22M18 9.5V22M8 7H7.72076C7.29033 7 6.90819 7.27543 6.77208 7.68377L5.5 11.5L7 12L8 7ZM14.5 3.5C14.5 4.05228 14.0523 4.5 13.5 4.5C12.9477 4.5 12.5 4.05228 12.5 3.5C12.5 2.94772 12.9477 2.5 13.5 2.5C14.0523 2.5 14.5 2.94772 14.5 3.5Z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
   const pencilSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4.5 16.75 3 21l4.25-1.5L19.5 7.25 16.75 4.5 4.5 16.75Zm12.5-12.5 2.75 2.75 1-1a1.88 1.88 0 0 0 0-2.62l-.88-.88a1.88 1.88 0 0 0-2.62 0l-1 1Z" fill="currentColor"/></svg>';
   const trashSvg = `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><g fill="currentColor"><path d="M0.982,5.073 L2.007,15.339 C2.007,15.705 2.314,16 2.691,16 L10.271,16 C10.648,16 10.955,15.705 10.955,15.339 L11.98,5.073 L0.982,5.073 L0.982,5.073 Z M7.033,14.068 L5.961,14.068 L5.961,6.989 L7.033,6.989 L7.033,14.068 L7.033,14.068 Z M9.033,14.068 L7.961,14.068 L8.961,6.989 L10.033,6.989 L9.033,14.068 L9.033,14.068 Z M5.033,14.068 L3.961,14.068 L2.961,6.989 L4.033,6.989 L5.033,14.068 L5.033,14.068 Z"/><path d="M12.075,2.105 L8.937,2.105 L8.937,0.709 C8.937,0.317 8.481,0 8.081,0 L4.986,0 C4.586,0 4.031,0.225 4.031,0.615 L4.031,2.011 L0.886,2.105 C0.485,2.105 0.159,2.421 0.159,2.813 L0.159,3.968 L12.8,3.968 L12.8,2.813 C12.801,2.422 12.477,2.105 12.075,2.105 L12.075,2.105 Z M4.947,1.44 C4.947,1.128 5.298,0.875 5.73,0.875 L7.294,0.875 C7.726,0.875 8.076,1.129 8.076,1.44 L8.076,2.105 L4.946,2.105 L4.946,1.44 L4.947,1.44 Z"/></g></svg>`;
   const checkSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6.6 11.2a.75.75 0 0 1-1.18.15L2.8 8.73a.75.75 0 0 1 1.06-1.06l2.02 2.03 4.46-4.46a.75.75 0 0 1 1.06 1.06Z"/></svg>';
@@ -257,6 +260,44 @@
     return { categories, byName };
   }
 
+  // Surface curated activity titles/locations so the custom builder can pull
+  // from the authoritative dataset without mutating it. This lets us mirror
+  // the “pick an existing activity” UX and feed the location select with
+  // known venues pulled from CHSDataLayer metadata.
+  function buildCustomCatalog(activitiesDataset){
+    const titleMap = new Map();
+    const locationSet = new Set();
+    const seasons = Array.isArray(activitiesDataset?.seasons) ? activitiesDataset.seasons : [];
+    const dayKeys = ['sun','mon','tue','wed','thu','fri','sat'];
+    seasons.forEach(season => {
+      dayKeys.forEach(dayKey => {
+        const rows = (window.CHSDataLayer && typeof window.CHSDataLayer.getActivitiesForSeasonDay === 'function')
+          ? window.CHSDataLayer.getActivitiesForSeasonDay(season.name, dayKey)
+          : [];
+        rows.forEach(row => {
+          if(!row || !row.title) return;
+          if(!titleMap.has(row.title)){
+            titleMap.set(row.title, { title: row.title, location: null });
+          }
+          const meta = (window.CHSDataLayer && typeof window.CHSDataLayer.getActivityMetadata === 'function')
+            ? window.CHSDataLayer.getActivityMetadata({ season: season.name, day: dayKey, title: row.title, start: row.start })
+            : null;
+          const location = (meta?.location || '').trim();
+          if(location){
+            locationSet.add(location);
+            const existing = titleMap.get(row.title);
+            if(existing && !existing.location){
+              existing.location = location;
+            }
+          }
+        });
+      });
+    });
+    const titles = Array.from(titleMap.values()).sort((a,b)=> a.title.localeCompare(b.title));
+    const locations = Array.from(locationSet.values()).sort((a,b)=> a.localeCompare(b));
+    return { titles, locations };
+  }
+
   const TimePickerKit = window.TimePickerKit || {};
   const { createTimePicker } = TimePickerKit;
 
@@ -277,7 +318,8 @@
     userEdited: '',
     previewDirty: true,
     previewFrozen: false,
-    spaCatalog: null
+    spaCatalog: null,
+    customCatalog: { titles: [], locations: [] }
   };
 
   // ---------- DOM ----------
@@ -291,6 +333,7 @@
   const copyBtn=$('#copy');
   const addDinnerBtn=$('#addDinner');
   const addSpaBtn=$('#addSpa');
+  const addCustomBtn=$('#addCustom');
   toggleEditBtn.textContent='✎';
   toggleEditBtn.title='Edit';
   toggleEditBtn.setAttribute('aria-pressed','false');
@@ -324,6 +367,7 @@
       const spaDataset = window.CHSDataLayer.getSpaDataset();
       state.data = { activities: activitiesDataset, spa: spaDataset };
       state.spaCatalog = buildSpaCatalog(spaDataset);
+      state.customCatalog = buildCustomCatalog(activitiesDataset);
       state.dataStatus = 'ready';
       ensureFocusInSeason();
       // Wait for the rest of this module to register helpers (e.g. toggleIcons) before rendering.
@@ -469,6 +513,7 @@
   function renderGuests(){
     syncDinnerGuests();
     syncSpaGuests();
+    syncCustomGuests();
     guestsEl.innerHTML='';
     state.guests.forEach((g,ix)=>{
       const b=document.createElement('button');
@@ -540,6 +585,13 @@
     });
   }
 
+  if(addCustomBtn){
+    addCustomBtn.addEventListener('click',()=>{
+      const activeGuestsSnapshot = state.guests.filter(g=>g.active).map(g=>g.id);
+      openCustomBuilder({ mode:'add', dateKey: keyDate(state.focus), guestIds: activeGuestsSnapshot });
+    });
+  }
+
   renderAll();
 
   function updateToggleAllButton(){
@@ -592,6 +644,7 @@
 
     updateAddDinnerButton();
     updateAddSpaButton();
+    updateAddCustomButton();
 
     const weekKey = weekdayKey(state.focus);
     let season = null;
@@ -626,12 +679,14 @@
     const dinnerEntry = getDinnerEntry(dateK);
     mergeSpaEntriesForDay(dateK);
     const spaEntries = getSpaEntries(dateK);
+    const customEntries = getCustomEntries(dateK);
     const spaOverlapById = computeSpaOverlapMap(spaEntries);
     const guestLookup = new Map(state.guests.map(g=>[g.id,g]));
     const combined = baseList.map(row=>({kind:'activity', data: row}));
     if(dinnerEntry){ combined.push({kind:'dinner', data: dinnerEntry}); }
     // Inject saved SPA blocks alongside activities/dinner so the list remains time-ordered.
     spaEntries.forEach(entry => combined.push({ kind:'spa', data: entry }));
+    customEntries.forEach(entry => combined.push({ kind:'custom', data: entry }));
     combined.sort((a,b)=>{
       const resolveStart = item => {
         if(item.kind==='activity') return item.data.start || '';
@@ -650,6 +705,10 @@
       }
       if(item.kind==='spa'){
         renderSpa(item.data);
+        return;
+      }
+      if(item.kind==='custom'){
+        renderCustom(item.data);
         return;
       }
       const row = item.data;
@@ -987,6 +1046,56 @@
       activitiesEl.appendChild(div);
     }
 
+    function renderCustom(entry){
+      if(!entry) return;
+      const div=document.createElement('div');
+      div.className='activity-row custom-item';
+      const body=document.createElement('div');
+      body.className='activity-row-body';
+
+      const headline=document.createElement('div');
+      headline.className='activity-row-headline';
+
+      const time=document.createElement('span');
+      time.className='activity-row-time';
+      const startLabel = entry.start ? fmt12(entry.start) : '';
+      const endLabel = entry.end ? fmt12(entry.end) : '';
+      time.textContent = startLabel && endLabel ? `${startLabel} – ${endLabel}` : startLabel || endLabel || '';
+      headline.appendChild(time);
+
+      const title=document.createElement('span');
+      title.className='activity-row-title';
+      title.textContent = entry.title || 'Custom Activity';
+      headline.appendChild(title);
+
+      body.appendChild(headline);
+
+      const tagWrap=document.createElement('div');
+      tagWrap.className='tag-row';
+
+      const guestIds = Array.isArray(entry.guestIds) ? entry.guestIds : Array.from(entry.guestIds || []);
+      if(state.guests.length>0){
+        // Reuse the shared assignment renderer so Both/Everyone chips stay in sync
+        // with the core guest logic after save.
+        renderAssignments(tagWrap, entry, guestIds, dateK);
+      }
+
+      const chip=document.createElement('button');
+      chip.type='button';
+      chip.className='dinner-chip custom-chip';
+      chip.innerHTML = `<span class="chip-icon custom-chip-label">Custom</span><span class="chip-pencil custom-chip-pencil">${customEditSvg}</span><span class="sr-only">Edit custom activity</span>`;
+      chip.dataset.pressExempt='true';
+      chip.setAttribute('aria-label','Edit custom activity');
+      chip.title='Edit custom activity';
+      chip.addEventListener('pointerdown', e=> e.stopPropagation());
+      chip.addEventListener('click',()=> openCustomBuilder({ mode:'edit', dateKey: dateK, entryId: entry.id }));
+      tagWrap.appendChild(chip);
+
+      body.appendChild(tagWrap);
+      div.appendChild(body);
+      activitiesEl.appendChild(div);
+    }
+
     function renderSpaGuestChips(container, entry, dateK){
       if(!container || !entry) return;
       const guestIds = Array.from(entry.guestIds || []);
@@ -1097,6 +1206,7 @@
 
   let dinnerDialog = null;
   let spaDialog = null;
+  let customDialog = null;
 
   function updateAddDinnerButton(){
     if(!addDinnerBtn) return;
@@ -1112,6 +1222,14 @@
     addSpaBtn.disabled = !enabled;
     const hasEntry = enabled ? getSpaEntries(keyDate(state.focus)).length>0 : false;
     addSpaBtn.setAttribute('aria-pressed', hasEntry ? 'true' : 'false');
+  }
+
+  function updateAddCustomButton(){
+    if(!addCustomBtn) return;
+    const enabled = state.dataStatus==='ready';
+    addCustomBtn.disabled = !enabled;
+    const hasEntry = enabled ? getCustomEntries(keyDate(state.focus)).length>0 : false;
+    addCustomBtn.setAttribute('aria-pressed', hasEntry ? 'true' : 'false');
   }
 
   function closeDinnerPicker({returnFocus=false}={}){
@@ -2988,6 +3106,572 @@
     },0);
   }
 
+  function closeCustomBuilder({returnFocus=false}={}){
+    if(!customDialog) return;
+    const { overlay, previousFocus, cleanup } = customDialog;
+    overlay.remove();
+    if(typeof cleanup === 'function') cleanup();
+    if(returnFocus && previousFocus && typeof previousFocus.focus==='function'){
+      previousFocus.focus();
+    }
+    customDialog = null;
+    document.body.classList.remove('custom-lock');
+  }
+
+  // Custom builder surfaces the dual title inputs (free text vs catalog) and
+  // funnels start/end selection through the shared time picker kit so physics
+  // stay consistent with dinner/spa flows.
+  function openCustomBuilder({mode='add', dateKey, entryId, guestIds}={}){
+    if(state.dataStatus!=='ready') return;
+    closeCustomBuilder();
+
+    const targetDateKey = dateKey || keyDate(state.focus);
+    const existing = entryId ? getCustomEntry(targetDateKey, entryId) : null;
+    const previousFocus = document.activeElement;
+    const catalog = state.customCatalog || { titles: [], locations: [] };
+    const stayGuestLookup = new Map(state.guests.map(g=>[g.id,g]));
+    const normalizeGuestIds = ids => {
+      const requested = Array.isArray(ids) ? ids.filter(Boolean) : [];
+      const requestedSet = new Set(requested);
+      const seen = new Set();
+      const normalized = [];
+      state.guests.forEach(guest => {
+        if(requestedSet.has(guest.id) && !seen.has(guest.id)){
+          seen.add(guest.id);
+          normalized.push(guest.id);
+        }
+      });
+      requested.forEach(id => {
+        if(!seen.has(id) && stayGuestLookup.has(id)){
+          seen.add(id);
+          normalized.push(id);
+        }
+      });
+      return normalized;
+    };
+
+    const defaultActiveIds = state.guests.filter(g=>g.active).map(g=>g.id);
+    const requestedIds = existing
+      ? Array.from(existing.guestIds || [])
+      : (Array.isArray(guestIds) ? guestIds : defaultActiveIds);
+    let modalGuestIds = normalizeGuestIds(requestedIds);
+    if(modalGuestIds.length===0){
+      modalGuestIds = normalizeGuestIds(defaultActiveIds);
+    }
+    // Guest assignments reuse the same chip helpers as the activities rail, so
+    // we only need to capture the IDs once here before the chips handle any
+    // inline removals after save.
+
+    const initialTitle = existing?.title || '';
+    const matchingActivity = catalog.titles.find(opt => opt.title === initialTitle) || null;
+    let titleMode = matchingActivity ? 'existing' : 'free';
+    let selectedActivity = matchingActivity;
+    let freeTitleValue = initialTitle;
+    let locationValue = existing?.location || selectedActivity?.location || '';
+    let locationManual = Boolean(existing?.location);
+    let startValue = existing?.start || '';
+    let endValue = existing?.end || '';
+    let currentTimeError = '';
+    const initialPickerValue = startValue ? from24Time(startValue) : { hour:9, minute:0, meridiem:'AM' };
+    let currentPickerValue = initialPickerValue;
+
+    const overlay=document.createElement('div');
+    overlay.className='custom-overlay';
+
+    const dialog=document.createElement('div');
+    dialog.className='custom-dialog';
+    dialog.setAttribute('role','dialog');
+    dialog.setAttribute('aria-modal','true');
+    dialog.setAttribute('aria-labelledby','custom-dialog-title');
+
+    const header=document.createElement('div');
+    header.className='custom-header';
+    const title=document.createElement('h2');
+    title.className='custom-heading';
+    title.id='custom-dialog-title';
+    title.textContent = existing ? 'Edit custom activity' : 'New custom activity';
+    header.appendChild(title);
+
+    const closeBtn=document.createElement('button');
+    closeBtn.type='button';
+    closeBtn.className='custom-close';
+    closeBtn.setAttribute('aria-label','Cancel custom activity');
+    closeBtn.textContent='×';
+    closeBtn.addEventListener('click',()=> closeCustomBuilder({returnFocus:true}));
+    header.appendChild(closeBtn);
+
+    dialog.appendChild(header);
+
+    const body=document.createElement('div');
+    body.className='custom-body';
+    dialog.appendChild(body);
+
+    const titleSection=document.createElement('section');
+    titleSection.className='custom-section custom-section-title';
+    const titleHeading=document.createElement('h3');
+    titleHeading.textContent='Title';
+    titleSection.appendChild(titleHeading);
+
+    const toggleGroup=document.createElement('div');
+    toggleGroup.className='custom-title-toggle-group';
+
+    const freeToggle=document.createElement('button');
+    freeToggle.type='button';
+    freeToggle.className='custom-title-toggle';
+    freeToggle.dataset.mode='free';
+    freeToggle.textContent='Type a title';
+    toggleGroup.appendChild(freeToggle);
+
+    const existingToggle=document.createElement('button');
+    existingToggle.type='button';
+    existingToggle.className='custom-title-toggle';
+    existingToggle.dataset.mode='existing';
+    existingToggle.textContent='Choose existing';
+    if(!catalog.titles.length){ existingToggle.disabled = true; }
+    toggleGroup.appendChild(existingToggle);
+
+    titleSection.appendChild(toggleGroup);
+
+    const freePane=document.createElement('div');
+    freePane.className='custom-title-pane';
+    const freeInput=document.createElement('input');
+    freeInput.type='text';
+    freeInput.className='custom-title-input';
+    freeInput.placeholder='Name this activity';
+    freeInput.value = freeTitleValue;
+    freePane.appendChild(freeInput);
+
+    const existingPane=document.createElement('div');
+    existingPane.className='custom-title-pane';
+    const existingInput=document.createElement('input');
+    existingInput.type='search';
+    existingInput.className='custom-title-input';
+    existingInput.placeholder='Search activities';
+    const datalistId = `custom-activities-${Date.now()}`;
+    existingInput.setAttribute('list', datalistId);
+    existingInput.value = selectedActivity ? selectedActivity.title : '';
+    existingPane.appendChild(existingInput);
+
+    const datalist=document.createElement('datalist');
+    datalist.id=datalistId;
+    catalog.titles.forEach(opt=>{
+      const option=document.createElement('option');
+      option.value = opt.title;
+      datalist.appendChild(option);
+    });
+    dialog.appendChild(datalist);
+
+    titleSection.appendChild(freePane);
+    titleSection.appendChild(existingPane);
+    body.appendChild(titleSection);
+
+    const timeSection=document.createElement('section');
+    timeSection.className='custom-section custom-section-time';
+    const timeHeading=document.createElement('h3');
+    timeHeading.textContent='Time';
+    timeSection.appendChild(timeHeading);
+
+    const timeSummary=document.createElement('div');
+    timeSummary.className='custom-time-summary';
+
+    const startPill=document.createElement('div');
+    startPill.className='custom-time-pill';
+    const startLabel=document.createElement('span');
+    startLabel.className='custom-time-pill-label';
+    startLabel.textContent='Start';
+    const startValueNode=document.createElement('span');
+    startValueNode.className='custom-time-value';
+    startPill.appendChild(startLabel);
+    startPill.appendChild(startValueNode);
+    timeSummary.appendChild(startPill);
+
+    const endPill=document.createElement('div');
+    endPill.className='custom-time-pill optional';
+    const endLabel=document.createElement('span');
+    endLabel.className='custom-time-pill-label';
+    endLabel.textContent='End';
+    const endValueNode=document.createElement('span');
+    endValueNode.className='custom-time-value';
+    const clearEndBtn=document.createElement('button');
+    clearEndBtn.type='button';
+    clearEndBtn.className='custom-clear-end';
+    clearEndBtn.textContent='Clear';
+    clearEndBtn.addEventListener('click',()=>{
+      endValue='';
+      updateEndDisplay();
+      setTimeError('');
+      refreshSaveState();
+    });
+    endPill.appendChild(endLabel);
+    endPill.appendChild(endValueNode);
+    endPill.appendChild(clearEndBtn);
+    timeSummary.appendChild(endPill);
+
+    timeSection.appendChild(timeSummary);
+
+    const pickerContainer=document.createElement('div');
+    pickerContainer.className='custom-picker';
+    timeSection.appendChild(pickerContainer);
+
+    const pickerActions=document.createElement('div');
+    pickerActions.className='custom-picker-actions';
+
+    const setStartBtn=document.createElement('button');
+    setStartBtn.type='button';
+    setStartBtn.className='custom-time-action';
+    setStartBtn.innerHTML = `<span class="custom-time-icon">${customSetStartSvg}</span><span>Set start time</span>`;
+    pickerActions.appendChild(setStartBtn);
+
+    const setEndBtn=document.createElement('button');
+    setEndBtn.type='button';
+    setEndBtn.className='custom-time-action';
+    setEndBtn.innerHTML = `<span class="custom-time-icon">${customSetEndSvg}</span><span>Set end time</span>`;
+    pickerActions.appendChild(setEndBtn);
+
+    timeSection.appendChild(pickerActions);
+
+    const timeError=document.createElement('p');
+    timeError.className='custom-time-error';
+    timeError.hidden=true;
+    timeSection.appendChild(timeError);
+
+    body.appendChild(timeSection);
+
+    const locationSection=document.createElement('section');
+    locationSection.className='custom-section custom-section-location';
+    const locationHeading=document.createElement('h3');
+    locationHeading.textContent='Location (optional)';
+    locationSection.appendChild(locationHeading);
+    // Location list is sourced from the CHS activities metadata so preview copy
+    // and in-app chips both draw from the same canonical venue names.
+    const locationSelect=document.createElement('select');
+    locationSelect.className='custom-location-select';
+    const emptyOption=document.createElement('option');
+    emptyOption.value='';
+    emptyOption.textContent='No location';
+    locationSelect.appendChild(emptyOption);
+    catalog.locations.forEach(loc=>{
+      const opt=document.createElement('option');
+      opt.value=loc;
+      opt.textContent=loc;
+      locationSelect.appendChild(opt);
+    });
+    locationSelect.value = locationValue || '';
+    locationSelect.addEventListener('change',()=>{
+      locationManual = true;
+      locationValue = locationSelect.value;
+    });
+    locationSection.appendChild(locationSelect);
+    body.appendChild(locationSection);
+
+    const guestSection=document.createElement('section');
+    guestSection.className='custom-section custom-section-guests';
+    const guestHeading=document.createElement('h3');
+    guestHeading.textContent='Guests';
+    guestSection.appendChild(guestHeading);
+    const guestSummary=document.createElement('p');
+    guestSummary.className='custom-guest-summary';
+    guestSection.appendChild(guestSummary);
+    body.appendChild(guestSection);
+
+    const actions=document.createElement('div');
+    actions.className='custom-actions';
+    const saveBtn=document.createElement('button');
+    saveBtn.type='button';
+    saveBtn.className='custom-save';
+    saveBtn.textContent='Save';
+    actions.appendChild(saveBtn);
+    let deleteBtn=null;
+    if(existing){
+      deleteBtn=document.createElement('button');
+      deleteBtn.type='button';
+      deleteBtn.className='custom-delete';
+      deleteBtn.textContent='Delete';
+      actions.appendChild(deleteBtn);
+    }
+    dialog.appendChild(actions);
+
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+    document.body.classList.add('custom-lock');
+
+    const updateGuestSummary=()=>{
+      const names=[];
+      const seen=new Set();
+      modalGuestIds.forEach(id=>{
+        if(seen.has(id)) return;
+        seen.add(id);
+        const guest=stayGuestLookup.get(id);
+        if(guest?.name){
+          names.push(guest.name);
+        }
+      });
+      if(names.length){
+        guestSummary.textContent = `Guests: ${names.join(', ')}`;
+        guestSummary.dataset.empty='false';
+      }else{
+        guestSummary.textContent = 'Guests: None selected (toggle guest pills before saving).';
+        guestSummary.dataset.empty='true';
+      }
+    };
+
+    const updateStartDisplay=()=>{
+      if(startValue){
+        startValueNode.textContent = fmt12(startValue);
+        startPill.dataset.empty='false';
+      }else{
+        startValueNode.textContent = 'Set start';
+        startPill.dataset.empty='true';
+      }
+    };
+
+    const updateEndDisplay=()=>{
+      if(endValue){
+        endValueNode.textContent = fmt12(endValue);
+        endPill.dataset.empty='false';
+        clearEndBtn.disabled=false;
+      }else{
+        endValueNode.textContent = 'Optional';
+        endPill.dataset.empty='true';
+        clearEndBtn.disabled=true;
+      }
+    };
+
+    const setTimeError=message=>{
+      currentTimeError = message ? String(message) : '';
+      if(currentTimeError){
+        timeError.textContent = currentTimeError;
+        timeError.hidden=false;
+      }else{
+        timeError.textContent='';
+        timeError.hidden=true;
+      }
+    };
+
+    const resolveTitle=()=>{
+      if(titleMode==='existing'){
+        return selectedActivity?.title || '';
+      }
+      return freeTitleValue.trim();
+    };
+
+    const refreshSaveState=()=>{
+      const titleValue = resolveTitle();
+      const titleValid = titleValue.length>0 && (titleMode==='free' || !!selectedActivity);
+      const startValid = !!startValue;
+      const guestsValid = modalGuestIds.length>0;
+      freeInput.setAttribute('aria-invalid', titleMode==='free' && !titleValid ? 'true' : 'false');
+      existingInput.setAttribute('aria-invalid', titleMode==='existing' && !selectedActivity ? 'true' : 'false');
+      saveBtn.disabled = !(titleValid && startValid && guestsValid && !currentTimeError);
+    };
+
+    const applyActivitySelection=value=>{
+      const trimmed=(value||'').trim();
+      if(!trimmed){
+        selectedActivity = null;
+      }else{
+        const match = catalog.titles.find(opt => opt.title.toLowerCase() === trimmed.toLowerCase()) || null;
+        selectedActivity = match;
+      }
+      if(selectedActivity && !locationManual && selectedActivity.location){
+        locationValue = selectedActivity.location;
+        locationSelect.value = selectedActivity.location;
+      }
+      refreshSaveState();
+    };
+
+    freeInput.addEventListener('input',()=>{
+      freeTitleValue = freeInput.value;
+      refreshSaveState();
+    });
+
+    existingInput.addEventListener('input',()=>{
+      applyActivitySelection(existingInput.value);
+    });
+
+    const setTitleMode=mode=>{
+      titleMode = (mode==='existing' && !existingToggle.disabled) ? 'existing' : 'free';
+      freePane.hidden = titleMode!=='free';
+      existingPane.hidden = titleMode!=='existing';
+      freeToggle.classList.toggle('selected', titleMode==='free');
+      existingToggle.classList.toggle('selected', titleMode==='existing');
+      freeToggle.setAttribute('aria-pressed', titleMode==='free' ? 'true' : 'false');
+      existingToggle.setAttribute('aria-pressed', titleMode==='existing' ? 'true' : 'false');
+      refreshSaveState();
+      if(titleMode==='free'){
+        requestAnimationFrame(()=> freeInput.focus());
+      }else{
+        requestAnimationFrame(()=> existingInput.focus());
+      }
+    };
+
+    freeToggle.addEventListener('click',()=> setTitleMode('free'));
+    existingToggle.addEventListener('click',()=> setTitleMode('existing'));
+
+    const applyStartValue=()=>{
+      const snapshot = currentPickerValue || (typeof timePicker?.getValue==='function' ? timePicker.getValue() : null);
+      if(!snapshot) return;
+      startValue = to24Time(snapshot);
+      updateStartDisplay();
+      if(endValue && minutesFromTime(endValue) <= minutesFromTime(startValue)){
+        setTimeError('End time must be after the start time.');
+      }else{
+        setTimeError('');
+      }
+      refreshSaveState();
+    };
+
+    const applyEndValue=()=>{
+      if(!startValue){
+        setTimeError('Set a start time before choosing an end time.');
+        refreshSaveState();
+        return;
+      }
+      const snapshot = currentPickerValue || (typeof timePicker?.getValue==='function' ? timePicker.getValue() : null);
+      if(!snapshot) return;
+      const candidate = to24Time(snapshot);
+      if(minutesFromTime(candidate) <= minutesFromTime(startValue)){
+        setTimeError('End time must be after the start time.');
+        endValue = candidate;
+      }else{
+        endValue = candidate;
+        setTimeError('');
+      }
+      updateEndDisplay();
+      refreshSaveState();
+    };
+
+    setStartBtn.addEventListener('click', applyStartValue);
+    setEndBtn.addEventListener('click', applyEndValue);
+
+    let timePicker=null;
+    if(typeof createTimePicker === 'function'){
+      // Reuse the shared time picker so visuals + physics remain identical to
+      // dinner/spa flows.
+      timePicker = createTimePicker({
+        hourRange:[1,12],
+        minuteStep:5,
+        showAmPm:true,
+        defaultValue: initialPickerValue,
+        ariaLabels:{ hours:'Hour', minutes:'Minutes', meridiem:'AM or PM' },
+        onChange:value=>{ currentPickerValue = value; }
+      });
+    }
+
+    if(timePicker){
+      pickerContainer.appendChild(timePicker.element);
+    }else{
+      const fallback=document.createElement('div');
+      fallback.className='custom-picker-fallback';
+      fallback.textContent='Time picker unavailable.';
+      pickerContainer.appendChild(fallback);
+    }
+
+    const handleSave=()=>{
+      const titleValue = resolveTitle();
+      if(!titleValue || !startValue || modalGuestIds.length===0 || currentTimeError){
+        refreshSaveState();
+        return;
+      }
+      const payload = {
+        id: existing?.id,
+        title: titleValue,
+        start: startValue,
+        end: endValue || '',
+        location: locationValue,
+        guestIds: modalGuestIds.slice()
+      };
+      upsertCustomEntry(targetDateKey, payload);
+      markPreviewDirty();
+      renderActivities();
+      renderPreview();
+      closeCustomBuilder({returnFocus:true});
+    };
+
+    saveBtn.addEventListener('click', handleSave);
+
+    if(deleteBtn && existing){
+      deleteBtn.addEventListener('click',()=>{
+        removeCustomEntry(targetDateKey, existing.id);
+        markPreviewDirty();
+        renderActivities();
+        renderPreview();
+        closeCustomBuilder({returnFocus:true});
+      });
+    }
+
+    overlay.addEventListener('click',event=>{
+      if(event.target===overlay){
+        closeCustomBuilder({returnFocus:true});
+      }
+    });
+
+    const handleKeyDown=event=>{
+      if(event.key==='Escape'){
+        event.preventDefault();
+        closeCustomBuilder({returnFocus:true});
+        return;
+      }
+      if((event.key==='Enter' || event.key==='Return') && event.target && event.target.tagName!=='BUTTON'){
+        event.preventDefault();
+        handleSave();
+        return;
+      }
+      if(event.key==='Tab'){
+        const focusable = Array.from(dialog.querySelectorAll('button,select,input,[tabindex]:not([tabindex="-1"])')).filter(el=> !el.disabled && el.offsetParent!==null);
+        if(focusable.length===0) return;
+        const first=focusable[0];
+        const last=focusable[focusable.length-1];
+        if(event.shiftKey){
+          if(document.activeElement===first){
+            event.preventDefault();
+            last.focus();
+          }
+        }else{
+          if(document.activeElement===last){
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    dialog.addEventListener('keydown', handleKeyDown);
+
+    updateGuestSummary();
+    updateStartDisplay();
+    updateEndDisplay();
+    setTimeError('');
+    setTitleMode(titleMode);
+    refreshSaveState();
+
+    const focusInitial=()=>{
+      if(titleMode==='free'){
+        freeInput.focus();
+        return;
+      }
+      if(titleMode==='existing' && !existingToggle.disabled){
+        existingInput.focus();
+        return;
+      }
+      if(timePicker?.focus){
+        timePicker.focus({ preventScroll:true });
+      }
+    };
+
+    setTimeout(focusInitial,0);
+
+    customDialog = {
+      overlay,
+      dialog,
+      previousFocus,
+      cleanup(){
+        timePicker?.dispose?.();
+        dialog.removeEventListener('keydown', handleKeyDown);
+      }
+    };
+  }
+
   function getOrCreateDay(dateK){ if(!state.schedule[dateK]) state.schedule[dateK]=[]; return state.schedule[dateK]; }
   function sortDayEntries(dateK){
     const day = state.schedule[dateK];
@@ -2997,6 +3681,56 @@
       const sb = b.start || '';
       return sa.localeCompare(sb);
     });
+  }
+
+  const generateCustomEntryId = () => (crypto.randomUUID ? crypto.randomUUID() : `custom_${Date.now()}_${Math.random().toString(16).slice(2)}`);
+
+  function getCustomEntries(dateK){
+    const day = state.schedule[dateK];
+    if(!day) return [];
+    return day.filter(entry => entry.type==='custom');
+  }
+
+  function getCustomEntry(dateK, entryId){
+    const day = state.schedule[dateK];
+    if(!day) return null;
+    return day.find(entry => entry.type==='custom' && entry.id===entryId) || null;
+  }
+
+  // Custom entries sit inside the same day array as preset activities, so we
+  // reuse the shared sorter after every save to keep chronological insertion in
+  // lockstep with the existing row renderer.
+  function upsertCustomEntry(dateK, config){
+    if(!dateK || !config) return null;
+    const title = (config.title || '').trim();
+    const start = (config.start || '').trim();
+    const end = (config.end || '').trim();
+    const location = (config.location || '').trim();
+    const guestIds = Array.isArray(config.guestIds) ? config.guestIds.filter(Boolean) : [];
+    const day = getOrCreateDay(dateK);
+    const existingId = config.id || null;
+    let entry = existingId ? day.find(item => item.type==='custom' && item.id===existingId) : null;
+    if(!entry){
+      entry = { type:'custom', id: existingId || generateCustomEntryId(), title:'', start:'', end:null, location:null, guestIds:new Set() };
+      day.push(entry);
+    }
+    entry.title = title;
+    entry.start = start;
+    entry.end = end ? end : null;
+    entry.location = location ? location : null;
+    entry.guestIds = new Set(guestIds);
+    sortDayEntries(dateK);
+    return entry;
+  }
+
+  function removeCustomEntry(dateK, entryId){
+    const day = state.schedule[dateK];
+    if(!day) return;
+    const idx = day.findIndex(entry => entry.type==='custom' && entry.id===entryId);
+    if(idx>-1){
+      day.splice(idx,1);
+      if(day.length===0) delete state.schedule[dateK];
+    }
   }
 
   function getDinnerEntry(dateK){
@@ -3034,6 +3768,31 @@
         }
       }
       mergeSpaEntriesForDay(key);
+      if(day.length===0){
+        purgeKeys.push(key);
+      }
+    }
+    purgeKeys.forEach(key => delete state.schedule[key]);
+  }
+
+  function syncCustomGuests(){
+    const activeIds = new Set(state.guests.map(g=>g.id));
+    const purgeKeys = [];
+    for(const key of Object.keys(state.schedule)){
+      const day = state.schedule[key];
+      if(!day) continue;
+      for(let i = day.length - 1; i >= 0; i--){
+        const entry = day[i];
+        if(!entry || entry.type!=='custom') continue;
+        const ids = entry.guestIds instanceof Set
+          ? Array.from(entry.guestIds)
+          : Array.isArray(entry.guestIds) ? entry.guestIds.slice() : [];
+        const filtered = ids.filter(id => activeIds.has(id));
+        entry.guestIds = new Set(filtered);
+        if(entry.guestIds.size===0){
+          day.splice(i,1);
+        }
+      }
       if(day.length===0){
         purgeKeys.push(key);
       }
@@ -3480,9 +4239,6 @@
           && totalGuestsInStay > 0
           && ids.length === totalGuestsInStay;
         if(!isDinner && guestNames.length===0 && !assignmentCoversAll) return;
-        const tag = (!isDinner && guestNames.length)
-          ? ` | ${guestNames.map(name => escapeHtml(name)).join(' | ')}`
-          : '';
         const startTime = it.start ? escapeHtml(fmt12(it.start)) : '';
         const endTime = it.end ? escapeHtml(fmt12(it.end)) : '';
         let timeSegment = '';
@@ -3496,11 +4252,22 @@
         // Wrap generic itinerary times so we can remove bold styling without affecting other text.
         const timeMarkup = timeSegment ? `<span class="email-activity-time">${timeSegment}</span>` : '';
         const title = escapeHtml(it.title||'');
+        const segments = [];
+        if(timeMarkup) segments.push(timeMarkup);
+        if(title) segments.push(title);
+        if(it.type==='custom' && it.location){
+          segments.push(escapeHtml(it.location));
+        }
+        let lineMarkup = segments.join(' | ');
+        if(!isDinner && guestNames.length){
+          const guestSegment = guestNames.map(name => escapeHtml(name)).join(' | ');
+          lineMarkup = lineMarkup ? `${lineMarkup} | ${guestSegment}` : guestSegment;
+        }
         daySection.appendChild(
           makeEl(
             'div',
             'email-activity',
-            `${timeMarkup}${timeMarkup && title ? ' | ' : ''}${title}${tag}`,
+            lineMarkup,
             {html:true}
           )
         );
@@ -3703,6 +4470,33 @@
       setDeparture,
       openSpaEditor,
       openDinnerPicker,
+      openCustomBuilder,
+      createCustomEntry(config = {}){
+        const key = config.dateKey || (config.date instanceof Date ? keyDate(zero(config.date)) : keyDate(state.focus));
+        const guestIds = Array.isArray(config.guestIds)
+          ? config.guestIds.filter(Boolean)
+          : state.guests.map(g=>g.id);
+        upsertCustomEntry(key, {
+          id: config.id,
+          title: config.title || '',
+          start: config.start || '09:00',
+          end: config.end || '',
+          location: config.location || '',
+          guestIds
+        });
+        markPreviewDirty();
+        renderActivities();
+        renderPreview();
+      },
+      deleteCustomEntry(config = {}){
+        const key = config.dateKey || (config.date instanceof Date ? keyDate(zero(config.date)) : keyDate(state.focus));
+        if(config.entryId){
+          removeCustomEntry(key, config.entryId);
+          markPreviewDirty();
+          renderActivities();
+          renderPreview();
+        }
+      },
       focusDate(date){
         if(!(date instanceof Date)) return;
         state.focus = zero(date);

--- a/style.css
+++ b/style.css
@@ -37,6 +37,7 @@
   --ink:var(--text-primary);
   --muted:var(--text-muted);
   --border:#e2e8f0;
+  --chip-size:26px;
 }
 @media (prefers-color-scheme: dark){
   :root{
@@ -405,7 +406,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .email .email-empty{margin:12px 0 0;font-size:15px;color:var(--muted)}
 .chips{display:flex;gap:8px;flex-wrap:wrap}
 
-.chip{width:26px;height:26px;border-radius:50%;display:inline-grid;place-items:center;font-weight:500;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
+.chip{width:var(--chip-size,26px);height:var(--chip-size,26px);border-radius:50%;display:inline-grid;place-items:center;font-weight:500;border:1px solid currentColor;background:#fff;user-select:none;position:relative;}
 .chip .initial{position:relative;z-index:1;font-size:13px;line-height:1;color:currentColor;transition:opacity .16s ease;font-weight:400;letter-spacing:0;}
 .chip .x{position:absolute;top:50%;left:50%;width:18px;height:18px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;background:#fff;border:1px solid var(--border);padding:0;cursor:pointer;color:var(--ink);z-index:2;transform:translate(-50%,-50%);opacity:0;pointer-events:none;transition:opacity .16s ease;}
 @media(hover:hover){.chip:hover .initial,.chip:focus-within .initial{opacity:0;}.chip:hover .x,.chip:focus-within .x{opacity:1;pointer-events:auto;}}
@@ -500,15 +501,47 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .dinner-chip:focus .chip-icon{opacity:0;}
 .dinner-chip:focus .chip-pencil{opacity:1;}
 /*
-  Custom chips keep the same pill dimensions as dinner/spa chips by sharing the
-  .dinner-chip shell. We only override the icon swap behavior so the slider
-  glyph shows by default and the pencil appears on hover or keyboard focus.
-*/
-.custom-chip .chip-icon{opacity:1;}
-.custom-chip .chip-pencil{opacity:0;}
-@media(hover:hover){.custom-chip:hover .chip-icon{opacity:0;}.custom-chip:hover .chip-pencil{opacity:1;}}
-.custom-chip:focus-visible .chip-icon{opacity:0;}
-.custom-chip:focus-visible .chip-pencil{opacity:1;}
+ * Custom activity chips layer the slider + pencil icons so the default glyph
+ * remains visible until hover or keyboard focus swaps in the edit affordance.
+ * The pill dimensions are pinned to the shared chip token so row height stays fixed.
+ */
+.chip--custom{
+  position:relative;
+  inline-size:var(--chip-size,26px);
+  block-size:var(--chip-size,26px);
+  border-radius:50%;
+  border:1px solid var(--chipBorder);
+  background:#fff;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  color:var(--brand);
+  padding:0;
+  cursor:pointer;
+  transition:box-shadow .2s ease,transform .2s ease;
+}
+.chip--custom:focus-visible{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+  box-shadow:0 4px 12px rgba(12,18,32,.16);
+  transform:translateY(-1px);
+}
+.chip--custom .icon{
+  position:absolute;
+  inline-size:1em;
+  block-size:1em;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  transition:opacity 120ms ease-out;
+}
+.chip--custom .icon svg{width:16px;height:16px;display:block;}
+.chip--custom .icon-custom{opacity:1;}
+.chip--custom .icon-pencil{opacity:0;}
+.chip--custom:hover .icon-custom,
+.chip--custom:focus-visible .icon-custom{opacity:0;}
+.chip--custom:hover .icon-pencil,
+.chip--custom:focus-visible .icon-pencil{opacity:1;}
 .dinner-icon{display:block;}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
 .dinner-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:24px;z-index:2000;}
@@ -831,9 +864,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-remove:hover{box-shadow:0 12px 24px rgba(15,23,42,.16);}
 .spa-remove:active{transform:translateY(1px);}
 body.spa-lock{overflow:hidden;}
-.custom-chip{color:var(--brand);}
-body[data-theme='dark'] .custom-chip{color:var(--chipText);}
-.custom-chip .chip-icon svg{width:16px;height:16px;display:block;}
+body[data-theme='dark'] .chip--custom{color:var(--chipText);}
 .custom-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:clamp(24px,7dvh,72px) clamp(16px,5vw,64px);z-index:2200;overflow:auto;box-sizing:border-box;}
 .custom-dialog{width:min(680px,100%);max-width:720px;max-height:calc(100dvh - 2 * clamp(24px,7dvh,72px));background:var(--surface,#fff);border-radius:26px;border:1px solid var(--border);box-shadow:0 28px 56px rgba(12,18,32,.22);display:flex;flex-direction:column;overflow:hidden;}
 .custom-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:32px clamp(24px,4vw,40px) 24px;border-bottom:1px solid var(--border-hairline);flex-shrink:0;background:var(--surface,#fff);}

--- a/style.css
+++ b/style.css
@@ -499,6 +499,16 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 @media(hover:hover){.dinner-chip:hover .chip-icon{opacity:0;}.dinner-chip:hover .chip-pencil{opacity:1;}}
 .dinner-chip:focus .chip-icon{opacity:0;}
 .dinner-chip:focus .chip-pencil{opacity:1;}
+/*
+  Custom chips keep the same pill dimensions as dinner/spa chips by sharing the
+  .dinner-chip shell. We only override the icon swap behavior so the slider
+  glyph shows by default and the pencil appears on hover or keyboard focus.
+*/
+.custom-chip .chip-icon{opacity:1;}
+.custom-chip .chip-pencil{opacity:0;}
+@media(hover:hover){.custom-chip:hover .chip-icon{opacity:0;}.custom-chip:hover .chip-pencil{opacity:1;}}
+.custom-chip:focus-visible .chip-icon{opacity:0;}
+.custom-chip:focus-visible .chip-pencil{opacity:1;}
 .dinner-icon{display:block;}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
 .dinner-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:24px;z-index:2000;}

--- a/style.css
+++ b/style.css
@@ -512,6 +512,13 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .time-picker-column{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}
 .time-picker-column::after{content:"";position:absolute;left:8px;right:8px;top:50%;height:44px;margin-top:-22px;border-radius:12px;border:1px solid rgba(42,107,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);pointer-events:none;}
 .time-picker-meridiem-static{font-size:18px;font-weight:600;color:var(--muted);text-transform:uppercase;display:flex;align-items:center;justify-content:center;height:176px;padding:0 4px;}
+.time-picker-column.time-picker-meridiem::after{content:none;}
+.time-picker-meridiem-toggle{width:100%;min-height:176px;padding:12px;border-radius:18px;border:1px solid var(--border-hairline);background:var(--surface,#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.08);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;}
+.time-picker-meridiem-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.time-picker-meridiem-option{border:0;border-radius:999px;padding:8px 18px;font:inherit;font-size:14px;font-weight:600;color:var(--muted);background:transparent;cursor:pointer;transition:background-color .18s ease,color .18s ease,box-shadow .18s ease;}
+.time-picker-meridiem-option.selected{background:var(--brand);color:#fff;box-shadow:0 12px 24px rgba(42,107,255,.24);}
+.time-picker-meridiem-option:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+@media(hover:hover){.time-picker-meridiem-option:not(.selected):hover{background:color-mix(in srgb,var(--brand) 14%,var(--surface));color:var(--brand);}}
 .time-picker-range-actions{display:flex;gap:12px;justify-content:center;margin-top:12px;flex-wrap:wrap;}
 .time-picker-range-btn{border-radius:999px;border:1px solid var(--border);background:var(--surface);color:var(--ink);padding:8px 16px;font-weight:500;font-size:14px;cursor:pointer;transition:box-shadow .16s ease,transform .16s ease;background-clip:padding-box;}
 .time-picker-range-btn:focus{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 6px 14px rgba(42,107,255,.18);}
@@ -814,23 +821,17 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-remove:hover{box-shadow:0 12px 24px rgba(15,23,42,.16);}
 .spa-remove:active{transform:translateY(1px);}
 body.spa-lock{overflow:hidden;}
-.custom-chip{width:auto;height:28px;min-width:68px;padding:0 14px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;gap:6px;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;}
-.custom-chip .chip-icon,.custom-chip .chip-pencil{width:auto;height:auto;}
-.custom-chip .custom-chip-label{transition:opacity .16s ease;}
-.custom-chip .custom-chip-pencil{opacity:0;transition:opacity .16s ease;display:flex;align-items:center;justify-content:center;}
-.custom-chip .custom-chip-pencil svg{width:16px;height:16px;display:block;}
-@media(hover:hover){.custom-chip:hover .custom-chip-label{opacity:0;}.custom-chip:hover .custom-chip-pencil{opacity:1;}}
-.custom-chip:focus .custom-chip-label{opacity:0;}
-.custom-chip:focus .custom-chip-pencil{opacity:1;}
-.custom-chip:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.custom-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:32px;z-index:2200;}
-.custom-dialog{width:min(680px,100%);max-width:720px;background:var(--surface,#fff);border-radius:26px;padding:30px;border:1px solid var(--border);box-shadow:0 28px 56px rgba(12,18,32,.22);display:flex;flex-direction:column;gap:28px;}
-.custom-header{display:flex;align-items:center;justify-content:space-between;gap:16px;}
+.custom-chip{color:var(--brand);}
+body[data-theme='dark'] .custom-chip{color:var(--chipText);}
+.custom-chip .chip-icon svg{width:16px;height:16px;display:block;}
+.custom-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:clamp(24px,7dvh,72px) clamp(16px,5vw,64px);z-index:2200;overflow:auto;box-sizing:border-box;}
+.custom-dialog{width:min(680px,100%);max-width:720px;max-height:calc(100dvh - 2 * clamp(24px,7dvh,72px));background:var(--surface,#fff);border-radius:26px;border:1px solid var(--border);box-shadow:0 28px 56px rgba(12,18,32,.22);display:flex;flex-direction:column;overflow:hidden;}
+.custom-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:32px clamp(24px,4vw,40px) 24px;border-bottom:1px solid var(--border-hairline);flex-shrink:0;background:var(--surface,#fff);}
 .custom-heading{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
 .custom-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#f1f5f9);font-size:20px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;transition:transform .18s ease,box-shadow .18s ease;}
 .custom-close:hover{box-shadow:0 12px 24px rgba(15,23,42,.18);}
 .custom-close:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.custom-body{display:flex;flex-direction:column;gap:24px;}
+.custom-body{display:flex;flex-direction:column;gap:24px;padding:24px clamp(24px,4vw,40px) 32px;overflow:auto;flex:1 1 auto;scrollbar-gutter:stable;}
 .custom-section{display:flex;flex-direction:column;gap:12px;}
 .custom-title-toggle-group{display:flex;flex-wrap:wrap;gap:8px;}
 .custom-title-toggle{border-radius:999px;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);padding:6px 16px;font:inherit;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,border-color .18s ease,color .18s ease,transform .18s ease;}
@@ -850,13 +851,13 @@ body.spa-lock{overflow:hidden;}
 .custom-clear-end:disabled{opacity:.35;cursor:default;}
 .custom-clear-end:not(:disabled):hover{color:var(--brand);}
 .custom-picker{display:flex;justify-content:center;}
-.custom-picker-actions{display:flex;flex-wrap:wrap;justify-content:center;gap:12px;}
-.custom-time-action{display:inline-flex;align-items:center;gap:10px;border-radius:16px;border:1px solid var(--border);background:var(--surface,#fff);padding:10px 18px;font:inherit;font-size:14px;font-weight:600;color:var(--ink);cursor:pointer;transition:box-shadow .18s ease,border-color .18s ease,transform .18s ease;}
+.custom-picker-actions{display:flex;flex-wrap:wrap;justify-content:center;gap:16px;}
+.custom-time-action{width:48px;height:48px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#fff);display:inline-flex;align-items:center;justify-content:center;color:var(--ink);cursor:pointer;transition:box-shadow .18s ease,border-color .18s ease,transform .18s ease;}
 .custom-time-action:hover{box-shadow:0 12px 24px rgba(15,23,42,.12);border-color:color-mix(in srgb,var(--brand) 28%,var(--border));}
 .custom-time-action:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 .custom-time-action:active{transform:translateY(1px);}
 .custom-time-icon{display:inline-flex;align-items:center;justify-content:center;}
-.custom-time-icon svg{width:18px;height:18px;display:block;}
+.custom-time-icon svg{width:20px;height:20px;display:block;}
 .custom-time-error{margin:0;font-size:13px;color:var(--brand);font-weight:600;}
 .custom-picker-fallback{font-size:14px;color:var(--muted);text-align:center;padding:16px;}
 .custom-section-location select{max-width:100%;}
@@ -865,7 +866,7 @@ body.spa-lock{overflow:hidden;}
 .custom-guest-summary{margin:0;font-size:14px;color:var(--muted);}
 .custom-guest-summary[data-empty='false']{color:var(--ink);}
 .custom-guest-summary[data-empty='true']{color:var(--brand);font-weight:600;}
-.custom-actions{display:flex;justify-content:flex-end;gap:12px;}
+.custom-actions{display:flex;justify-content:flex-end;gap:12px;padding:24px clamp(24px,4vw,40px) 32px;border-top:1px solid var(--border-hairline);flex-shrink:0;background:var(--surface,#fff);}
 .custom-save{border-radius:999px;border:none;background:var(--brand);color:#fff;padding:10px 24px;font:inherit;font-size:15px;font-weight:600;box-shadow:0 18px 36px rgba(42,107,255,.28);cursor:pointer;transition:box-shadow .2s ease,transform .2s ease,opacity .18s ease;}
 .custom-save:hover{box-shadow:0 26px 54px rgba(42,107,255,.32);}
 .custom-save:focus-visible{outline:2px solid #fff;outline-offset:3px;}

--- a/style.css
+++ b/style.css
@@ -842,6 +842,27 @@ body[data-theme='dark'] .custom-chip{color:var(--chipText);}
 .custom-title-input{border-radius:14px;border:1px solid var(--border);padding:12px 16px;font:inherit;font-size:15px;color:var(--ink);box-shadow:0 3px 10px rgba(15,23,42,.08);transition:border-color .18s ease,box-shadow .18s ease;}
 .custom-title-input:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 .custom-title-input[aria-invalid='true']{border-color:var(--brand);box-shadow:0 0 0 2px rgba(42,107,255,.18);}
+/* Embedded existing-activity list keeps scrolling inside the field so the */
+/* dialog height never jumps while showing catalog rows. */
+.custom-existing-pane{position:relative;}
+.custom-existing-field{border-radius:14px;border:1px solid var(--border);background:var(--surface,#fff);box-shadow:0 3px 10px rgba(15,23,42,.08);display:flex;flex-direction:column;overflow:hidden;}
+.custom-existing-header{display:flex;justify-content:flex-end;padding:8px 12px 0;}
+.custom-existing-back{background:none;border:none;color:var(--brand);font:inherit;font-size:13px;font-weight:500;padding:4px 8px;border-radius:999px;cursor:pointer;transition:background-color .18s ease,color .18s ease;}
+.custom-existing-back:hover{background-color:color-mix(in srgb,var(--brand) 14%,transparent);}
+.custom-existing-back:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-existing-list{max-height:240px;overflow:auto;padding:4px 0;scrollbar-gutter:stable both-edges;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;}
+.custom-existing-list::-webkit-scrollbar{width:6px;}
+.custom-existing-list::-webkit-scrollbar-thumb{background:rgba(148,163,184,.5);border-radius:999px;}
+.custom-existing-list::-webkit-scrollbar-track{background:transparent;}
+.custom-existing-row{display:flex;flex-direction:column;align-items:flex-start;gap:2px;width:100%;padding:12px 16px;background:none;border:none;font:inherit;font-size:15px;color:var(--ink);text-align:left;cursor:pointer;transition:background-color .18s ease,color .18s ease;}
+.custom-existing-row + .custom-existing-row{border-top:1px solid var(--border-hairline);}
+.custom-existing-row.active{background:color-mix(in srgb,var(--brand) 12%,transparent);color:var(--ink);}
+.custom-existing-row:focus-visible{outline:2px solid var(--brand);outline-offset:-2px;}
+.custom-existing-title{font-weight:600;line-height:1.2;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.custom-existing-sub{font-size:13px;color:var(--muted);max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+body[data-theme='dark'] .custom-existing-back:hover{background-color:color-mix(in srgb,var(--brand) 28%,transparent);}
+body[data-theme='dark'] .custom-existing-row.active{background:color-mix(in srgb,var(--brand) 28%,transparent);}
+body[data-theme='dark'] .custom-existing-list::-webkit-scrollbar-thumb{background:rgba(148,163,184,.7);}
 .custom-time-summary{display:flex;flex-wrap:wrap;gap:12px;}
 .custom-time-pill{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border-radius:999px;border:1px solid var(--border);background:var(--panel,#f8fafc);transition:background-color .18s ease,border-color .18s ease,color .18s ease;}
 .custom-time-pill[data-empty='true']{color:var(--muted);}

--- a/style.css
+++ b/style.css
@@ -134,13 +134,15 @@ body[data-theme='light']{
 }
 @media (prefers-color-scheme: dark){
   .dinner-item,
-  .spa-item{
+  .spa-item,
+  .custom-item{
     background:linear-gradient(135deg,rgba(99,127,255,0.22),rgba(99,127,255,0.08));
     box-shadow:inset 0 0 0 1px rgba(148,163,255,0.32);
   }
 }
 body[data-theme='dark'] .dinner-item,
-body[data-theme='dark'] .spa-item{
+body[data-theme='dark'] .spa-item,
+body[data-theme='dark'] .custom-item{
   background:linear-gradient(135deg,rgba(99,127,255,0.22),rgba(99,127,255,0.08));
   box-shadow:inset 0 0 0 1px rgba(148,163,255,0.32);
 }
@@ -457,9 +459,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 #activities .activity-row-time,#demoActivities .activity-row-time{font-weight:600;font-variant-numeric:tabular-nums;}
 #activities .activity-row-title,#demoActivities .activity-row-title{flex:1 1 auto;min-width:0;}
 #activities .activity-row .tag-row,#demoActivities .activity-row .tag-row{margin-top:2px;}
-.dinner-item,.spa-item{cursor:default;background:linear-gradient(135deg,rgba(42,107,255,.08),rgba(42,107,255,.02));box-shadow:inset 0 0 0 1px rgba(42,107,255,.16);border-radius:16px;}
-.dinner-item::after,.spa-item::after{content:none;}
-.dinner-item .tag-row,.spa-item .tag-row{margin-top:6px;}
+.dinner-item,.spa-item,.custom-item{cursor:default;background:linear-gradient(135deg,rgba(42,107,255,.08),rgba(42,107,255,.02));box-shadow:inset 0 0 0 1px rgba(42,107,255,.16);border-radius:16px;}
+.dinner-item::after,.spa-item::after,.custom-item::after{content:none;}
+.dinner-item .tag-row,.spa-item .tag-row,.custom-item .tag-row{margin-top:6px;}
 .spa-item .spa-meta{margin-top:4px;font-size:13px;color:var(--muted);}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:4px 12px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;color:var(--chipText);cursor:pointer;appearance:none;font:inherit;line-height:1;transition:box-shadow .2s ease;}
 .tag-everyone:focus{outline:2px solid var(--brand);outline-offset:2px;}
@@ -812,6 +814,68 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-remove:hover{box-shadow:0 12px 24px rgba(15,23,42,.16);}
 .spa-remove:active{transform:translateY(1px);}
 body.spa-lock{overflow:hidden;}
+.custom-chip{width:auto;height:28px;min-width:68px;padding:0 14px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;gap:6px;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;}
+.custom-chip .chip-icon,.custom-chip .chip-pencil{width:auto;height:auto;}
+.custom-chip .custom-chip-label{transition:opacity .16s ease;}
+.custom-chip .custom-chip-pencil{opacity:0;transition:opacity .16s ease;display:flex;align-items:center;justify-content:center;}
+.custom-chip .custom-chip-pencil svg{width:16px;height:16px;display:block;}
+@media(hover:hover){.custom-chip:hover .custom-chip-label{opacity:0;}.custom-chip:hover .custom-chip-pencil{opacity:1;}}
+.custom-chip:focus .custom-chip-label{opacity:0;}
+.custom-chip:focus .custom-chip-pencil{opacity:1;}
+.custom-chip:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:32px;z-index:2200;}
+.custom-dialog{width:min(680px,100%);max-width:720px;background:var(--surface,#fff);border-radius:26px;padding:30px;border:1px solid var(--border);box-shadow:0 28px 56px rgba(12,18,32,.22);display:flex;flex-direction:column;gap:28px;}
+.custom-header{display:flex;align-items:center;justify-content:space-between;gap:16px;}
+.custom-heading{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
+.custom-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#f1f5f9);font-size:20px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;transition:transform .18s ease,box-shadow .18s ease;}
+.custom-close:hover{box-shadow:0 12px 24px rgba(15,23,42,.18);}
+.custom-close:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-body{display:flex;flex-direction:column;gap:24px;}
+.custom-section{display:flex;flex-direction:column;gap:12px;}
+.custom-title-toggle-group{display:flex;flex-wrap:wrap;gap:8px;}
+.custom-title-toggle{border-radius:999px;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);padding:6px 16px;font:inherit;font-size:14px;font-weight:500;cursor:pointer;transition:box-shadow .18s ease,border-color .18s ease,color .18s ease,transform .18s ease;}
+.custom-title-toggle.selected{border-color:var(--brand);color:var(--brand);box-shadow:0 12px 24px rgba(42,107,255,.18);transform:translateY(-1px);}
+.custom-title-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-title-pane{display:flex;flex-direction:column;gap:8px;}
+.custom-title-pane[hidden]{display:none;}
+.custom-title-input{border-radius:14px;border:1px solid var(--border);padding:12px 16px;font:inherit;font-size:15px;color:var(--ink);box-shadow:0 3px 10px rgba(15,23,42,.08);transition:border-color .18s ease,box-shadow .18s ease;}
+.custom-title-input:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-title-input[aria-invalid='true']{border-color:var(--brand);box-shadow:0 0 0 2px rgba(42,107,255,.18);}
+.custom-time-summary{display:flex;flex-wrap:wrap;gap:12px;}
+.custom-time-pill{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border-radius:999px;border:1px solid var(--border);background:var(--panel,#f8fafc);transition:background-color .18s ease,border-color .18s ease,color .18s ease;}
+.custom-time-pill[data-empty='true']{color:var(--muted);}
+.custom-time-pill-label{font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);}
+.custom-time-value{font-size:15px;font-weight:600;letter-spacing:.01em;color:var(--ink);}
+.custom-clear-end{border:0;background:transparent;color:var(--muted);font:inherit;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;cursor:pointer;padding:0;transition:color .18s ease;}
+.custom-clear-end:disabled{opacity:.35;cursor:default;}
+.custom-clear-end:not(:disabled):hover{color:var(--brand);}
+.custom-picker{display:flex;justify-content:center;}
+.custom-picker-actions{display:flex;flex-wrap:wrap;justify-content:center;gap:12px;}
+.custom-time-action{display:inline-flex;align-items:center;gap:10px;border-radius:16px;border:1px solid var(--border);background:var(--surface,#fff);padding:10px 18px;font:inherit;font-size:14px;font-weight:600;color:var(--ink);cursor:pointer;transition:box-shadow .18s ease,border-color .18s ease,transform .18s ease;}
+.custom-time-action:hover{box-shadow:0 12px 24px rgba(15,23,42,.12);border-color:color-mix(in srgb,var(--brand) 28%,var(--border));}
+.custom-time-action:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-time-action:active{transform:translateY(1px);}
+.custom-time-icon{display:inline-flex;align-items:center;justify-content:center;}
+.custom-time-icon svg{width:18px;height:18px;display:block;}
+.custom-time-error{margin:0;font-size:13px;color:var(--brand);font-weight:600;}
+.custom-picker-fallback{font-size:14px;color:var(--muted);text-align:center;padding:16px;}
+.custom-section-location select{max-width:100%;}
+.custom-location-select{border-radius:14px;border:1px solid var(--border);padding:12px 14px;font:inherit;font-size:15px;color:var(--ink);background:var(--surface,#fff);box-shadow:0 3px 10px rgba(15,23,42,.08);transition:border-color .18s ease,box-shadow .18s ease;}
+.custom-location-select:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-guest-summary{margin:0;font-size:14px;color:var(--muted);}
+.custom-guest-summary[data-empty='false']{color:var(--ink);}
+.custom-guest-summary[data-empty='true']{color:var(--brand);font-weight:600;}
+.custom-actions{display:flex;justify-content:flex-end;gap:12px;}
+.custom-save{border-radius:999px;border:none;background:var(--brand);color:#fff;padding:10px 24px;font:inherit;font-size:15px;font-weight:600;box-shadow:0 18px 36px rgba(42,107,255,.28);cursor:pointer;transition:box-shadow .2s ease,transform .2s ease,opacity .18s ease;}
+.custom-save:hover{box-shadow:0 26px 54px rgba(42,107,255,.32);}
+.custom-save:focus-visible{outline:2px solid #fff;outline-offset:3px;}
+.custom-save:active{transform:translateY(1px);}
+.custom-save:disabled{opacity:.55;cursor:not-allowed;box-shadow:none;}
+.custom-delete{border-radius:999px;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);padding:10px 18px;font:inherit;font-size:15px;font-weight:500;box-shadow:0 10px 22px rgba(15,23,42,.14);cursor:pointer;transition:box-shadow .18s ease,color .18s ease,transform .18s ease;}
+.custom-delete:hover{box-shadow:0 14px 26px rgba(15,23,42,.16);color:var(--ink);}
+.custom-delete:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.custom-delete:active{transform:translateY(1px);}
+body.custom-lock{overflow:hidden;}
 @media (max-width:1100px){
   .spa-dialog{max-width:980px;}
 }


### PR DESCRIPTION
Context: Enable the Custom button to author bespoke activities without touching SPA logic.
Approach: Build a catalog-backed custom builder that reuses the shared time picker for start/end capture, writes entries in chronological order, and wires guest/tag handling plus preview updates. Extend styles for the premium modal and chip affordances, and add a QA-focused demo page with seeded examples.
Guardrails upheld: Activities row height, existing chip logic, unified time picker physics, preview layout, theme tokens, and no SPA coupling.
Screenshots: ![Custom activities demo](browser:/invocations/btkdjyvz/artifacts/artifacts/custom-demo.png)
Notes: Demo page seeds the three QA scenarios described in the brief.


------
https://chatgpt.com/codex/tasks/task_e_68e4b359394c8330bb995bc743b75b87