### PR TITLE
Align action chips on activity rows

### DIFF
--- a/script.js
+++ b/script.js
@@ -1234,10 +1234,18 @@
       chip.dataset.pressExempt='true';
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openDinnerPicker({ mode:'edit', dateKey: dateK }));
-      tagWrap.appendChild(chip);
 
-      body.appendChild(tagWrap);
+      if(tagWrap.childElementCount>0){
+        body.appendChild(tagWrap);
+      }
+
+      // Keep the dinner edit affordance in a dedicated rail so it pins to the right.
+      const rail=document.createElement('div');
+      rail.className='activity-row-rail';
+      rail.appendChild(chip);
+
       div.appendChild(body);
+      div.appendChild(rail);
       activitiesEl.appendChild(div);
     }
 
@@ -1311,10 +1319,18 @@
       chip.dataset.pressExempt='true';
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openSpaEditor({ mode:'edit', dateKey: dateK, entryId: entry.id }));
-      tagWrap.appendChild(chip);
 
-      body.appendChild(tagWrap);
+      if(tagWrap.childElementCount>0){
+        body.appendChild(tagWrap);
+      }
+
+      // Share the right rail treatment so every activity action aligns consistently.
+      const rail=document.createElement('div');
+      rail.className='activity-row-rail';
+      rail.appendChild(chip);
+
       div.appendChild(body);
+      div.appendChild(rail);
       activitiesEl.appendChild(div);
     }
 
@@ -1363,10 +1379,17 @@
       chip.title='Edit custom activity';
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openCustomBuilder({ mode:'edit', dateKey: dateK, entryId: entry.id }));
-      tagWrap.appendChild(chip);
 
-      body.appendChild(tagWrap);
+      if(tagWrap.childElementCount>0){
+        body.appendChild(tagWrap);
+      }
+
+      const rail=document.createElement('div');
+      rail.className='activity-row-rail';
+      rail.appendChild(chip);
+
       div.appendChild(body);
+      div.appendChild(rail);
       activitiesEl.appendChild(div);
     }
 

--- a/style.css
+++ b/style.css
@@ -494,7 +494,12 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   scrollbar-gutter:stable both-edges;
   -webkit-overflow-scrolling:touch;
 }
-#activities .activity-row,#demoActivities .activity-row{position:relative;display:flex;flex-direction:column;gap:8px;padding:14px 16px;border-radius:14px;background:transparent;cursor:pointer;touch-action:pan-y;transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;}
+/*
+ * Pivot the row into a horizontal flex lane so the action chips can live in a
+ * dedicated right rail while the title/time stack stays untouched. The
+ * min-height keeps the fixed activity cadence even when the rail is empty.
+ */
+#activities .activity-row,#demoActivities .activity-row{position:relative;display:flex;align-items:center;flex-wrap:nowrap;gap:var(--space-4);padding:14px 16px;min-height:80px;border-radius:14px;background:transparent;cursor:pointer;touch-action:pan-y;transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;}
 #activities .activity-row::after,#demoActivities .activity-row::after{content:"";position:absolute;left:16px;right:16px;bottom:0;height:1px;background:var(--activity-divider);transform-origin:center;transform:scaleY(.5);}
 #activities .activity-row:last-of-type::after,#demoActivities .activity-row:last-of-type::after{content:none;}
 #activities .activity-row[data-disabled='true'],#demoActivities .activity-row[data-disabled='true']{cursor:default;opacity:.55;}
@@ -503,7 +508,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 @media(prefers-reduced-motion:reduce){#activities .activity-row,#demoActivities .activity-row{transition:none;}#activities .activity-row[data-pressed='true'],#demoActivities .activity-row[data-pressed='true']{transform:none;}}
 @media(hover:hover){#activities .activity-row:not([data-disabled='true']):hover,#demoActivities .activity-row:not([data-disabled='true']):hover{background:var(--activity-hover);box-shadow:var(--activity-shadow-hover);}}
 #activities .activity-row:focus-visible,#demoActivities .activity-row:focus-visible{outline:none;box-shadow:0 0 0 2px var(--activity-focus-ring),0 0 0 6px var(--activity-focus-glow);background:var(--activity-hover);}
-#activities .activity-row-body,#demoActivities .activity-row-body{display:flex;flex-direction:column;gap:6px;min-width:0;}
+#activities .activity-row-body,#demoActivities .activity-row-body{display:flex;flex-direction:column;gap:6px;min-width:0;flex:1 1 auto;}
 #activities .activity-row-headline,#demoActivities .activity-row-headline{display:flex;flex-wrap:wrap;align-items:baseline;gap:8px;font-weight:500;letter-spacing:.01em;color:var(--text-primary);}
 #activities .activity-row-time,#demoActivities .activity-row-time{font-weight:600;font-variant-numeric:tabular-nums;}
 #activities .activity-row-title,#demoActivities .activity-row-title{flex:1 1 auto;min-width:0;}
@@ -526,6 +531,8 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .tag-everyone.open .popover,.tag-everyone[aria-expanded="true"] .popover,.tag-everyone:focus-within .popover{display:flex}
 @media(hover:hover){.tag-everyone:hover .popover{display:flex}}
 .tag-row{display:flex;gap:6px;flex-wrap:wrap}
+/* Dedicated lane for dinner/spa/custom chips so they never wrap and stay pinned. */
+.activity-row-rail{margin-left:auto;display:flex;align-items:center;gap:var(--space-2);flex-wrap:nowrap;flex:0 0 auto;min-width:0;}
 .stick-right{justify-content:flex-end}
 .section{margin-top:16px}
 #calMonth{font-weight:700;font-size:16px}


### PR DESCRIPTION
Context: Align dinner / spa / custom chips to the far-right rail of each activity row.
Approach: Pivoted `.activity-row` into a horizontal flex lane with a fixed-height rail so the main stack and right-aligned action chips stay separated, then render the dinner/spa/custom buttons inside the new `.activity-row-rail` container.
Guardrails upheld: fixed row heights, guest chip positioning, hover/focus treatments, no business-logic changes.
Screenshots: Included updated desktop capture demonstrating the right-pinned rail.
Notes: None.

------
https://chatgpt.com/codex/tasks/task_e_68e5c2e0c16883308262bd093cdd9539