### PR TITLE
Implement guest lane reveal in activities demo

### DIFF
--- a/activities-demo.js
+++ b/activities-demo.js
@@ -26,6 +26,12 @@
     const hidden = [];
     let overflowButton = null;
     const measurementPadding = 1;
+    const measureWidth = () => {
+      if(typeof options.availableWidth === 'number' && options.availableWidth > 0){
+        return options.availableWidth;
+      }
+      return container.clientWidth;
+    };
 
     const applyLayout = () => {
       container.innerHTML = '';
@@ -42,7 +48,7 @@
 
     applyLayout();
 
-    if(container.clientWidth <= 0){
+    if(measureWidth() <= 0){
       if(typeof requestAnimationFrame === 'function'){
         requestAnimationFrame(() => layoutGuestCluster(container, items, options));
       }
@@ -50,7 +56,9 @@
     }
 
     let guard = 0;
-    while(visible.length > 0 && container.scrollWidth > container.clientWidth + measurementPadding && guard < items.length){
+    while(visible.length > 0 && container.scrollWidth > measureWidth() + measurementPadding && guard < items.length){
+      // Peel chips from the far left until the measured width fits, then trade
+      // the leftovers for the +N overflow pill.
       hidden.unshift(visible.pop());
       guard += 1;
       applyLayout();
@@ -62,7 +70,7 @@
     }
 
     guard = 0;
-    while(visible.length > 0 && container.scrollWidth > container.clientWidth + measurementPadding && guard < items.length){
+    while(visible.length > 0 && container.scrollWidth > measureWidth() + measurementPadding && guard < items.length){
       hidden.unshift(visible.pop());
       guard += 1;
       applyLayout();
@@ -77,6 +85,8 @@
     button.className = 'tag-everyone guest-overflow-pill';
     button.dataset.pressExempt = 'true';
     button.dataset.overflowChip = 'true';
+    button.dataset.guestChip = 'true';
+    button.tabIndex = -1;
     button.setAttribute('aria-haspopup', 'true');
     button.setAttribute('aria-expanded', 'false');
     button.addEventListener('pointerdown', event => event.stopPropagation());
@@ -120,30 +130,304 @@
     }
   };
 
+  const buildGuestChip = (guest, log) => {
+    const chip = document.createElement('span');
+    chip.className = 'chip';
+    chip.dataset.guestChip = 'true';
+    chip.tabIndex = -1;
+    chip.style.borderColor = guest.color;
+    chip.style.color = guest.color;
+    const guestName = guest?.name || 'Guest';
+    chip.title = guestName;
+    chip.setAttribute('aria-label', guestName);
+
+    const initial = document.createElement('span');
+    initial.className = 'initial';
+    initial.textContent = guestName.charAt(0).toUpperCase();
+    chip.appendChild(initial);
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'x';
+    remove.textContent = '×';
+    remove.dataset.pressExempt = 'true';
+    remove.addEventListener('pointerdown', e => e.stopPropagation());
+    remove.addEventListener('click', e => {
+      e.stopPropagation();
+      log(`Simulated removal of ${guestName}`);
+    });
+    chip.appendChild(remove);
+
+    return chip;
+  };
+
+  const createGuestLane = (activity, log) => {
+    const lane = document.createElement('div');
+    lane.className = 'activity-row-guest-lane';
+
+    const slot = document.createElement('div');
+    slot.className = 'activity-row-guest-slot';
+    slot.dataset.expanded = 'false';
+    lane.appendChild(slot);
+
+    const guests = Array.isArray(activity.guests) ? activity.guests : [];
+    if(guests.length === 0){
+      if(activity.pill){
+        const pill = document.createElement('button');
+        pill.type = 'button';
+        pill.className = 'tag-everyone guest-reveal-pill';
+        pill.dataset.pressExempt = 'true';
+        pill.textContent = activity.pill.label;
+        pill.setAttribute('aria-expanded', 'false');
+        if(activity.pill.aria){
+          pill.setAttribute('aria-label', activity.pill.aria);
+        }
+        pill.addEventListener('pointerdown', event => event.stopPropagation());
+        pill.addEventListener('click', event => {
+          event.stopPropagation();
+          log(`Previewed group pill: ${activity.pill.label}`);
+        });
+        slot.appendChild(pill);
+      }
+      return { lane, open: () => {}, close: () => {} };
+    }
+
+    const chips = guests.map(guest => buildGuestChip(guest, log));
+    if(guests.length <= 1 || !activity.pill){
+      const cluster = document.createElement('div');
+      cluster.className = 'activity-row-guests';
+      cluster.dataset.hasGuests = 'true';
+      chips.forEach(chip => cluster.appendChild(chip));
+      slot.appendChild(cluster);
+      return { lane, open: () => {}, close: () => {} };
+    }
+
+    const cluster = document.createElement('div');
+    cluster.className = 'activity-row-guest-cluster';
+    slot.appendChild(cluster);
+
+    const collapsedLabel = activity.pill?.label || (guests.length === 2 ? 'Both' : 'Everyone');
+    const allNames = guests.map(guest => guest.name).filter(Boolean).join(', ');
+    const pillAria = activity.pill?.aria || (allNames ? `${collapsedLabel}: ${allNames}` : collapsedLabel);
+
+    const pill = document.createElement('button');
+    pill.type = 'button';
+    pill.className = 'tag-everyone guest-reveal-pill';
+    pill.dataset.pressExempt = 'true';
+    pill.textContent = collapsedLabel;
+    pill.setAttribute('aria-expanded', 'false');
+    pill.setAttribute('aria-label', pillAria);
+    if(allNames){
+      pill.title = allNames;
+    }
+    pill.addEventListener('pointerdown', event => event.stopPropagation());
+    slot.appendChild(pill);
+
+    let expanded = false;
+    let availableWidth = 0;
+    let focusIndex = 0;
+    const getFocusTargets = () => Array.from(cluster.querySelectorAll('[data-guest-chip="true"]'));
+
+    const focusByIndex = (index) => {
+      const targets = getFocusTargets();
+      if(targets.length === 0) return;
+      const nextIndex = Math.max(0, Math.min(index, targets.length - 1));
+      const target = targets[nextIndex];
+      if(target && typeof target.focus === 'function'){
+        target.focus({ preventScroll: true });
+        focusIndex = nextIndex;
+      }
+    };
+
+    const syncFocusIndex = () => {
+      const active = document.activeElement;
+      const targets = getFocusTargets();
+      const current = targets.indexOf(active);
+      if(current >= 0){
+        focusIndex = current;
+      }else{
+        focusIndex = Math.min(focusIndex, Math.max(0, targets.length - 1));
+      }
+    };
+
+    const renderCluster = () => {
+      if(!expanded) return;
+      const width = availableWidth > 0 ? availableWidth : lane.getBoundingClientRect().width;
+      if(width <= 0){
+        if(typeof requestAnimationFrame === 'function'){
+          requestAnimationFrame(renderCluster);
+        }
+        return;
+      }
+      cluster.style.width = `${width}px`;
+      slot.style.setProperty('--guest-lane-width', `${width}px`);
+      // Width is passed to the overflow controller so the row-reverse cluster can
+      // trim from the left while keeping the reveal anchored to the action rail.
+      layoutGuestCluster(cluster, chips, {
+        popoverLabel: 'Guests',
+        ariaLabelPrefix: 'More guests',
+        availableWidth: width
+      });
+      syncFocusIndex();
+    };
+
+    const updateAvailableWidth = (width) => {
+      const normalized = Math.max(0, Math.floor(width));
+      if(normalized === availableWidth) return;
+      availableWidth = normalized;
+      renderCluster();
+    };
+
+    if(typeof ResizeObserver === 'function'){
+      // Track the live width of the middle grid lane so overflow math knows how
+      // many chips can fit without nudging the right rail.
+      const observer = new ResizeObserver(entries => {
+        entries.forEach(entry => updateAvailableWidth(entry.contentRect.width));
+      });
+      observer.observe(lane);
+    }else{
+      window.addEventListener('resize', () => updateAvailableWidth(lane.getBoundingClientRect().width));
+    }
+
+    requestAnimationFrame(() => updateAvailableWidth(lane.getBoundingClientRect().width));
+
+    const open = ({ focusFirst = false, source = 'pointer' } = {}) => {
+      if(expanded) return;
+      expanded = true;
+      slot.dataset.expanded = 'true';
+      pill.setAttribute('aria-expanded', 'true');
+      renderCluster();
+      if(focusFirst){
+        focusIndex = 0;
+        requestAnimationFrame(() => focusByIndex(0));
+      }
+      if(source === 'action'){
+        log(`Previewed group pill: ${collapsedLabel}`);
+      }
+    };
+
+    const close = ({ restoreFocus = true } = {}) => {
+      if(!expanded) return;
+      expanded = false;
+      slot.dataset.expanded = 'false';
+      pill.setAttribute('aria-expanded', 'false');
+      cluster.style.width = '';
+      focusIndex = 0;
+      if(restoreFocus && typeof pill.focus === 'function'){
+        pill.focus({ preventScroll: true });
+      }
+    };
+
+    pill.addEventListener('mouseenter', () => open());
+    pill.addEventListener('focus', () => open({ focusFirst: true, source: 'focus' }));
+
+    pill.addEventListener('click', event => {
+      event.stopPropagation();
+      if(expanded){
+        close({ restoreFocus: false });
+      }else{
+        open({ focusFirst: true, source: 'action' });
+      }
+    });
+
+    pill.addEventListener('keydown', event => {
+      if(event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter'){
+        event.preventDefault();
+      }
+      if(event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'){
+        if(expanded){
+          close();
+        }else{
+          open({ focusFirst: true, source: 'action' });
+        }
+      }
+    });
+
+    lane.addEventListener('mouseleave', () => {
+      if(lane.matches(':focus-within')) return;
+      close({ restoreFocus: false });
+    });
+
+    lane.addEventListener('focusout', event => {
+      if(lane.contains(event.relatedTarget)) return;
+      close({ restoreFocus: false });
+    });
+
+    lane.addEventListener('keydown', event => {
+      if(event.key === 'Escape' && expanded){
+        event.preventDefault();
+        close();
+        return;
+      }
+      if(!expanded) return;
+      if(event.key === 'ArrowLeft' || event.key === 'ArrowRight'){
+        // Arrow keys drive a roving focus order across the revealed chips so the
+        // screen reader outline follows the right-to-left visual order without
+        // changing the tab stop stack.
+        const delta = event.key === 'ArrowRight' ? -1 : 1;
+        event.preventDefault();
+        focusByIndex(focusIndex + delta);
+      }
+    });
+
+    return { lane, open, close };
+  };
+
   const list = document.getElementById('demoActivities');
   const logEl = document.getElementById('demoLog');
   if(!list || !logEl) return;
 
   const sampleActivities = [
     {
-      start: '8:30am',
-      end: '9:25am',
-      title: 'Rise & Shine Flow Yoga',
+      start: '8:00am',
+      end: '8:45am',
+      title: 'Sunrise Trail Run',
+      guests: [
+        { name: 'Aria', color: '#6366f1' }
+      ]
+    },
+    {
+      start: '10:15am',
+      end: '11:00am',
+      title: 'Couples Sound Bath',
+      pill: { label: 'Both', aria: 'Both guests preview' },
       guests: [
         { name: 'Alex', color: '#6366f1' },
         { name: 'Bailey', color: '#ec4899' }
       ]
     },
     {
-      start: '10:15am',
-      end: '11:00am',
-      title: 'Botanical Immersion Walk',
-      pill: { label: 'Both', aria: 'Both guests preview' }
+      start: '12:30pm',
+      end: '1:30pm',
+      title: 'Chef’s Garden Luncheon',
+      pill: { label: 'Everyone', aria: 'All four guests preview' },
+      guests: [
+        { name: 'Casey', color: '#22c55e' },
+        { name: 'Drew', color: '#f97316' },
+        { name: 'Emery', color: '#6366f1' },
+        { name: 'Finley', color: '#ec4899' }
+      ]
     },
     {
-      start: '1:00pm',
-      end: '2:00pm',
-      title: 'Sound Bath Session',
+      start: '5:30pm',
+      end: '7:00pm',
+      title: 'Stargazing Terrace',
+      pill: { label: 'Everyone', aria: 'Full party preview' },
+      guests: [
+        { name: 'Grey', color: '#0ea5e9' },
+        { name: 'Harper', color: '#f97316' },
+        { name: 'Indie', color: '#22c55e' },
+        { name: 'Jules', color: '#a855f7' },
+        { name: 'Kai', color: '#6366f1' },
+        { name: 'Lennon', color: '#ec4899' },
+        { name: 'Milan', color: '#14b8a6' },
+        { name: 'Noa', color: '#ef4444' }
+      ]
+    },
+    {
+      start: '8:30pm',
+      end: '9:15pm',
+      title: 'Moonlight Meditation',
       disabled: true
     }
   ];
@@ -193,71 +477,13 @@
 
     body.appendChild(headline);
 
-    const guestCluster = document.createElement('div');
-    guestCluster.className = 'activity-row-guests';
+    const { lane: guestLane } = createGuestLane(activity, log);
 
     const actionCluster = document.createElement('div');
     actionCluster.className = 'activity-row-rail';
 
-    if(activity.pill){
-      const pill = document.createElement('button');
-      pill.type = 'button';
-      pill.className = 'tag-everyone';
-      pill.dataset.pressExempt = 'true';
-      pill.addEventListener('pointerdown', e => e.stopPropagation());
-      pill.textContent = activity.pill.label;
-      pill.setAttribute('aria-label', activity.pill.aria || activity.pill.label);
-      pill.addEventListener('click', e => {
-        e.stopPropagation();
-        log(`Previewed group pill: ${activity.pill.label}`);
-      });
-      guestCluster.appendChild(pill);
-      guestCluster.dataset.hasGuests = 'true';
-    }
-
-    if(Array.isArray(activity.guests) && activity.guests.length > 0){
-      const chips = activity.guests.map(guest => {
-        const chip = document.createElement('span');
-        chip.className = 'chip';
-        chip.style.borderColor = guest.color;
-        chip.style.color = guest.color;
-        chip.title = guest.name;
-
-        const initial = document.createElement('span');
-        initial.className = 'initial';
-        initial.textContent = guest.name.charAt(0).toUpperCase();
-        chip.appendChild(initial);
-
-        const remove = document.createElement('button');
-        remove.type = 'button';
-        remove.className = 'x';
-        remove.textContent = '×';
-        remove.dataset.pressExempt = 'true';
-        remove.addEventListener('pointerdown', e => e.stopPropagation());
-        remove.addEventListener('click', e => {
-          e.stopPropagation();
-          log(`Simulated removal of ${guest.name}`);
-        });
-        chip.appendChild(remove);
-
-        return chip;
-      });
-
-      const targetCluster = activity.pill ? (() => {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'activity-row-guests';
-        guestCluster.appendChild(wrapper);
-        return wrapper;
-      })() : guestCluster;
-
-      layoutGuestCluster(targetCluster, chips, {
-        popoverLabel: 'Guests',
-        ariaLabelPrefix: 'More guests'
-      });
-    }
-
     row.appendChild(body);
-    row.appendChild(guestCluster);
+    row.appendChild(guestLane);
     row.appendChild(actionCluster);
     list.appendChild(row);
 

--- a/style.css
+++ b/style.css
@@ -499,7 +499,25 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
  * min-height so chips never resize the lane. Padding + divider offsets lean on
  * the spacing scale to stay in sync with neighboring sections.
  */
-#activities .activity-row,#demoActivities .activity-row{position:relative;display:grid;grid-template-columns:minmax(0,1fr) auto auto;align-items:center;column-gap:var(--space-3);padding:var(--space-4);min-height:5rem;border-radius:14px;background:transparent;cursor:pointer;touch-action:pan-y;transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;}
+#activities .activity-row,#demoActivities .activity-row{
+  /*
+   * Three-track grid keeps the title/time stack fixed on the left, dedicates the
+   * middle track to the guest reveal lane, and pins the action chips to the
+   * right so the reveal never shifts the rail.
+   */
+  position:relative;
+  display:grid;
+  grid-template-columns:auto minmax(0,1fr) auto;
+  align-items:center;
+  column-gap:var(--space-3);
+  padding:var(--space-4);
+  min-height:5rem;
+  border-radius:14px;
+  background:transparent;
+  cursor:pointer;
+  touch-action:pan-y;
+  transition:background-color .18s ease,box-shadow .22s ease,transform .16s ease,opacity .16s ease;
+}
 #activities .activity-row::after,#demoActivities .activity-row::after{content:"";position:absolute;left:var(--space-4);right:var(--space-4);bottom:0;height:1px;background:var(--activity-divider);transform-origin:center;transform:scaleY(.5);}
 #activities .activity-row:last-of-type::after,#demoActivities .activity-row:last-of-type::after{content:none;}
 #activities .activity-row[data-disabled='true'],#demoActivities .activity-row[data-disabled='true']{cursor:default;opacity:.55;}
@@ -514,21 +532,66 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 #activities .activity-row-headline,#demoActivities .activity-row-headline{display:flex;flex-direction:column;align-items:flex-start;gap:var(--space-1);min-width:0;color:var(--text-primary);}
 #activities .activity-row-time,#demoActivities .activity-row-time{font-size:.8125rem;font-weight:500;letter-spacing:.02em;color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap;}
 #activities .activity-row-title,#demoActivities .activity-row-title{display:block;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--text-primary);min-width:0;}
-#activities .activity-row-guests,#demoActivities .activity-row-guests{
+#activities .activity-row-guest-lane,#demoActivities .activity-row-guest-lane{
   /*
-   * The guest lane hugs the action chips while leaving enough room for the left
-   * stack. Clamp the inline size so the overflow controller can reliably
-   * replace extra chips with a +N pill without ever growing the row height.
+   * The middle track stretches to absorb available width and anchors content to
+   * the right edge so expanded chips grow right → left without pushing the
+   * action rail.
    */
+  justify-self:stretch;
   display:flex;
   align-items:center;
-  justify-self:end;
-  flex:0 1 auto;
+  justify-content:flex-end;
+  min-width:0;
+  overflow:hidden;
+  max-inline-size:clamp(10rem,34vw,18rem);
+}
+#activities .activity-row-guest-slot,#demoActivities .activity-row-guest-slot{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:var(--space-2);
+  min-width:0;
+  inline-size:100%;
+}
+#activities .activity-row-guest-slot[data-expanded='true'],#demoActivities .activity-row-guest-slot[data-expanded='true']{
+  gap:0;
+}
+#activities .activity-row-guest-cluster,#demoActivities .activity-row-guest-cluster{
+  display:flex;
+  flex-direction:row-reverse;
+  align-items:center;
   gap:var(--space-2);
   overflow:hidden;
