### PR TITLE
Align activities row chips within trailing cluster

### DIFF
--- a/activities-demo.js
+++ b/activities-demo.js
@@ -478,13 +478,18 @@
     body.appendChild(headline);
 
     const { lane: guestLane } = createGuestLane(activity, log);
+    guestLane.classList.add('guest-chips');
 
     const actionCluster = document.createElement('div');
-    actionCluster.className = 'activity-row-rail';
+    actionCluster.className = 'activity-row-rail add-chips';
+
+    const trailing = document.createElement('div');
+    trailing.className = 'activity-row-trailing row-trailing';
+    trailing.appendChild(guestLane);
+    trailing.appendChild(actionCluster);
 
     row.appendChild(body);
-    row.appendChild(guestLane);
-    row.appendChild(actionCluster);
+    row.appendChild(trailing);
     list.appendChild(row);
 
     const setPressed = (pressed) => {

--- a/script.js
+++ b/script.js
@@ -1043,10 +1043,16 @@
       // Split the trailing rail into guest + action clusters so chips sit to the
       // right of the title stack without affecting row height.
       const guestCluster=document.createElement('div');
-      guestCluster.className='activity-row-guests';
+      guestCluster.className='activity-row-guests guest-chips';
 
       const actionRail=document.createElement('div');
-      actionRail.className='activity-row-rail';
+      actionRail.className='activity-row-rail add-chips';
+
+      // Wrapper keeps the trailing controls as a single right-aligned cluster.
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing row-trailing';
+      trailing.appendChild(guestCluster);
+      trailing.appendChild(actionRail);
 
       const setPressedState = (pressed)=>{
         if(pressed){
@@ -1106,8 +1112,7 @@
       });
 
       div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(actionRail);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
 
       if(state.guests.length>0){
@@ -1378,16 +1383,20 @@
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openDinnerPicker({ mode:'edit', dateKey: dateK }));
       const guestCluster=document.createElement('div');
-      guestCluster.className='activity-row-guests';
+      guestCluster.className='activity-row-guests guest-chips';
 
       // Keep the dinner edit affordance in a dedicated rail so it pins to the right.
       const rail=document.createElement('div');
-      rail.className='activity-row-rail';
+      rail.className='activity-row-rail add-chips';
       rail.appendChild(chip);
 
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing row-trailing';
+      trailing.appendChild(guestCluster);
+      trailing.appendChild(rail);
+
       div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(rail);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
     }
 
@@ -1427,16 +1436,20 @@
       chip.addEventListener('pointerdown', e=> e.stopPropagation());
       chip.addEventListener('click',()=> openSpaEditor({ mode:'edit', dateKey: dateK, entryId: entry.id }));
       const guestCluster=document.createElement('div');
-      guestCluster.className='activity-row-guests';
+      guestCluster.className='activity-row-guests guest-chips';
 
       // Share the right rail treatment so every activity action aligns consistently.
       const rail=document.createElement('div');
-      rail.className='activity-row-rail';
+      rail.className='activity-row-rail add-chips';
       rail.appendChild(chip);
 
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing row-trailing';
+      trailing.appendChild(guestCluster);
+      trailing.appendChild(rail);
+
       div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(rail);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
 
       renderSpaGuestChips(guestCluster, entry, dateK);
@@ -1481,15 +1494,19 @@
       chip.addEventListener('click',()=> openCustomBuilder({ mode:'edit', dateKey: dateK, entryId: entry.id }));
 
       const guestCluster=document.createElement('div');
-      guestCluster.className='activity-row-guests';
+      guestCluster.className='activity-row-guests guest-chips';
 
       const rail=document.createElement('div');
-      rail.className='activity-row-rail';
+      rail.className='activity-row-rail add-chips';
       rail.appendChild(chip);
 
+      const trailing=document.createElement('div');
+      trailing.className='activity-row-trailing row-trailing';
+      trailing.appendChild(guestCluster);
+      trailing.appendChild(rail);
+
       div.appendChild(body);
