### PR TITLE
Standardize modal headers and controls

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,10 +121,36 @@
   // focus reveals the standard pencil affordance for editing.
   const customChipIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 22V16L12 14M12 14L13 8M12 14H10M13 8C14 9.16667 15.6 11 18 11M13 8L12.8212 7.82124C12.2565 7.25648 11.2902 7.54905 11.1336 8.33223L10 14M10 14L8 22M18 9.5V22M8 7H7.72076C7.29033 7 6.90819 7.27543 6.77208 7.68377L5.5 11.5L7 12L8 7ZM14.5 3.5C14.5 4.05228 14.0523 4.5 13.5 4.5C12.9477 4.5 12.5 4.05228 12.5 3.5C12.5 2.94772 12.9477 2.5 13.5 2.5C14.0523 2.5 14.5 2.94772 14.5 3.5Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
   const pencilSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4.5 16.75 3 21l4.25-1.5L19.5 7.25 16.75 4.5 4.5 16.75Zm12.5-12.5 2.75 2.75 1-1a1.88 1.88 0 0 0 0-2.62l-.88-.88a1.88 1.88 0 0 0-2.62 0l-1 1Z" fill="currentColor" stroke="currentColor"/></svg>';
-  const trashSvg = `<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><g fill="currentColor"><path d="M0.982,5.073 L2.007,15.339 C2.007,15.705 2.314,16 2.691,16 L10.271,16 C10.648,16 10.955,15.705 10.955,15.339 L11.98,5.073 L0.982,5.073 L0.982,5.073 Z M7.033,14.068 L5.961,14.068 L5.961,6.989 L7.033,6.989 L7.033,14.068 L7.033,14.068 Z M9.033,14.068 L7.961,14.068 L8.961,6.989 L10.033,6.989 L9.033,14.068 L9.033,14.068 Z M5.033,14.068 L3.961,14.068 L2.961,6.989 L4.033,6.989 L5.033,14.068 L5.033,14.068 Z"/><path d="M12.075,2.105 L8.937,2.105 L8.937,0.709 C8.937,0.317 8.481,0 8.081,0 L4.986,0 C4.586,0 4.031,0.225 4.031,0.615 L4.031,2.011 L0.886,2.105 C0.485,2.105 0.159,2.421 0.159,2.813 L0.159,3.968 L12.8,3.968 L12.8,2.813 C12.801,2.422 12.477,2.105 12.075,2.105 L12.075,2.105 Z M4.947,1.44 C4.947,1.128 5.298,0.875 5.73,0.875 L7.294,0.875 C7.726,0.875 8.076,1.129 8.076,1.44 L8.076,2.105 L4.946,2.105 L4.946,1.44 L4.947,1.44 Z"/></g></svg>`;
+  // Shared modal glyphs keep every destructive/save affordance visually in sync while
+  // letting the CSS drive color via `currentColor` so themes remain consistent.
+  const saveIconSvg = '<svg viewBox="-3 -3 24 24" aria-hidden="true" focusable="false"><path d="M2 0h11.22a2 2 0 0 1 1.345.52l2.78 2.527A2 2 0 0 1 18 4.527V16a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2zm0 2v14h14V4.527L13.22 2H2zm4 8h6a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2zm0 2v4h6v-4H6zm7-9a1 1 0 0 1 1 1v3a1 1 0 0 1-2 0V4a1 1 0 0 1 1-1zM5 3h5a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm1 3h3V5H6v1z" fill="currentColor"/></svg>';
+  const deleteIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 4a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2h4a1 1 0 1 1 0 2h-1.069l-.867 12.142A2 2 0 0 1 17.069 22H6.93a2 2 0 0 1-1.995-1.858L4.07 8H3a1 1 0 0 1 0-2h4V4zm2 2h6V4H9v2zM6.074 8l.857 12H17.07l.857-12H6.074zM10 10a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0v-6a1 1 0 0 1 1-1zm4 0a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0v-6a1 1 0 0 1 1-1z" fill="currentColor"/></svg>';
+  const addIconSvg = '<svg viewBox="0 0 256 256" aria-hidden="true" focusable="false"><circle cx="128" cy="128" r="112" fill="none" stroke="currentColor" stroke-width="16"/><path d="M 80,128 H 176" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round"/><path d="M 128,80 V 176" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round"/></svg>';
   // Toolbar clear button uses the MIT-licensed Ant Design delete glyph so destructive affordances stay readable at small sizes.
   const clearToolbarSvg = '<svg viewBox="0 0 1024 1024" aria-hidden="true" focusable="false"><path fill="currentColor" d="M899.1 869.6l-53-305.6H864c14.4 0 26-11.6 26-26V346c0-14.4-11.6-26-26-26H618V138c0-14.4-11.6-26-26-26H432c-14.4 0-26 11.6-26 26v182H160c-14.4 0-26 11.6-26 26v192c0 14.4 11.6 26 26 26h17.9l-53 305.6c-0.3 1.5-0.4 3-0.4 4.4 0 14.4 11.6 26 26 26h723c1.5 0 3-0.1 4.4-0.4 14.2-2.4 23.7-15.9 21.2-30zM204 390h272V182h72v208h272v104H204V390zm468 440V674c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v156H416V674c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v156H202.8l45.1-260H776l45.1 260H672z"/></svg>';
   const checkSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M6.6 11.2a.75.75 0 0 1-1.18.15L2.8 8.73a.75.75 0 0 1 1.06-1.06l2.02 2.03 4.46-4.46a.75.75 0 0 1 1.06 1.06Z"/></svg>';