-  max-inline-size:clamp(8rem,32vw,14rem);
-  min-inline-size:0;
+  max-inline-size:100%;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .18s ease;
 }
+#activities .activity-row-guest-slot[data-expanded='true'] .activity-row-guest-cluster,#demoActivities .activity-row-guest-slot[data-expanded='true'] .activity-row-guest-cluster{
+  opacity:1;
+  pointer-events:auto;
+}
+#activities .activity-row-guest-slot[data-expanded='true'] .guest-reveal-pill,#demoActivities .activity-row-guest-slot[data-expanded='true'] .guest-reveal-pill{
+  opacity:0;
+  pointer-events:none;
+}
+#activities .activity-row-guest-slot .guest-reveal-pill,#demoActivities .activity-row-guest-slot .guest-reveal-pill{
+  transition:opacity .18s ease;
+}
+#activities .activity-row-guest-slot[data-expanded='false'] .activity-row-guest-cluster,#demoActivities .activity-row-guest-slot[data-expanded='false'] .activity-row-guest-cluster{
+  max-inline-size:0;
+}
+#activities .activity-row-guest-slot[data-expanded='true'] .activity-row-guest-cluster,#demoActivities .activity-row-guest-slot[data-expanded='true'] .activity-row-guest-cluster{
+  max-inline-size:var(--guest-lane-width, 100%);
+}
+#activities .activity-row-guest-slot:focus-within .guest-reveal-pill,#demoActivities .activity-row-guest-slot:focus-within .guest-reveal-pill{
+  outline:none;
+}
+#activities .activity-row-guest-slot:focus-within .activity-row-guest-cluster,#demoActivities .activity-row-guest-slot:focus-within .activity-row-guest-cluster{
+  outline:none;
+}
+#activities .activity-row-guests,#demoActivities .activity-row-guests{display:flex;align-items:center;gap:var(--space-2);}
 #activities .activity-row-guests:empty,#demoActivities .activity-row-guests:empty{display:flex;min-height:0;}
 .dinner-item,
 .spa-item,
