### PR TITLE
Align activities guest chips with trailing rail

### DIFF
--- a/style.css
+++ b/style.css
@@ -499,7 +499,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
  * min-height so chips never resize the lane. Padding + divider offsets lean on
  * the spacing scale to stay in sync with neighboring sections.
  */
-#activities .activity-row,#demoActivities .activity-row{position:relative;display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;column-gap:var(--space-3);padding:var(--space-4);min-height:5rem;border-radius:14px;background:transparent;cursor:pointer;touch-action:pan-y;transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;}
+#activities .activity-row,#demoActivities .activity-row{position:relative;display:grid;grid-template-columns:minmax(0,1fr) auto auto;align-items:center;column-gap:var(--space-3);padding:var(--space-4);min-height:5rem;border-radius:14px;background:transparent;cursor:pointer;touch-action:pan-y;transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;}
 #activities .activity-row::after,#demoActivities .activity-row::after{content:"";position:absolute;left:var(--space-4);right:var(--space-4);bottom:0;height:1px;background:var(--activity-divider);transform-origin:center;transform:scaleY(.5);}
 #activities .activity-row:last-of-type::after,#demoActivities .activity-row:last-of-type::after{content:none;}
 #activities .activity-row[data-disabled='true'],#demoActivities .activity-row[data-disabled='true']{cursor:default;opacity:.55;}
@@ -514,7 +514,22 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 #activities .activity-row-headline,#demoActivities .activity-row-headline{display:flex;flex-direction:column;align-items:flex-start;gap:var(--space-1);min-width:0;color:var(--text-primary);}
 #activities .activity-row-time,#demoActivities .activity-row-time{font-size:.8125rem;font-weight:500;letter-spacing:.02em;color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap;}
 #activities .activity-row-title,#demoActivities .activity-row-title{display:block;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--text-primary);min-width:0;}
-#activities .activity-row .tag-row,#demoActivities .activity-row .tag-row{margin-top:var(--space-1);}
+#activities .activity-row-guests,#demoActivities .activity-row-guests{
+  /*
+   * The guest lane hugs the action chips while leaving enough room for the left
+   * stack. Clamp the inline size so the overflow controller can reliably
+   * replace extra chips with a +N pill without ever growing the row height.
+   */
+  display:flex;
+  align-items:center;
+  justify-self:end;
+  flex:0 1 auto;
+  gap:var(--space-2);
+  overflow:hidden;
+  max-inline-size:clamp(8rem,32vw,14rem);
+  min-inline-size:0;
+}
+#activities .activity-row-guests:empty,#demoActivities .activity-row-guests:empty{display:flex;min-height:0;}
 .dinner-item,
 .spa-item,
 .custom-item{
@@ -532,7 +547,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .tag-everyone .popover{position:absolute;transform:translate(-50%,0);bottom:calc(100% - 4px);left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;z-index:10;min-width:0;width:max-content;max-width:min(360px,90vw);justify-content:flex-start}
 .tag-everyone.open .popover,.tag-everyone[aria-expanded="true"] .popover,.tag-everyone:focus-within .popover{display:flex}
 @media(hover:hover){.tag-everyone:hover .popover{display:flex}}
-.tag-row{display:flex;gap:6px;flex-wrap:wrap}
+.guest-overflow-pill{gap:var(--space-2);padding-inline:var(--space-2);font-variant-numeric:tabular-nums;}
+.guest-overflow-pill .guest-overflow-label{display:inline-flex;align-items:center;line-height:1;font-weight:600;}
+.guest-overflow-pill .popover{justify-content:flex-start;}
 /* Dedicated right rail remains auto-sized so editing chips pin right without altering row height. */
 .activity-row-rail{display:flex;align-items:center;justify-self:end;gap:var(--space-2);flex-wrap:nowrap;min-width:0;}
 .stick-right{justify-content:flex-end}


### PR DESCRIPTION
Context: Move activities guest chips into the trailing rail while preserving row height and overflow behaviour.

Approach:
- Split the activities row into time/title, guest, and action columns and update the shared styling so the guest cluster sits beside the action chips without shifting height.
- Add a guest cluster layout helper that swaps overflowed chips for a +N popover while keeping removal controls accessible; reuse the same logic in the demo preview.
- Refresh the activities preview wiring to exercise the new layout and overflow handling in both light and dark modes.

Guardrails upheld: fixed row height, token spacing, chip logic (Both/Everyone), hairline dividers, preview/iPad layout, theming, and interaction affordances.

Screenshots:
![activities demo light](browser:/invocations/efvptfjv/artifacts/artifacts/activities-demo-light.png)

Notes: Manual QA via activities-demo.html (light/dark toggle and guest overflow).


------
https://chatgpt.com/codex/tasks/task_e_68e5da994bfc83309f2fb416de9a3ef8