+
+  // Reusable factory keeps icon-only buttons consistent across modals while retaining
+  // semantic labels + tooltips for assistive tech and pointer affordances.
+  const createIconButton = ({ icon, label, extraClass='' }) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = ['btn-icon', extraClass].filter(Boolean).join(' ');
+    button.setAttribute('aria-label', label);
+    button.title = label;
+    button.innerHTML = icon;
+    return button;
+  };
+
+  // Close buttons reuse the shared icon styling so the hit target stays ≥44px and
+  // the "×" glyph remains purely presentational under a uniform "Close" label.
+  const createModalCloseButton = onClick => {
+    const button = createIconButton({ icon: '<span aria-hidden="true">×</span>', label: 'Close', extraClass: 'modal-close' });
+    if(typeof onClick === 'function'){
+      button.addEventListener('click', onClick);
+    }
+    return button;
+  };
 
   const dinnerMinutes = [0,15,30,45];
   const dinnerHours = [5,6,7,8];
@@ -1844,27 +1870,27 @@
     dialog.setAttribute('role','dialog');
     dialog.setAttribute('aria-modal','true');
 
+    // Shared modal header keeps the typography + spacing identical across flows.
     const header=document.createElement('div');
-    header.className='dinner-header';
-    const title=document.createElement('div');
-    title.className='dinner-title';
-    title.textContent='Dinner time';
+    header.className='modal-header';
+    const title=document.createElement('h2');
+    title.className='modal-title';
+    title.textContent='Dinner';
     title.id='dinner-dialog-title';
+    const modeDescriptor=document.createElement('span');
+    modeDescriptor.className='sr-only';
+    modeDescriptor.textContent = (mode==='edit' || existing) ? ' – Editing dinner time' : ' – Add dinner time';
+    title.appendChild(modeDescriptor);
     dialog.setAttribute('aria-labelledby','dinner-dialog-title');
     header.appendChild(title);
 
-    const closeBtn=document.createElement('button');
-    closeBtn.type='button';
-    closeBtn.className='dinner-close';
-    closeBtn.setAttribute('aria-label','Cancel dinner selection');
-    closeBtn.textContent='×';
-    closeBtn.addEventListener('click',()=> closeDinnerPicker({returnFocus:true}));
+    const closeBtn=createModalCloseButton(()=> closeDinnerPicker({returnFocus:true}));
     header.appendChild(closeBtn);
 
     dialog.appendChild(header);
 
     const body=document.createElement('div');