-      div.appendChild(guestCluster);
-      div.appendChild(rail);
+      div.appendChild(trailing);
       activitiesEl.appendChild(div);
 
       if(state.guests.length>0){

--- a/style.css
+++ b/style.css
@@ -501,15 +501,14 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
  */
 #activities .activity-row,#demoActivities .activity-row{
   /*
-   * Three-track grid keeps the title/time stack fixed on the left, dedicates the
-   * middle track to the guest reveal lane, and pins the action chips to the
-   * right so the reveal never shifts the rail.
+   * Flex lets the trailing rail behave as a single right-aligned cluster while
+   * keeping the title/time stack anchored on the left so the row height stays
+   * fixed.
    */
   position:relative;
-  display:grid;
-  grid-template-columns:auto minmax(0,1fr) auto;
+  display:flex;
   align-items:center;
-  column-gap:var(--space-3);
+  gap:var(--space-3);
   padding:var(--space-4);
   min-height:5rem;
   border-radius:14px;
@@ -526,25 +525,27 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 @media(prefers-reduced-motion:reduce){#activities .activity-row,#demoActivities .activity-row{transition:none;}#activities .activity-row[data-pressed='true'],#demoActivities .activity-row[data-pressed='true']{transform:none;}}
 @media(hover:hover){#activities .activity-row:not([data-disabled='true']):hover,#demoActivities .activity-row:not([data-disabled='true']):hover{background:var(--activity-hover);box-shadow:var(--activity-shadow-hover);}}
 #activities .activity-row:focus-visible,#demoActivities .activity-row:focus-visible{outline:none;box-shadow:0 0 0 2px var(--activity-focus-ring),0 0 0 6px var(--activity-focus-glow);background:var(--activity-hover);}
-#activities .activity-row-body,#demoActivities .activity-row-body{display:flex;flex-direction:column;justify-content:center;gap:var(--space-2);min-width:0;}
+#activities .activity-row-body,#demoActivities .activity-row-body{display:flex;flex-direction:column;justify-content:center;gap:var(--space-2);min-width:0;flex:1 1 auto;}
 /* Stack time above title with a tight rhythm so the details read as a two-line
  * block while honoring the fixed min-height guardrail. */
 #activities .activity-row-headline,#demoActivities .activity-row-headline{display:flex;flex-direction:column;align-items:flex-start;gap:var(--space-1);min-width:0;color:var(--text-primary);}
 #activities .activity-row-time,#demoActivities .activity-row-time{font-size:.8125rem;font-weight:500;letter-spacing:.02em;color:var(--text-muted);font-variant-numeric:tabular-nums;white-space:nowrap;}
 #activities .activity-row-title,#demoActivities .activity-row-title{display:block;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--text-primary);min-width:0;}
+#activities .activity-row-trailing,#demoActivities .activity-row-trailing{margin-left:auto;display:flex;align-items:center;gap:var(--space-2);flex:0 1 auto;min-width:0;}
+#activities .activity-row-trailing>.guest-chips,#demoActivities .activity-row-trailing>.guest-chips{order:1;flex:1 1 auto;min-width:0;display:flex;align-items:center;justify-content:flex-end;gap:var(--space-2);}
+#activities .activity-row-trailing>.add-chips,#demoActivities .activity-row-trailing>.add-chips{order:2;flex:0 0 auto;display:flex;align-items:center;gap:var(--space-2);}
 #activities .activity-row-guest-lane,#demoActivities .activity-row-guest-lane{
   /*
-   * The middle track stretches to absorb available width and anchors content to
-   * the right edge so expanded chips grow right → left without pushing the
-   * action rail.
+   * The guest lane stretches within the trailing cluster so expansion happens
+   * right → left without nudging the action rail.
    */
-  justify-self:stretch;
   display:flex;
   align-items:center;
   justify-content:flex-end;
   min-width:0;
   overflow:hidden;
   max-inline-size:clamp(10rem,34vw,18rem);
+  flex:1 1 auto;
 }
 #activities .activity-row-guest-slot,#demoActivities .activity-row-guest-slot{
   display:flex;
@@ -619,7 +620,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .activity-row-guest-cluster .chip[tabindex]{outline:none;}
 .activity-row-guest-cluster .chip:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 /* Dedicated right rail remains auto-sized so editing chips pin right without altering row height. */
-.activity-row-rail{display:flex;align-items:center;justify-self:end;gap:var(--space-2);flex-wrap:nowrap;min-width:0;}
+.activity-row-rail{display:flex;align-items:center;gap:var(--space-2);flex-wrap:nowrap;min-width:0;flex:0 0 auto;}
 .stick-right{justify-content:flex-end}
 .section{margin-top:16px}
 #calMonth{font-weight:700;font-size:16px}


### PR DESCRIPTION
Context: Align guest and add chips on activities rows.
Approach: Switched the row shell to flex, wrapped guest/add chips in a right-aligned trailing cluster, and applied ordering classes so add chips stay flush right while guests sit immediately left.
Guardrails upheld: Row height preserved, spacing tokens reused, no handler changes, interactions unchanged.
Screenshots: ![Activities demo showing trailing alignment](browser:/invocations/nlxokdtq/artifacts/artifacts/activities-demo.png)
Notes: None.

------
https://chatgpt.com/codex/tasks/task_e_68e5f5be47a483309e12cf75fade61a3