### PR TITLE
Align guest chips with trailing action rail

### DIFF
--- a/activities-demo.js
+++ b/activities-demo.js
@@ -479,12 +479,24 @@
 
     const { lane: guestLane } = createGuestLane(activity, log);
 
+    const main = document.createElement('div');
+    main.className = 'activity-row-main';
+    main.appendChild(body);
+
+    const trailing = document.createElement('div');
+    trailing.className = 'activity-row-trailing';
+
+    // Group the guest lane and action chips so the right rail stays pinned while
+    // letting guest pills expand leftward without nudging the add chips.
+    trailing.appendChild(guestLane);
+
     const actionCluster = document.createElement('div');
     actionCluster.className = 'activity-row-rail';
+    // When there are no add chips this rail collapses so guest pills sit flush.
+    trailing.appendChild(actionCluster);
 
-    row.appendChild(body);
-    row.appendChild(guestLane);
-    row.appendChild(actionCluster);
+    row.appendChild(main);
+    row.appendChild(trailing);
     list.appendChild(row);
 
     const setPressed = (pressed) => {

--- a/script.js
+++ b/script.js
@@ -1040,13 +1040,31 @@
       const entry = day.find(e=> e.type==='activity' && e.title===row.title && e.start===row.start && e.end===row.end);
       const assignedIds = entry ? Array.from(entry.guestIds) : [];
 
-      // Split the trailing rail into guest + action clusters so chips sit to the
-      // right of the title stack without affecting row height.
+      // Build the trailing rail as [guest lane][actions] so pills align against
+      // the right edge while keeping add chips pinned to the far side.
+      const main=document.createElement('div');
+      main.className='activity-row-main';
+      main.appendChild(body);
+
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing';
+
+      const guestLane=document.createElement('div');
+      guestLane.className='activity-row-guest-lane';
+      const guestSlot=document.createElement('div');
+      guestSlot.className='activity-row-guest-slot';
+      guestLane.appendChild(guestSlot);
+
       const guestCluster=document.createElement('div');
       guestCluster.className='activity-row-guests';
+      guestSlot.appendChild(guestCluster);
 
       const actionRail=document.createElement('div');
       actionRail.className='activity-row-rail';
+      trailing.appendChild(guestLane);
+      // When there are no action chips this empty rail collapses, leaving the
+      // guest lane flush with the right edge.
+      trailing.appendChild(actionRail);
 
       const setPressedState = (pressed)=>{
         if(pressed){
@@ -1105,9 +1123,8 @@
         setPressedState(false);
       });
 
-      div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(actionRail);
+      div.appendChild(main);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
 
       if(state.guests.length>0){
@@ -1377,17 +1394,33 @@
       chip.dataset.pressExempt='true';
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openDinnerPicker({ mode:'edit', dateKey: dateK }));
+      const main=document.createElement('div');
+      main.className='activity-row-main';
+      main.appendChild(body);
+
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing';
+
+      const guestLane=document.createElement('div');
+      guestLane.className='activity-row-guest-lane';
+      const guestSlot=document.createElement('div');
+      guestSlot.className='activity-row-guest-slot';
+      guestLane.appendChild(guestSlot);
+
       const guestCluster=document.createElement('div');
       guestCluster.className='activity-row-guests';
+      guestSlot.appendChild(guestCluster);
 
       // Keep the dinner edit affordance in a dedicated rail so it pins to the right.
       const rail=document.createElement('div');
       rail.className='activity-row-rail';
       rail.appendChild(chip);
 
-      div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(rail);
+      trailing.appendChild(guestLane);
+      trailing.appendChild(rail);
+
+      div.appendChild(main);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
     }
 
@@ -1426,17 +1459,33 @@
       chip.dataset.pressExempt='true';
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openSpaEditor({ mode:'edit', dateKey: dateK, entryId: entry.id }));
+      const main=document.createElement('div');
+      main.className='activity-row-main';
+      main.appendChild(body);
+
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing';
+
+      const guestLane=document.createElement('div');
+      guestLane.className='activity-row-guest-lane';
+      const guestSlot=document.createElement('div');
+      guestSlot.className='activity-row-guest-slot';
+      guestLane.appendChild(guestSlot);
+
       const guestCluster=document.createElement('div');
       guestCluster.className='activity-row-guests';
+      guestSlot.appendChild(guestCluster);
 
       // Share the right rail treatment so every activity action aligns consistently.
       const rail=document.createElement('div');
       rail.className='activity-row-rail';
       rail.appendChild(chip);
 
-      div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(rail);
+      trailing.appendChild(guestLane);
+      trailing.appendChild(rail);
+
+      div.appendChild(main);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
 
       renderSpaGuestChips(guestCluster, entry, dateK);
@@ -1480,16 +1529,32 @@
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openCustomBuilder({ mode:'edit', dateKey: dateK, entryId: entry.id }));
 
+      const main=document.createElement('div');
+      main.className='activity-row-main';
+      main.appendChild(body);
+
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing';
+
+      const guestLane=document.createElement('div');
+      guestLane.className='activity-row-guest-lane';
+      const guestSlot=document.createElement('div');
+      guestSlot.className='activity-row-guest-slot';
+      guestLane.appendChild(guestSlot);
+
       const guestCluster=document.createElement('div');
       guestCluster.className='activity-row-guests';
+      guestSlot.appendChild(guestCluster);
 
       const rail=document.createElement('div');
       rail.className='activity-row-rail';
       rail.appendChild(chip);
 