-    body.className='dinner-body';
+    body.className='modal-body dinner-body';
 
     const timePicker = (typeof createTimePicker === 'function') ? createTimePicker({
       hourRange: [dinnerHours[0], dinnerHours[dinnerHours.length-1]],
@@ -1894,27 +1920,30 @@
 
     dialog.appendChild(body);
 
-    const actions=document.createElement('div');
-    actions.className='dinner-actions';
+    const footer=document.createElement('div');
+    footer.className='modal-footer';
+    const footerStart=document.createElement('div');
+    footerStart.className='modal-footer-start';
+    const footerEnd=document.createElement('div');
+    footerEnd.className='modal-footer-end';
+    // Shared footer layout keeps destructive controls on the left while primary
+    // actions stay grouped on the right for every modal.
 
-    const confirmBtn=document.createElement('button');
-    confirmBtn.type='button';
-    confirmBtn.className='dinner-confirm';
-    const confirmLabel = (mode==='edit' || existing) ? 'Update dinner time' : 'Add dinner time';
-    confirmBtn.innerHTML=`<span aria-hidden="true">+</span><span class="sr-only">${confirmLabel}</span>`;
-    confirmBtn.setAttribute('aria-label', confirmLabel);
-    actions.appendChild(confirmBtn);
+    const confirmIsEdit = mode==='edit' && !!existing;
+    const confirmLabel = confirmIsEdit ? 'Save dinner time' : 'Add dinner time';
+    const confirmIcon = confirmIsEdit ? saveIconSvg : addIconSvg;
+    const confirmBtn = createIconButton({ icon: confirmIcon, label: confirmLabel, extraClass: 'btn-icon--primary' });
+    footerEnd.appendChild(confirmBtn);
 
     let removeBtn=null;
-    if(mode==='edit' && existing){
-      removeBtn=document.createElement('button');
-      removeBtn.type='button';
-      removeBtn.className='dinner-remove';
-      removeBtn.innerHTML=`${trashSvg}<span class="sr-only">Remove dinner</span>`;
-      actions.appendChild(removeBtn);
+    if(confirmIsEdit){
+      removeBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete dinner', extraClass: 'btn-icon--subtle' });
+      footerStart.appendChild(removeBtn);
     }
 
-    dialog.appendChild(actions);
+    footer.appendChild(footerStart);
+    footer.appendChild(footerEnd);
+    dialog.appendChild(footer);
 
     const previousFocus = document.activeElement;
 
@@ -2215,24 +2244,27 @@
     overlay.className='spa-overlay';
     const dialog = document.createElement('div');
     dialog.className='spa-dialog';
+    dialog.setAttribute('role','dialog');
+    dialog.setAttribute('aria-modal','true');
 
     const header = document.createElement('div');
-    header.className='spa-header';
+    header.className='modal-header';
     const title=document.createElement('h2');
-    title.className='spa-title';
-    title.textContent='SPA Appointment';
-    const closeBtn=document.createElement('button');
-    closeBtn.type='button';
-    closeBtn.className='spa-close';
-    closeBtn.setAttribute('aria-label','Close');
-    closeBtn.textContent='×';
-    closeBtn.addEventListener('click',()=> closeSpaEditor({returnFocus:true}));
+    title.className='modal-title';
+    title.id='spa-dialog-title';
+    title.textContent='Spa';
+    const spaModeDescriptor=document.createElement('span');
+    spaModeDescriptor.className='sr-only';
+    spaModeDescriptor.textContent = existing ? ' – Editing spa appointment' : ' – Add spa appointment';
+    title.appendChild(spaModeDescriptor);
+    dialog.setAttribute('aria-labelledby','spa-dialog-title');
+    const closeBtn=createModalCloseButton(()=> closeSpaEditor({returnFocus:true}));
     header.appendChild(title);
     header.appendChild(closeBtn);
     dialog.appendChild(header);
 
     const body = document.createElement('div');
-    body.className='spa-body';
+    body.className='modal-body spa-body';
     dialog.appendChild(body);
 
     // Compose the SPA flow left-to-right so each decision feeds the next stage:
@@ -2948,32 +2980,27 @@
     primaryColumn.appendChild(locationGroup);
     detailsGrid.appendChild(guestSection);
 
-    const actions=document.createElement('div');
-    actions.className='spa-actions';
-    const confirmBtn=document.createElement('button');
-    confirmBtn.type='button';
-    confirmBtn.className='spa-confirm';
-    const confirmLabel = (mode==='edit' || existing) ? 'Update spa appointment' : 'Add spa appointment';
-    // Match the dinner flow: the visible copy is the plus glyph while screen
-    // readers receive a descriptive label so both dialogs share the same
-    // primary-action affordance.
-    confirmBtn.innerHTML = `<span aria-hidden="true">+</span><span class="sr-only">${confirmLabel}</span>`;
-    confirmBtn.setAttribute('aria-label', confirmLabel);
-    actions.appendChild(confirmBtn);
+    const footer=document.createElement('div');
+    footer.className='modal-footer';
+    const footerStart=document.createElement('div');
+    footerStart.className='modal-footer-start';
+    const footerEnd=document.createElement('div');
+    footerEnd.className='modal-footer-end';
+    const confirmIsEdit = mode==='edit' && !!existing;
+    const confirmLabel = confirmIsEdit ? 'Save spa appointment' : 'Add spa appointment';
+    const confirmIcon = confirmIsEdit ? saveIconSvg : addIconSvg;
+    const confirmBtn = createIconButton({ icon: confirmIcon, label: confirmLabel, extraClass: 'btn-icon--primary' });
+    footerEnd.appendChild(confirmBtn);
     let removeBtn=null;
-    if(mode==='edit' && existing){
+    if(confirmIsEdit){
       // Editing exposes a destructive control that clears the entire merged
       // appointment; inline chips remain responsible for single-guest removals.
-      removeBtn=document.createElement('button');
-      removeBtn.type='button';
-      removeBtn.className='spa-remove';
-      removeBtn.innerHTML=`${trashSvg}<span class="sr-only">Remove spa appointment</span>`;
-      actions.appendChild(removeBtn);
+      removeBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete spa appointment', extraClass: 'btn-icon--subtle' });
+      footerStart.appendChild(removeBtn);
     }
-    // Floating action cluster: the container anchors the + pill to the modal's
-    // bottom-right corner while keeping the optional delete button alongside it,
-    // and the shared aria-label keeps the accessible add/update copy intact.
-    body.appendChild(actions);
+    footer.appendChild(footerStart);
+    footer.appendChild(footerEnd);
+    dialog.appendChild(footer);
 
     const previousFocus=document.activeElement;
 
@@ -3761,19 +3788,18 @@
     dialog.setAttribute('aria-labelledby','custom-dialog-title');
 
     const header=document.createElement('div');
-    header.className='custom-header';
+    header.className='modal-header';
     const title=document.createElement('h2');
-    title.className='custom-heading';
+    title.className='modal-title';
     title.id='custom-dialog-title';
-    title.textContent = existing ? 'Edit custom activity' : 'New custom activity';
+    title.textContent='Custom';
+    const customModeDescriptor=document.createElement('span');
+    customModeDescriptor.className='sr-only';
+    customModeDescriptor.textContent = existing ? ' – Editing custom activity' : ' – Add custom activity';
+    title.appendChild(customModeDescriptor);
     header.appendChild(title);
 
-    const closeBtn=document.createElement('button');
-    closeBtn.type='button';
-    closeBtn.className='custom-close';
-    closeBtn.setAttribute('aria-label','Cancel custom activity');
-    closeBtn.textContent='×';
-    closeBtn.addEventListener('click',()=> closeCustomBuilder({returnFocus:true}));
+    const closeBtn=createModalCloseButton(()=> closeCustomBuilder({returnFocus:true}));
     header.appendChild(closeBtn);
 
     dialog.appendChild(header);
@@ -3781,7 +3807,7 @@
     const body=document.createElement('div');
     // Keep scrolling inside the content wrapper so the header/footer stay
     // pinned while the dialog respects the viewport-safe max height.
-    body.className='custom-body';
+    body.className='modal-body custom-body';
     dialog.appendChild(body);
 
     const titleSection=document.createElement('section');
@@ -3965,22 +3991,25 @@
     guestSection.appendChild(guestSummary);
     body.appendChild(guestSection);
 
-    const actions=document.createElement('div');
-    actions.className='custom-actions';
-    const saveBtn=document.createElement('button');
-    saveBtn.type='button';
-    saveBtn.className='custom-save';
-    saveBtn.textContent='Save';
-    actions.appendChild(saveBtn);
+    const footer=document.createElement('div');
+    footer.className='modal-footer';
+    const footerStart=document.createElement('div');
+    footerStart.className='modal-footer-start';
+    const footerEnd=document.createElement('div');
+    footerEnd.className='modal-footer-end';
+    const saveIsEdit = !!existing;
+    const saveLabel = saveIsEdit ? 'Save custom activity' : 'Add custom activity';
+    const saveIcon = saveIsEdit ? saveIconSvg : addIconSvg;
+    const saveBtn=createIconButton({ icon: saveIcon, label: saveLabel, extraClass: 'btn-icon--primary' });
+    footerEnd.appendChild(saveBtn);
     let deleteBtn=null;
-    if(existing){
-      deleteBtn=document.createElement('button');
-      deleteBtn.type='button';
-      deleteBtn.className='custom-delete';
-      deleteBtn.textContent='Delete';
-      actions.appendChild(deleteBtn);
+    if(saveIsEdit){
+      deleteBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete custom activity', extraClass: 'btn-icon--subtle' });
+      footerStart.appendChild(deleteBtn);
     }
-    dialog.appendChild(actions);
+    footer.appendChild(footerStart);
+    footer.appendChild(footerEnd);
+    dialog.appendChild(footer);
 
     overlay.appendChild(dialog);
     document.body.appendChild(overlay);

--- a/style.css
+++ b/style.css
@@ -20,6 +20,9 @@
   --chip:#eef2ff;
   --chipBorder:#c7d2fe;
   --chipText:#1e1b4b;
+  --fg:var(--text-primary);
+  --hairline:var(--border-hairline);
+  --surface-tint:color-mix(in srgb,var(--surface) 92%,var(--brand) 8%);
   --activity-divider:var(--border-hairline);
   --activity-hover:rgba(42,107,255,0.06);
   --activity-pressed:rgba(42,107,255,0.12);
@@ -914,12 +917,88 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .chip--custom:focus-visible .icon-pencil{opacity:1;}
 .dinner-icon{display:block;}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+
+/*
+ * Shared modal scaffolding keeps the three editors visually aligned: icon-only
+ * buttons inherit color from CSS custom properties while headers/footers reuse
+ * the same spacing and hairline dividers.
+ */
+.btn-icon{
+  --btn-size:44px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:var(--btn-size);
+  min-width:var(--btn-size);
+  height:var(--btn-size);
+  min-height:var(--btn-size);
+  border-radius:999px;
+  border:1px solid var(--hairline);
+  background:var(--surface-tint);
+  color:var(--fg);
+  padding:0;
+  cursor:pointer;
+  line-height:0;
+  transition:background-color .18s ease,color .18s ease,box-shadow .18s ease,border-color .18s ease,transform .18s ease;
+}
+.btn-icon svg{width:22px;height:22px;display:block;}
+.btn-icon span[aria-hidden="true"]{display:block;font-size:22px;line-height:1;}
+.btn-icon:focus-visible{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 0 0 2px color-mix(in srgb,var(--brand) 20%,transparent);}
+@media(hover:hover){
+  .btn-icon:not([disabled]):hover{
+    background:color-mix(in srgb,var(--brand) 18%,var(--surface));
+    border-color:color-mix(in srgb,var(--brand) 32%,var(--hairline));
+    color:var(--brand);
+  }
+}
+.btn-icon:not([disabled]):active{background:color-mix(in srgb,var(--brand) 24%,var(--surface));transform:translateY(1px);}
+.btn-icon[disabled]{opacity:.45;cursor:not-allowed;box-shadow:none;}
+.btn-icon--primary{color:var(--brand);}
+.btn-icon--subtle{color:var(--muted);}
+@media(hover:hover){
+  .btn-icon--subtle:not([disabled]):hover{color:var(--brand);}
+}
+.modal-close{color:var(--muted);}
+.modal-close span[aria-hidden="true"]{font-size:24px;}
+@media (prefers-reduced-motion:reduce){
+  .btn-icon{transition:none;}
+}
+
+.modal-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:var(--space-3);
+  padding:var(--space-4) var(--space-5);
+  background:var(--surface);
+  border-bottom:1px solid var(--hairline);
+  flex-shrink:0;
+}
+.modal-title{margin:0;font-size:20px;font-weight:600;letter-spacing:.01em;}
+.modal-body{
+  flex:1 1 auto;
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-4);
+  padding:clamp(var(--space-5),4vw,var(--space-6));
+  background:var(--surface);
+  min-height:0;
+}
+.modal-footer{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:var(--space-4);
+  padding:var(--space-4) var(--space-5);
+  background:var(--surface);
+  border-top:1px solid var(--hairline);
+  flex-shrink:0;
+}
+.modal-footer-start,.modal-footer-end{display:flex;align-items:center;gap:var(--space-3);}
+.modal-footer-end{justify-content:flex-end;}
 .dinner-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:24px;z-index:2000;}
-.dinner-dialog{background:#fff;border-radius:20px;padding:20px;min-width:280px;max-width:320px;width:100%;box-shadow:0 22px 44px rgba(12,18,32,.18);border:1px solid rgba(226,232,240,.8);display:flex;flex-direction:column;gap:16px;}
-.dinner-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
-.dinner-title{font-size:17px;font-weight:600;letter-spacing:.01em;}
-.dinner-close{width:32px;height:32px;border-radius:50%;border:1px solid var(--border);background:#f1f5f9;font-size:20px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);}
-.dinner-body{display:flex;justify-content:center;}
+.dinner-dialog{background:#fff;border-radius:20px;min-width:280px;max-width:320px;width:100%;box-shadow:0 22px 44px rgba(12,18,32,.18);border:1px solid rgba(226,232,240,.8);display:flex;flex-direction:column;overflow:hidden;}
+.dinner-body{display:flex;justify-content:center;align-items:center;padding:var(--space-5);}
 .time-picker{display:flex;flex-direction:column;align-items:center;gap:16px;}
 .time-picker-wheels{display:flex;align-items:center;gap:12px;}
 .time-picker-column{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}
@@ -946,12 +1025,6 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .wheel-viewport::before,.wheel-viewport::after{content:"";position:absolute;left:0;right:0;height:44px;pointer-events:none;z-index:2;}
 .wheel-viewport::before{top:0;background:linear-gradient(180deg,rgba(255,255,255,.85),rgba(255,255,255,0));}
 .wheel-viewport::after{bottom:0;background:linear-gradient(0deg,rgba(255,255,255,.85),rgba(255,255,255,0));}
-.dinner-actions{display:flex;justify-content:flex-end;gap:10px;}
-.dinner-confirm{width:44px;height:44px;border-radius:50%;border:none;background:var(--brand);color:#fff;font-size:28px;display:flex;align-items:center;justify-content:center;box-shadow:0 12px 24px rgba(42,107,255,.24);cursor:pointer;}
-.dinner-confirm:focus{outline:2px solid #fff;outline-offset:3px;}
-.dinner-remove{width:44px;height:44px;border-radius:50%;border:1px solid var(--border);background:#fff;color:var(--muted);display:flex;align-items:center;justify-content:center;padding:0;}
-.dinner-remove svg{width:18px;height:18px;}
-.dinner-remove:focus{outline:2px solid var(--brand);outline-offset:2px;}
 .dinner-lock{overflow:hidden;}
 .spa-icon{display:block;}
 /*
@@ -994,14 +1067,12 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-dialog{
   background:#fff;
   border-radius:24px;
-  padding:24px;
   max-width:1160px;
   width:100%;
   box-shadow:0 26px 54px rgba(12,18,32,.2);
   border:1px solid rgba(226,232,240,.85);
   display:flex;
   flex-direction:column;
-  gap:24px;
   overflow:hidden;
   height:min(clamp(560px, 88vh, 920px), calc(100vh - 2*var(--spa-viewport-gutter)));
   block-size:min(clamp(560px, 88vh, 920px), calc(100vh - 2*var(--spa-viewport-gutter)));
@@ -1036,15 +1107,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   flex:1 1 auto;
   overflow:hidden;
   min-height:0;
-  padding-block-end:calc(88px + env(safe-area-inset-bottom));
+  --spa-body-padding:clamp(var(--space-5),4vw,var(--space-6));
+  padding:var(--spa-body-padding);
+  padding-block-end:calc(var(--spa-body-padding) + env(safe-area-inset-bottom));
 }
-.spa-header,
-.spa-actions{
-  flex-shrink:0;
-}
-.spa-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
-.spa-title{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
-.spa-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:#f1f5f9;font-size:22px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;}
 /*
  * The layout grid flexes to fill the fixed dialog height so the service column
  * can own all vertical overflow without forcing the shell to resize.
@@ -1124,10 +1190,6 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   .spa-cascade-panel{transition:none;}
   .spa-cascade-chevron{transition:none;}
 }
-@media(prefers-reduced-motion:reduce){
-  .spa-confirm,
-  .spa-remove{transition:none;}
-}
 .spa-block{display:flex;flex-direction:column;gap:12px;padding:18px;border-radius:18px;background:var(--panel);border:1px solid var(--border-hairline);}
 .spa-details-grid{
   /*
@@ -1155,9 +1217,9 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   grid-row:1;
   grid-template-rows:3fr 1fr;
 }
-.spa-detail-card{display:flex;flex-direction:column;gap:12px;min-height:0;height:100%;}
-.spa-detail-card-guests{grid-column:1/-1;grid-row:2;}
-.spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
+  .spa-detail-card{display:flex;flex-direction:column;gap:12px;min-height:0;height:100%;}
+  .spa-detail-card-guests{grid-column:1/-1;grid-row:2;}
+  .spa-radio-list{display:flex;flex-wrap:wrap;gap:10px;}
 /*
  * The duration row always reserves space for the three-option case so the
  * modal frame never needs to grow when Castle Hot Springs exposes its third
@@ -1193,55 +1255,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-end-time-value{font-size:14px;color:var(--muted);font-weight:500;}
 .spa-time-hint{margin-top:-6px;font-size:12px;text-align:center;color:var(--brand);}
 .spa-helper-text{margin:0;font-size:13px;color:var(--muted);}
-.spa-actions{
-  position:absolute;
-  inset-inline-end:calc(24px + env(safe-area-inset-right));
-  inset-block-end:calc(24px + env(safe-area-inset-bottom));
-  display:flex;
-  gap:12px;
-  align-items:flex-end;
-  pointer-events:none;
-  z-index:2;
-}
-.spa-actions > *{pointer-events:auto;}
-.spa-confirm{
-  width:60px;
-  height:60px;
-  min-width:60px;
-  min-height:60px;
-  border-radius:999px;
-  border:none;
-  background:var(--brand);
-  color:#fff;
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  font-weight:600;
-  font-size:28px;
-  line-height:1;
-  cursor:pointer;
-  box-shadow:0 20px 38px rgba(42,107,255,.28);
-  transition:box-shadow .2s ease,transform .2s ease;
-}
-.spa-confirm span[aria-hidden="true"]{display:block;line-height:1;font-size:28px;}
-.spa-confirm:focus{outline:2px solid #fff;outline-offset:3px;}
-.spa-confirm:hover{box-shadow:0 24px 46px rgba(42,107,255,.3);}
-.spa-confirm:active{transform:translateY(1px);}
-.spa-confirm:disabled{opacity:.5;cursor:not-allowed;box-shadow:none;}
-.spa-remove{width:44px;height:44px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);display:flex;align-items:center;justify-content:center;padding:0;box-shadow:0 10px 20px rgba(15,23,42,.12);transition:box-shadow .2s ease,transform .2s ease;}
-.spa-remove svg{width:18px;height:18px;}
-.spa-remove:focus{outline:2px solid var(--brand);outline-offset:2px;}
-.spa-remove:hover{box-shadow:0 12px 24px rgba(15,23,42,.16);}
-.spa-remove:active{transform:translateY(1px);}
 body.spa-lock{overflow:hidden;}
 body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:clamp(24px,7dvh,72px) clamp(16px,5vw,64px);z-index:2200;overflow:auto;box-sizing:border-box;}
 .custom-dialog{width:min(680px,100%);max-width:720px;max-height:calc(100dvh - 2 * clamp(24px,7dvh,72px));background:var(--surface,#fff);border-radius:26px;border:1px solid var(--border);box-shadow:0 28px 56px rgba(12,18,32,.22);display:flex;flex-direction:column;overflow:hidden;}
-.custom-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:32px clamp(24px,4vw,40px) 24px;border-bottom:1px solid var(--border-hairline);flex-shrink:0;background:var(--surface,#fff);}
-.custom-heading{margin:0;font-size:22px;font-weight:600;letter-spacing:.01em;}
-.custom-close{width:36px;height:36px;border-radius:50%;border:1px solid var(--border);background:var(--surface,#f1f5f9);font-size:20px;line-height:1;display:flex;align-items:center;justify-content:center;padding:0;color:var(--muted);cursor:pointer;transition:transform .18s ease,box-shadow .18s ease;}
-.custom-close:hover{box-shadow:0 12px 24px rgba(15,23,42,.18);}
-.custom-close:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 .custom-body{display:flex;flex-direction:column;gap:24px;padding:24px clamp(24px,4vw,40px) 32px;overflow:auto;flex:1 1 auto;scrollbar-gutter:stable;}
 .custom-section{display:flex;flex-direction:column;gap:12px;}
 .custom-title-toggle-group{display:flex;flex-wrap:wrap;gap:8px;}
@@ -1298,16 +1315,6 @@ body[data-theme='dark'] .custom-existing-list::-webkit-scrollbar-thumb{backgroun
 .custom-guest-summary{margin:0;font-size:14px;color:var(--muted);}
 .custom-guest-summary[data-empty='false']{color:var(--ink);}
 .custom-guest-summary[data-empty='true']{color:var(--brand);font-weight:600;}
-.custom-actions{display:flex;justify-content:flex-end;gap:12px;padding:24px clamp(24px,4vw,40px) 32px;border-top:1px solid var(--border-hairline);flex-shrink:0;background:var(--surface,#fff);}
-.custom-save{border-radius:999px;border:none;background:var(--brand);color:#fff;padding:10px 24px;font:inherit;font-size:15px;font-weight:600;box-shadow:0 18px 36px rgba(42,107,255,.28);cursor:pointer;transition:box-shadow .2s ease,transform .2s ease,opacity .18s ease;}
-.custom-save:hover{box-shadow:0 26px 54px rgba(42,107,255,.32);}
-.custom-save:focus-visible{outline:2px solid #fff;outline-offset:3px;}
-.custom-save:active{transform:translateY(1px);}
-.custom-save:disabled{opacity:.55;cursor:not-allowed;box-shadow:none;}
-.custom-delete{border-radius:999px;border:1px solid var(--border);background:var(--surface,#fff);color:var(--muted);padding:10px 18px;font:inherit;font-size:15px;font-weight:500;box-shadow:0 10px 22px rgba(15,23,42,.14);cursor:pointer;transition:box-shadow .18s ease,color .18s ease,transform .18s ease;}
-.custom-delete:hover{box-shadow:0 14px 26px rgba(15,23,42,.16);color:var(--ink);}
-.custom-delete:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.custom-delete:active{transform:translateY(1px);}
 body.custom-lock{overflow:hidden;}
 @media (max-width:1100px){
   .spa-dialog{max-width:980px;}
@@ -1327,15 +1334,14 @@ body.custom-lock{overflow:hidden;}
     gap:16px;
   }
   .spa-detail-card-guests{grid-column:1;grid-row:auto;}
-  .spa-body{padding-block-end:calc(96px + env(safe-area-inset-bottom));}
+  .spa-body{--spa-body-padding:clamp(var(--space-5),6vw,var(--space-6));padding-block-end:calc(var(--spa-body-padding) + env(safe-area-inset-bottom));}
 }
 @media (max-width:720px){
-  .spa-dialog{padding:18px;gap:18px;}
+  .spa-body{--spa-body-padding:clamp(var(--space-4),6vw,var(--space-5));}
   .spa-service-button{padding:10px 16px 10px 44px;}
   .spa-block{padding:16px;}
-  .spa-actions{inset-inline-end:calc(16px + env(safe-area-inset-right));inset-block-end:calc(20px + env(safe-area-inset-bottom));}
-  .spa-confirm{width:56px;height:56px;min-width:56px;min-height:56px;font-size:26px;}
-  .spa-confirm span[aria-hidden="true"]{font-size:26px;}
+  .spa-dialog .modal-header,
+  .spa-dialog .modal-footer{padding-inline:clamp(var(--space-4),6vw,var(--space-5));}
 }
 .demo-page{background:var(--bg);padding:24px;}
 .demo-container{max-width:960px;margin:0 auto;display:flex;flex-direction:column;gap:24px;}


### PR DESCRIPTION
## Context
- Standardize the Dinner, Spa, and Custom modals.

## Approach
- Introduced shared icon glyphs plus reusable icon/close button helpers so modal actions inherit theme color via `currentColor`.
- Reworked Dinner, Spa, and Custom modals to use the shared modal header/footer, consistent titles, and icon-only Add/Save/Delete controls with aligned placement.
- Added `.btn-icon`/`.modal-*` styles and updated dinner & spa spacing to accommodate the common footer layout.

## Guardrails upheld
- Activities layout, picker physics, and analytics untouched.
- Token-based styling and accessible labels/focus rings maintained.
- Verified on desktop preview.

## Testing
- ✅ `Manual` – Opened Dinner, Spa, and Custom modals in local browser preview.

## Screenshots
![Unified spa modal](browser:/invocations/jiaefpoy/artifacts/artifacts/unified-modals.png)


------
https://chatgpt.com/codex/tasks/task_e_68e6046252288330aae8ff2b792a2d66