### PR TITLE
Refine calendar column controls and stay notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,24 +33,35 @@
         <div id="dow" class="grid dow" aria-hidden="true"></div>
         <div id="calGrid" class="grid days" role="grid" aria-label="Calendar grid"></div>
         <div class="calendar-actions">
-          <button id="btnToday" title="Today" aria-label="Today">Today</button>
-          <button id="btnArrival" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
-          <button id="btnDeparture" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
+          <!-- Full-width Today button anchors the control stack so it reads as the primary action without shifting nearby content. -->
+          <button id="btnToday" class="calendar-today-button" title="Today" aria-label="Today">Today</button>
+        </div>
+        <div class="stay-note-row" aria-label="Stay arrival and departure tools">
+          <!-- Group arrival controls so the note input sits inline with the button while keeping keyboard order logical. -->
+          <div class="stay-note">
+            <button id="btnArrival" class="stay-note-button" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
+            <input id="arrivalEta" class="stay-time-input" type="text" placeholder="ETA" aria-label="Arrival time note" aria-haspopup="dialog" readonly>
+          </div>
+          <div class="stay-note">
+            <button id="btnDeparture" class="stay-note-button" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
+            <input id="departureEtd" class="stay-time-input" type="text" placeholder="ETD" aria-label="Departure time note" aria-haspopup="dialog" readonly>
+          </div>
         </div>
         <!-- Guest tools sit in the calendar flow so iPad can stack header → nav → grid → controls → guests without JS shuffles. -->
         <div class="section guest-section">
-          <div class="card-section-header">
+          <div class="card-section-header guests-header">
             <h2>Guests</h2>
-          </div>
-          <div class="row">
-            <input id="guestName" class="guest-input" type="text" placeholder="Add guest" aria-label="Guest name">
-            <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
+            <!-- Keep guest entry inline with the header so the divider still separates chips from controls. -->
+            <div class="guest-tools">
+              <input id="guestName" class="guest-input" type="text" placeholder="Who..?" aria-label="Guest name">
+              <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
               <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
                 <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>
                 <rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/>
               </svg>
-            </button>
+              </button>
+            </div>
           </div>
           <div id="guests" class="chips" aria-label="Guests"></div>
         </div>

--- a/style.css
+++ b/style.css
@@ -27,6 +27,13 @@
   --activity-shadow-pressed:0 8px 18px rgba(12,18,32,0.08);
   --activity-focus-ring:rgba(42,107,255,0.55);
   --activity-focus-glow:rgba(42,107,255,0.16);
+  /* Surface the preview spacing scale to the live route so every column shares the same rhythm. */
+  --space-1:0.25rem;
+  --space-2:0.5rem;
+  --space-3:0.75rem;
+  --space-4:1rem;
+  --space-5:1.25rem;
+  --space-6:1.5rem;
   /* Responsive layout tokens keep columns balanced and gutters subtle across breakpoints. */
   --space-edge:clamp(1rem,3vw,2.5rem);
   --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
@@ -59,6 +66,12 @@
     --activity-focus-ring:rgba(148,163,255,0.7);
     --activity-focus-glow:rgba(148,163,255,0.35);
     --border:rgba(148,163,184,0.28);
+    --space-1:0.25rem;
+    --space-2:0.5rem;
+    --space-3:0.75rem;
+    --space-4:1rem;
+    --space-5:1.25rem;
+    --space-6:1.5rem;
     --space-edge:clamp(1rem,3vw,2.5rem);
     --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
     --layout-column-min:clamp(16rem,25vw,22rem);