-      div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(rail);
+      trailing.appendChild(guestLane);
+      trailing.appendChild(rail);
+
+      div.appendChild(main);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
 
       if(state.guests.length>0){

--- a/style.css
+++ b/style.css
@@ -501,15 +501,13 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
  */
 #activities .activity-row,#demoActivities .activity-row{
   /*
-   * Three-track grid keeps the title/time stack fixed on the left, dedicates the
-   * middle track to the guest reveal lane, and pins the action chips to the
-   * right so the reveal never shifts the rail.
+   * Flex layout mirrors the production column: main content grows on the left
+   * while the trailing cluster hugs the right edge without affecting row height.
    */
   position:relative;
-  display:grid;
-  grid-template-columns:auto minmax(0,1fr) auto;
+  display:flex;
   align-items:center;
-  column-gap:var(--space-3);
+  gap:var(--space-3);
   padding:var(--space-4);
   min-height:5rem;
   border-radius:14px;
@@ -526,38 +524,32 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 @media(prefers-reduced-motion:reduce){#activities .activity-row,#demoActivities .activity-row{transition:none;}#activities .activity-row[data-pressed='true'],#demoActivities .activity-row[data-pressed='true']{transform:none;}}
 @media(hover:hover){#activities .activity-row:not([data-disabled='true']):hover,#demoActivities .activity-row:not([data-disabled='true']):hover{background:var(--activity-hover);box-shadow:var(--activity-shadow-hover);}}
 #activities .activity-row:focus-visible,#demoActivities .activity-row:focus-visible{outline:none;box-shadow:0 0 0 2px var(--activity-focus-ring),0 0 0 6px var(--activity-focus-glow);background:var(--activity-hover);}
-#activities .activity-row-body,#demoActivities .activity-row-body{display:flex;flex-direction:column;justify-content:center;gap:var(--space-2);min-width:0;}
+#activities .activity-row-main,#demoActivities .activity-row-main{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;}
+#activities .activity-row-body,#demoActivities .activity-row-body{display:flex;flex-direction:column;justify-content:center;gap:var(--space-2);min-width:0;flex:1 1 auto;}
 /* Stack time above title with a tight rhythm so the details read as a two-line
  * block while honoring the fixed min-height guardrail. */
 #activities .activity-row-headline,#demoActivities .activity-row-headline{display:flex;flex-direction:column;align-items:flex-start;gap:var(--space-1);min-width:0;color:var(--text-primary);}
 #activities .activity-row-time,#demoActivities .activity-row-time{font-size:.8125rem;font-weight:500;letter-spacing:.02em;color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap;}
 #activities .activity-row-title,#demoActivities .activity-row-title{display:block;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--text-primary);min-width:0;}
+#activities .activity-row-trailing,#demoActivities .activity-row-trailing{margin-left:auto;display:flex;align-items:center;gap:var(--space-2);min-width:0;}
 #activities .activity-row-guest-lane,#demoActivities .activity-row-guest-lane{
   /*
-   * The middle track stretches to absorb available width and anchors content to
-   * the right edge so expanded chips grow right → left without pushing the
-   * action rail.
+   * Guest lane flexes to the left of the action rail so reveals expand toward
+   * the body while the actions stay pinned to the right edge.
    */
-  justify-self:stretch;
   display:flex;
   align-items:center;
   justify-content:flex-end;
+  flex:0 1 clamp(10rem,34vw,18rem);
   min-width:0;
   overflow:hidden;
-  max-inline-size:clamp(10rem,34vw,18rem);
 }
-#activities .activity-row-guest-slot,#demoActivities .activity-row-guest-slot{
-  display:flex;
-  align-items:center;
-  justify-content:flex-end;
-  gap:var(--space-2);
-  min-width:0;
-  inline-size:100%;
-}
+#activities .activity-row-guest-slot,#demoActivities .activity-row-guest-slot{display:flex;align-items:center;justify-content:flex-end;gap:var(--space-2);min-width:0;inline-size:100%;}
 #activities .activity-row-guest-slot[data-expanded='true'],#demoActivities .activity-row-guest-slot[data-expanded='true']{
   gap:0;
 }
 #activities .activity-row-guest-cluster,#demoActivities .activity-row-guest-cluster{
+  /* Row-reverse keeps the reveal anchored to the action rail so chips grow leftward. */
   display:flex;
   flex-direction:row-reverse;
   align-items:center;
@@ -619,7 +611,8 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .activity-row-guest-cluster .chip[tabindex]{outline:none;}
 .activity-row-guest-cluster .chip:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 /* Dedicated right rail remains auto-sized so editing chips pin right without altering row height. */
-.activity-row-rail{display:flex;align-items:center;justify-self:end;gap:var(--space-2);flex-wrap:nowrap;min-width:0;}
+.activity-row-rail{display:flex;align-items:center;gap:var(--space-2);flex-wrap:nowrap;min-width:0;}
+.activity-row-rail:empty{display:none;}
 .stick-right{justify-content:flex-end}
 .section{margin-top:16px}
 #calMonth{font-weight:700;font-size:16px}


### PR DESCRIPTION
## Summary
- switch the activities row layout to a flex-based main + trailing cluster so guest chips sit immediately left of actions
- update demo and production rendering to wrap guest lanes and action rails inside the shared trailing container
- refresh guest lane styling so Both/Everyone reveals grow leftward without displacing add chips and empty rails collapse

## Testing
- Manual QA in activities demo and main itinerary view

## Screenshots
- ![Activities column layout](browser:/invocations/zulagtit/artifacts/artifacts/activities-layout.png)


------
https://chatgpt.com/codex/tasks/task_e_68e5f23073b883309d8a99d843f15a32