### PR TITLE
Implement in-place guest pill reveal for activities preview

### DIFF
--- a/style.css
+++ b/style.css
@@ -555,8 +555,18 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   min-width:0;
   inline-size:100%;
 }
+#activities .guest-reveal-slot,#demoActivities .guest-reveal-slot{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  min-width:0;
+  flex:0 0 auto;
+}
 #activities .activity-row-guest-slot[data-expanded='true'],#demoActivities .activity-row-guest-slot[data-expanded='true']{
   gap:0;
+}
+#activities .activity-row-guest-slot[data-expanded='true'] .guest-reveal-slot,#demoActivities .activity-row-guest-slot[data-expanded='true'] .guest-reveal-slot{
+  flex:1 1 auto;
 }
 #activities .activity-row-guest-cluster,#demoActivities .activity-row-guest-cluster{
   display:flex;


### PR DESCRIPTION
## Summary
- replace the Both/Everyone pill with a live chip cluster inside a dedicated guest reveal slot
- reuse the existing overflow layout helper so expanded rows keep their +N behavior and trailing rail alignment
- update styling so the reveal slot grows leftward without affecting the action chips or row height

## Testing
- Manual verification in activities-demo.html (light/dark, hover, focus, keyboard)

## Screenshots
- ![Activities pill reveal](browser:/invocations/afafngmp/artifacts/artifacts/activities-reveal.png)


------
https://chatgpt.com/codex/tasks/task_e_68e5f889f2588330ae966142050433eb