@@ -106,6 +119,12 @@ body[data-theme='light']{
   --activity-shadow-pressed:0 8px 18px rgba(12,18,32,0.08);
   --activity-focus-ring:rgba(42,107,255,0.55);
   --activity-focus-glow:rgba(42,107,255,0.16);
+  --space-1:0.25rem;
+  --space-2:0.5rem;
+  --space-3:0.75rem;
+  --space-4:1rem;
+  --space-5:1.25rem;
+  --space-6:1.5rem;
   /* Responsive layout tokens keep rails full-bleed while retaining a polished gutter. */
   --space-edge:clamp(1rem,3vw,2.5rem);
   --layout-gap:clamp(0.75rem,2.5vw,1.75rem);
@@ -131,6 +150,12 @@ body[data-theme='light']{
     --activity-shadow-pressed:0 8px 18px rgba(12,18,32,0.08);
     --activity-focus-ring:rgba(42,107,255,0.55);
     --activity-focus-glow:rgba(42,107,255,0.16);
+    --space-1:0.25rem;
+    --space-2:0.5rem;
+    --space-3:0.75rem;
+    --space-4:1rem;
+    --space-5:1.25rem;
+    --space-6:1.5rem;
   }
 }
 @media (prefers-color-scheme: dark){
@@ -362,7 +387,17 @@ body{
 .day-header-details #dayTitle{margin:0}
 .space-between{justify-content:space-between}
 h2{margin:0 0 12px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
-.calendar-header,.card-section-header{display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin:0 0 12px;padding-bottom:12px;border-bottom:1px solid var(--border-hairline);inline-size:100%}
+.calendar-header,.card-section-header{
+  display:flex;
+  align-items:center;
+  gap:var(--space-3);
+  flex-wrap:wrap;
+  margin:0;
+  margin-block-end:var(--space-4);
+  padding-block-end:var(--space-3);
+  border-bottom:1px solid var(--border-hairline);
+  inline-size:100%;
+}
 .card-section-header{padding-top:0.4375rem}
 .calendar-header h2,.card-section-header h2{margin:0}
 .calendar-header .season-indicator{margin-inline-start:auto}
@@ -375,7 +410,13 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .lock-icon{width:1em;height:1em;display:block}
 #toggleEdit{display:flex;align-items:center;justify-content:center;gap:0;line-height:1}
 .muted{color:var(--muted)}
-.grid{display:grid;grid-template-columns:repeat(7,1fr);gap:6px}
+.grid{
+  display:grid;
+  grid-template-columns:repeat(7,1fr);
+  gap:6px;
+  margin:0;
+}
+.dow{margin:0;margin-block-end:var(--space-2)}
 .dow div{font-size:11px;color:var(--muted);text-align:center}
 .days button{aspect-ratio:1/1;border-radius:12px;background:#fff;position:relative}
 .days button.other{opacity:.45}
@@ -474,21 +515,34 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .section{margin-top:16px}
 #calMonth{font-weight:700;font-size:16px}
 #calYear{color:var(--muted);font-size:12px}
-.toolbar{margin-bottom:8px}
+.toolbar{
+  margin:0;
+  margin-block-end:var(--space-3);
+}
 .toolbar .nav-row{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:nowrap;width:100%}
 .toolbar .monthyear-col{display:flex;flex-direction:column;line-height:1.05;align-items:center;text-align:center;flex:0 0 140px;white-space:nowrap}
 .toolbar .nav-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;border-radius:10px;padding:0}
-.calendar-actions{margin-top:1.1rem}
-/* Softly elevate the Today button so it reads as primary without overpowering the column. */
+/* The calendar stack now uses token spacing so the live route matches the preview cadence. */
+.calendar-actions{
+  margin:0;
+  margin-block-start:var(--space-5);
+}
+/*
+ * Softly elevate the Today button and stretch it full-width so it reads as the
+ * primary action without nudging the calendar grid or nearby controls.
+ */
 .calendar-today-button{
+  display:block;
   inline-size:100%;
   min-height:44px;
+  padding-block:var(--space-2);
   border-radius:14px;
   border:1px solid var(--border-hairline);
   background:var(--surface);
   color:var(--brand);
   font-weight:600;
   letter-spacing:0.02em;
+  text-align:center;
   box-shadow:0 10px 24px color-mix(in srgb,var(--brand) 14%, transparent);
   transition:box-shadow 140ms ease,transform 140ms ease;
 }
@@ -504,46 +558,63 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .stay-note-row{
   display:flex;
-  gap:0.75rem;
+  gap:var(--space-3);
   flex-wrap:wrap;
-  margin-top:0.85rem;
+  margin:0;
+  margin-block-start:var(--space-4);
 }
-.stay-note{display:flex;align-items:center;gap:0.5rem;min-width:0}
+.stay-note{display:flex;align-items:center;gap:var(--space-2);min-width:0}
 .stay-note-button{
   min-height:36px;
-  padding:0 14px;
+  padding-inline:var(--space-3);
   border-radius:12px;
   background:var(--surface);
   color:var(--text-primary);
   border:1px solid var(--border);
 }
+/* Neutralize native chrome so the time pills match the soft preview styling in every browser. */
 .stay-time-input{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
   min-height:36px;
-  padding:0 12px;
+  padding-inline:var(--space-3);
   min-width:4.5rem;
-  border:1px solid var(--border);
-  border-radius:12px;
+  border:1px solid var(--border-hairline);
+  border-radius:999px;
   background:var(--surface);
   color:var(--text-primary);
   font:inherit;
+  font-weight:400;
+  font-size:16px;
   letter-spacing:0.01em;
+  text-align:center;
+  cursor:pointer;
+  appearance:none;
+  -webkit-appearance:none;
+  -moz-appearance:none;
+  box-shadow:0 6px 16px color-mix(in srgb,var(--text-primary) 10%, transparent);
 }
+.stay-time-input::-webkit-calendar-picker-indicator{display:none}
+.stay-time-input::-webkit-inner-spin-button,
+.stay-time-input::-webkit-clear-button,
+.stay-time-input::-webkit-outer-spin-button{display:none}
 .stay-time-input:focus{
   outline:2px solid var(--brand);
   outline-offset:2px;
 }
 .stay-time-input::placeholder{color:var(--text-muted);}
 @media(max-width:720px){
-  .stay-note-row{gap:0.65rem}
+  .stay-note-row{gap:var(--space-2)}
   .stay-note{flex:1 1 100%}
   .stay-note-button{flex:0 0 auto}
 }
-.guests-header{align-items:center;gap:0.75rem}
+.guests-header{align-items:center;gap:var(--space-3)}
 .guests-header .guest-tools{
   margin-inline-start:auto;
   display:flex;
   align-items:center;
-  gap:0.5rem;
+  gap:var(--space-2);
   flex-wrap:wrap;
   justify-content:flex-end;
 }
@@ -580,8 +651,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 #actions{margin:8px 0 12px}
 .guest-section{
   /* Hairline divider + spacing align the relocated guest block with the calendar controls. */
-  margin-top:12px;
-  padding-top:12px;
+  margin:0;
+  margin-block-start:var(--space-5);
+  padding-block-start:var(--space-3);
   border-top:1px solid var(--border-hairline);
 }
 

--- a/style.css
+++ b/style.css
@@ -478,8 +478,105 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .toolbar .nav-row{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:nowrap;width:100%}
 .toolbar .monthyear-col{display:flex;flex-direction:column;line-height:1.05;align-items:center;text-align:center;flex:0 0 140px;white-space:nowrap}
 .toolbar .nav-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;border-radius:10px;padding:0}
-.calendar-actions{display:flex;gap:6px;margin-top:8px;flex-wrap:wrap;align-items:center}
-.calendar-actions button{height:32px;padding:0 10px;border-radius:10px}
+.calendar-actions{margin-top:1.1rem}
+/* Softly elevate the Today button so it reads as primary without overpowering the column. */
+.calendar-today-button{
+  inline-size:100%;
+  min-height:44px;
+  border-radius:14px;
+  border:1px solid var(--border-hairline);
+  background:var(--surface);
+  color:var(--brand);
+  font-weight:600;
+  letter-spacing:0.02em;
+  box-shadow:0 10px 24px color-mix(in srgb,var(--brand) 14%, transparent);
+  transition:box-shadow 140ms ease,transform 140ms ease;
+}
+@supports(color-mix(in srgb, red 50%, white 50%)){
+  .calendar-today-button{
+    background:color-mix(in srgb,var(--brand) 16%, var(--surface));
+    border-color:color-mix(in srgb,var(--brand) 38%, transparent);
+  }
+}
+.calendar-today-button:active{
+  transform:translateY(1px);
+  box-shadow:0 6px 18px color-mix(in srgb,var(--brand) 18%, transparent);
+}
+.stay-note-row{
+  display:flex;
+  gap:0.75rem;
+  flex-wrap:wrap;
+  margin-top:0.85rem;
+}
+.stay-note{display:flex;align-items:center;gap:0.5rem;min-width:0}
+.stay-note-button{
+  min-height:36px;
+  padding:0 14px;
+  border-radius:12px;
+  background:var(--surface);
+  color:var(--text-primary);
+  border:1px solid var(--border);
+}
+.stay-time-input{
+  min-height:36px;
+  padding:0 12px;
+  min-width:4.5rem;
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:var(--surface);
+  color:var(--text-primary);
+  font:inherit;
+  letter-spacing:0.01em;
+}
+.stay-time-input:focus{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+}
+.stay-time-input::placeholder{color:var(--text-muted);}
+@media(max-width:720px){
+  .stay-note-row{gap:0.65rem}
+  .stay-note{flex:1 1 100%}
+  .stay-note-button{flex:0 0 auto}
+}
+.guests-header{align-items:center;gap:0.75rem}
+.guests-header .guest-tools{
+  margin-inline-start:auto;
+  display:flex;
+  align-items:center;
+  gap:0.5rem;
+  flex-wrap:wrap;
+  justify-content:flex-end;
+}
+.guests-header .guest-input{flex:1 1 auto;min-width:8rem}
+.guests-header .icon-btn{flex:0 0 auto}
+.stay-time-layer{position:fixed;inset:0;z-index:1200}
+.stay-time-scrim{position:absolute;inset:0;background:transparent}
+/* Anchor the floating picker near its trigger without breaking layout flow. */
+.stay-time-surface{
+  position:absolute;
+  min-width:15rem;
+  padding:1rem;
+  border-radius:16px;
+  border:1px solid var(--border-hairline);
+  background:var(--surface-elevated);
+  box-shadow:0 20px 44px color-mix(in srgb,var(--text-primary) 20%, transparent);
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+}
+.stay-time-actions{display:flex;justify-content:flex-end;gap:0.5rem;flex-wrap:wrap}
+.stay-time-actions button{min-height:36px;border-radius:12px;padding:0 14px}
+.stay-time-clear{background:var(--surface);color:var(--text-muted);border:1px solid var(--border)}
+.stay-time-primary{background:var(--surface);color:var(--brand);border:1px solid var(--border)}
+@supports(color-mix(in srgb, red 50%, white 50%)){
+  .stay-time-primary{
+    background:color-mix(in srgb,var(--brand) 18%, var(--surface));
+    border-color:color-mix(in srgb,var(--brand) 35%, transparent);
+  }
+}
+.stay-time-primary:focus{outline:2px solid var(--brand);outline-offset:2px}
+.stay-time-clear:focus{outline:2px solid var(--brand);outline-offset:2px}
+.stay-time-fallback{color:var(--text-muted);font-size:0.9rem;padding:0.25rem 0}
 #actions{margin:8px 0 12px}
 .guest-section{
   /* Hairline divider + spacing align the relocated guest block with the calendar controls. */


### PR DESCRIPTION
Context: Calendar column polish and stay note capture
Approach:
- Centered the Today button beneath the calendar grid, added a dedicated stay-note row for Arrival/Departure, and tucked the guest input beside the Guests header for tighter tooling alignment.
- Applied new styling tokens so the Today action, stay note controls, and guest header share a soft, Apple-like presentation in both light and dark themes.
- Extended the calendar script to expose compact weekday initials with accessible labels, track ETA/ETD note state, and host an inline time picker overlay that reuses the shared TimePickerKit.
Guardrails upheld: Activities layout, chip rendering, picker physics, preview behaviors, iPad layout, theming tokens.
Screenshots: ![Calendar column redesign](browser:/invocations/bplevvea/artifacts/artifacts/calendar-update.png)
Notes: Verified ETA/ETD entry at 7:05 AM and 11:55 PM plus guest management via automation; no regressions observed.


------
https://chatgpt.com/codex/tasks/task_e_68e5a20b44b0833085e1bbdd655c5b4b