@@ -543,6 +606,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .spa-item .spa-meta{margin-top:4px;font-size:13px;color:var(--muted);}
 .tag-everyone{position:relative;display:inline-flex;align-items:center;gap:6px;min-height:28px;padding:4px 12px;border-radius:999px;border:1px solid var(--chipBorder);background:#fff;font-weight:600;color:var(--chipText);cursor:pointer;appearance:none;font:inherit;line-height:1;transition:box-shadow .2s ease;}
+.guest-reveal-pill{white-space:nowrap;}
 .tag-everyone:focus{outline:2px solid var(--brand);outline-offset:2px;}
 .tag-everyone .popover{position:absolute;transform:translate(-50%,0);bottom:calc(100% - 4px);left:50%;display:none;gap:6px;padding:6px;border:1px solid var(--border);border-radius:10px;background:#fff;box-shadow:0 4px 14px rgba(0,0,0,.08);flex-wrap:wrap;z-index:10;min-width:0;width:max-content;max-width:min(360px,90vw);justify-content:flex-start}
 .tag-everyone.open .popover,.tag-everyone[aria-expanded="true"] .popover,.tag-everyone:focus-within .popover{display:flex}
@@ -550,6 +614,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .guest-overflow-pill{gap:var(--space-2);padding-inline:var(--space-2);font-variant-numeric:tabular-nums;}
 .guest-overflow-pill .guest-overflow-label{display:inline-flex;align-items:center;line-height:1;font-weight:600;}
 .guest-overflow-pill .popover{justify-content:flex-start;}
+.activity-row-guest-cluster .guest-overflow-pill{min-height:24px;padding-block:2px;}
+.activity-row-guest-cluster .guest-overflow-pill:focus{outline:2px solid var(--brand);outline-offset:2px;}
+.activity-row-guest-cluster .chip[tabindex]{outline:none;}
+.activity-row-guest-cluster .chip:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 /* Dedicated right rail remains auto-sized so editing chips pin right without altering row height. */
 .activity-row-rail{display:flex;align-items:center;justify-self:end;gap:var(--space-2);flex-wrap:nowrap;min-width:0;}
 .stick-right{justify-content:flex-end}


### PR DESCRIPTION
Context: Improve the activities guest lane reveal UX.

Approach:
- Converted the activities row into a three-track grid and wired a right-anchored guest lane that expands right-to-left without moving the action rail.
- Added a guest reveal controller that measures available width, swaps in +N overflow chips, and provides focus/ARIA handling for keyboard navigation and escape collapse.
- Updated the demo data to showcase 1/2/4/8 guest scenarios across light/dark themes and narrow/wide layouts.

Guardrails upheld:
- Row height and action rail positioning remain fixed.
- Tokens, focus rings, and existing press/hover interactions preserved.
- No public APIs or business logic altered.

Screenshots:
- activities-reveal.png

Notes:
- Hover/focus, keyboard arrows, Enter/Space, and Esc interactions mirror the spec, including +N overflow with popover.


------
https://chatgpt.com/codex/tasks/task_e_68e5e411a9348330b4c0158a1747aa60