### PR TITLE
Standardize time displays to lowercase am/pm

### DIFF
--- a/activities-demo.html
+++ b/activities-demo.html
@@ -36,6 +36,7 @@
   </div>
 
   <script src="activities-interactions.js"></script>
+  <script src="utils/format.js"></script>
   <script src="activities-demo.js"></script>
 </body>
 </html>

--- a/activities-demo.js
+++ b/activities-demo.js
@@ -11,6 +11,10 @@
     ? window.AssignmentChipLogic.attachGroupPillInteractions
     : () => ({ open: () => {}, close: () => {} });
 
+  const formatTimeDisplay = (window.CHSFormatUtils && window.CHSFormatUtils.formatTimeDisplay)
+    ? window.CHSFormatUtils.formatTimeDisplay
+    : value => (value==null ? '' : String(value));
+
   // Mirror the production overflow controller so the preview keeps the guest
   // rail locked to one line and trades excess chips for a +N popover.
   const layoutGuestCluster = (container, chips, options = {}) => {
@@ -456,7 +460,10 @@
       row.tabIndex = 0;
     }
 
-    const ariaLabel = `Add activity: ${activity.start} to ${activity.end} ${activity.title}`;
+    const startLabel = activity.start ? formatTimeDisplay(activity.start) : '';
+    const endLabel = activity.end ? formatTimeDisplay(activity.end) : '';
+    const timeLabel = startLabel && endLabel ? `${startLabel} – ${endLabel}` : startLabel || endLabel || '';
+    const ariaLabel = endLabel ? `Add activity: ${startLabel} to ${endLabel} ${activity.title}` : `Add activity: ${timeLabel} ${activity.title}`;
     row.setAttribute('aria-label', ariaLabel);
 
     const body = document.createElement('div');
@@ -467,7 +474,7 @@
 
     const time = document.createElement('span');
     time.className = 'activity-row-time';
-    time.textContent = `${activity.start} – ${activity.end}`;
+    time.textContent = timeLabel;
     headline.appendChild(time);
 
     const title = document.createElement('span');

--- a/assignment-demo.html
+++ b/assignment-demo.html
@@ -43,6 +43,7 @@
   </div>
 
   <script src="assignment-chip-logic.js"></script>
+  <script src="utils/format.js"></script>
   <script src="assignment-chip-demo.js"></script>
 </body>
 </html>

--- a/custom-demo.html
+++ b/custom-demo.html
@@ -130,6 +130,7 @@
   <script src="assignment-chip-logic.js"></script>
   <script src="activities-interactions.js"></script>
   <script src="time-picker.js"></script>
+  <script src="utils/format.js"></script>
   <script src="script.js"></script>
   <script>
     (function initCustomDemo(){

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
   <script src="assignment-chip-logic.js"></script>
   <script src="activities-interactions.js"></script>
   <script src="time-picker.js"></script>
+  <script src="utils/format.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/layout-demo.html
+++ b/layout-demo.html
@@ -51,9 +51,9 @@
             <span class="layout-demo-pill" role="listitem">Wave One</span>
           </div>
           <ul class="layout-demo-cardlist" aria-label="Sample day plan">
-            <li><strong>3:30 PM · Arrival</strong>Guests settle in and drop bags.</li>
-            <li><strong>5:00 PM · Welcome cocktails</strong>Courtyard gathering with live music.</li>
-            <li><strong>7:30 PM · Dinner</strong>Private dining room in the manor.</li>
+            <li><strong>3:30pm · Arrival</strong>Guests settle in and drop bags.</li>
+            <li><strong>5:00pm · Welcome cocktails</strong>Courtyard gathering with live music.</li>
+            <li><strong>7:30pm · Dinner</strong>Private dining room in the manor.</li>
           </ul>
         </section>
         <section class="right card" aria-labelledby="layout-right-title">

--- a/script.js
+++ b/script.js
@@ -17,14 +17,11 @@
     .replace(/>/g,'&gt;')
     .replace(/"/g,'&quot;')
     .replace(/'/g,'&#39;');
-  const fmt12 = hm => {
-    let [h, m] = hm.split(':').map(Number);
-    const isAm = h < 12;
-    h = ((h + 11) % 12) + 1;
-    const meridiem = isAm ? 'AM' : 'PM';
-    return `${h}:${pad(m)} ${meridiem}`;
-  };
   const parse24Time = hm => { const [h,m] = hm.split(':').map(Number); return { hour: h, minute: m }; };
+  // Centralized formatter is provided by utils/format.js so every surface stays in sync.
+  const formatTimeDisplay = (window.CHSFormatUtils && typeof window.CHSFormatUtils.formatTimeDisplay === 'function')
+    ? window.CHSFormatUtils.formatTimeDisplay
+    : (value => (value==null ? '' : String(value)));
   const minutesFromTime = hm => {
     if(!hm) return null;
     const { hour, minute } = parse24Time(hm || '00:00');
@@ -452,12 +449,12 @@
   let stayNotePicker=null;
   function updateStayNoteInputs(){
     if(arrivalEtaInput){
-      const display = state.arrivalNote ? fmt12(state.arrivalNote) : '';
+      const display = state.arrivalNote ? formatTimeDisplay(state.arrivalNote) : '';
       arrivalEtaInput.value = display;
       arrivalEtaInput.setAttribute('aria-expanded', stayNotePicker?.stateKey==='arrivalNote' ? 'true' : 'false');
     }
     if(departureEtdInput){
-      const display = state.departureNote ? fmt12(state.departureNote) : '';
+      const display = state.departureNote ? formatTimeDisplay(state.departureNote) : '';
       departureEtdInput.value = display;
       departureEtdInput.setAttribute('aria-expanded', stayNotePicker?.stateKey==='departureNote' ? 'true' : 'false');
     }
@@ -1040,7 +1037,7 @@
         div.tabIndex = 0;
         div.removeAttribute('aria-disabled');
       }
-      const ariaLabel = `Add activity: ${fmt12(row.start)} to ${fmt12(row.end)} ${row.title}`;
+      const ariaLabel = `Add activity: ${formatTimeDisplay(row.start)} to ${formatTimeDisplay(row.end)} ${row.title}`;
       div.setAttribute('aria-label', ariaLabel);
 
       const body=document.createElement('div');
@@ -1051,7 +1048,7 @@
 
       const time=document.createElement('span');
       time.className='activity-row-time';
-      time.textContent = `${fmt12(row.start)} – ${fmt12(row.end)}`;
+      time.textContent = `${formatTimeDisplay(row.start)} – ${formatTimeDisplay(row.end)}`;
       headline.appendChild(time);
 
       const title=document.createElement('span');
@@ -1541,7 +1538,7 @@
       headline.className='activity-row-headline';
       const time=document.createElement('span');
       time.className='activity-row-time';
-      time.textContent = fmt12(entry.start);
+      time.textContent = formatTimeDisplay(entry.start);
       const title=document.createElement('span');
       title.className='activity-row-title';
       title.textContent = entry.title;
@@ -1587,8 +1584,8 @@
 
       const time=document.createElement('span');
       time.className='activity-row-time';
-      const startLabel = entry.start ? fmt12(entry.start) : '';
-      const endLabel = entry.end ? fmt12(entry.end) : '';
+      const startLabel = entry.start ? formatTimeDisplay(entry.start) : '';
+      const endLabel = entry.end ? formatTimeDisplay(entry.end) : '';
       time.textContent = startLabel && endLabel ? `${startLabel} – ${endLabel}` : startLabel || endLabel || '';
       headline.appendChild(time);
 
@@ -1643,8 +1640,8 @@
 
       const time=document.createElement('span');
       time.className='activity-row-time';
-      const startLabel = entry.start ? fmt12(entry.start) : '';
-      const endLabel = entry.end ? fmt12(entry.end) : '';
+      const startLabel = entry.start ? formatTimeDisplay(entry.start) : '';
+      const endLabel = entry.end ? formatTimeDisplay(entry.end) : '';
       time.textContent = startLabel && endLabel ? `${startLabel} – ${endLabel}` : startLabel || endLabel || '';
       headline.appendChild(time);
 
@@ -3281,7 +3278,7 @@
       if(commit){
         const parsed = parseManualTimeInput(input.value);
         if(parsed.error){
-          timeHint.textContent = parsed.error==='missing-meridiem' ? 'Include am or pm' : 'Enter a valid time (e.g., 7:00 AM)';
+          timeHint.textContent = parsed.error==='missing-meridiem' ? 'Include am or pm' : 'Enter a valid time (e.g., 7:00am)';
           timeHint.hidden = false;
           input.setAttribute('aria-invalid','true');
           setTimeout(()=>{
@@ -3292,7 +3289,7 @@
         }
         input.removeAttribute('aria-invalid');
         timeHint.hidden = true;
-        const canonical = fmt12(to24Time(parsed));
+        const canonical = formatTimeDisplay(to24Time(parsed));
         startTimeDisplay.textContent = canonical;
         if(timePicker){
           timePicker.hourWheel?.setValue?.(parsed.hour);
@@ -3326,7 +3323,7 @@
       input.setAttribute('autocapitalize','none');
       input.setAttribute('spellcheck','false');
       input.setAttribute('inputmode','text');
-      input.placeholder='e.g. 7:00 AM';
+      input.placeholder='e.g. 7:00am';
       input.dataset.spaNoSubmit='true';
       startTimeDisplay.replaceWith(input);
       startTimeInput = input;
@@ -3436,8 +3433,8 @@
     function refreshEndPreview(){
       const selection = getCanonicalSelection();
       if(selection){
-        const startLabel = fmt12(selection.start);
-        const endLabel = fmt12(selection.end);
+        const startLabel = formatTimeDisplay(selection.start);
+        const endLabel = formatTimeDisplay(selection.end);
         if(startTimeEditing && startTimeInput){
           startTimeInput.value = startLabel;
         }else{
@@ -4073,7 +4070,7 @@
 
     const updateStartDisplay=()=>{
       if(startValue){
-        startValueNode.textContent = fmt12(startValue);
+        startValueNode.textContent = formatTimeDisplay(startValue);
         startPill.dataset.empty='false';
       }else{
         startValueNode.textContent = 'Set start';
@@ -4083,7 +4080,7 @@
 
     const updateEndDisplay=()=>{
       if(endValue){
-        endValueNode.textContent = fmt12(endValue);
+        endValueNode.textContent = formatTimeDisplay(endValue);
         endPill.dataset.empty='false';
         clearEndBtn.disabled=false;
       }else{
@@ -4900,7 +4897,9 @@
         totalGuestsInStay: state.guests.length
       });
       const guestLabel = guestNames.length ? ` | ${guestNames.map(name => escapeHtml(name)).join(' | ')}` : '';
-      const timeRange = `<span class="email-activity-time">${escapeHtml(fmt12(base.start))} – ${escapeHtml(fmt12(base.end))}</span>`;
+      const timeRangeStart = escapeHtml(formatTimeDisplay(base.start));
+      const timeRangeEnd = escapeHtml(formatTimeDisplay(base.end));
+      const timeRange = `<span class="email-activity-time">${timeRangeStart} – ${timeRangeEnd}</span>`;
       // Wrap the spa time range so we can normalize its weight in the preview email.
       lines.push(`${timeRange} | ${escapeHtml(serviceTitle)} | ${escapeHtml(therapist)} | ${escapeHtml(location)}${guestLabel}`);
       return lines;
@@ -4914,7 +4913,9 @@
       const therapist = spaTherapistLabel(app.therapist);
       const location = spaLocationLabel(app.location);
       const guestLabel = guest ? ` | ${escapeHtml(guest.name)}` : '';
-      const timeRange = `<span class="email-activity-time">${escapeHtml(fmt12(app.start))} – ${escapeHtml(fmt12(app.end))}</span>`;
+      const timeRangeStart = escapeHtml(formatTimeDisplay(app.start));
+      const timeRangeEnd = escapeHtml(formatTimeDisplay(app.end));
+      const timeRange = `<span class="email-activity-time">${timeRangeStart} – ${timeRangeEnd}</span>`;
       // Wrap the per-guest spa time so its font weight matches the rest of the itinerary line.
       lines.push(`${timeRange} | ${escapeHtml(serviceTitle)} | ${escapeHtml(therapist)} | ${escapeHtml(location)}${guestLabel}`);
     });
@@ -4991,15 +4992,15 @@
 
       const checkoutLine = () => {
         const row = makeEl('div', 'email-activity');
-        row.appendChild(document.createTextNode(`${fmt12('11:00')} Check-Out | Welcome to stay on property until `));
-        const stayWindow = makeEl('span', 'email-activity-parenthetical-time', fmt12('13:00'));
+        row.appendChild(document.createTextNode(`${formatTimeDisplay('11:00')} Check-Out | Welcome to stay on property until `));
+        const stayWindow = makeEl('span', 'email-activity-parenthetical-time', formatTimeDisplay('13:00'));
         row.appendChild(stayWindow);
         return row;
       };
       const checkinLine = () => {
         const row = makeEl('div', 'email-activity');
-        row.appendChild(document.createTextNode(`${fmt12('16:00')} Guaranteed Check-In | Welcome to arrive as early as `));
-        const arrivalWindow = makeEl('span', 'email-activity-parenthetical-time', fmt12('12:00'));
+        row.appendChild(document.createTextNode(`${formatTimeDisplay('16:00')} Guaranteed Check-In | Welcome to arrive as early as `));
+        const arrivalWindow = makeEl('span', 'email-activity-parenthetical-time', formatTimeDisplay('12:00'));
         row.appendChild(arrivalWindow);
         return row;
       };
@@ -5038,8 +5039,8 @@
           && totalGuestsInStay > 0
           && ids.length === totalGuestsInStay;
         if(!isDinner && guestNames.length===0 && !assignmentCoversAll) return;
-        const startTime = it.start ? escapeHtml(fmt12(it.start)) : '';
-        const endTime = it.end ? escapeHtml(fmt12(it.end)) : '';
+        const startTime = it.start ? escapeHtml(formatTimeDisplay(it.start)) : '';
+        const endTime = it.end ? escapeHtml(formatTimeDisplay(it.end)) : '';
         let timeSegment = '';
         if(startTime && endTime){
           timeSegment = `${startTime} - ${endTime}`;

--- a/style.css
+++ b/style.css
@@ -1003,7 +1003,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .time-picker-wheels{display:flex;align-items:center;gap:12px;}
 .time-picker-column{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}
 .time-picker-column::after{content:"";position:absolute;left:8px;right:8px;top:50%;height:44px;margin-top:-22px;border-radius:12px;border:1px solid rgba(42,107,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);pointer-events:none;}
-.time-picker-meridiem-static{font-size:18px;font-weight:600;color:var(--muted);text-transform:uppercase;display:flex;align-items:center;justify-content:center;height:176px;padding:0 4px;}
+.time-picker-meridiem-static{font-size:18px;font-weight:600;color:var(--muted);display:flex;align-items:center;justify-content:center;height:176px;padding:0 4px;}
 .time-picker-column.time-picker-meridiem::after{content:none;}
 .time-picker-meridiem-toggle{width:100%;min-height:176px;padding:12px;border-radius:18px;border:1px solid var(--border-hairline);background:var(--surface,#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.08);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;}
 .time-picker-meridiem-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}

--- a/time-picker-demo.html
+++ b/time-picker-demo.html
@@ -24,6 +24,7 @@
   </main>
 
   <script src="time-picker.js"></script>
+  <script src="utils/format.js"></script>
   <script src="time-picker-demo.js"></script>
 </body>
 </html>

--- a/time-picker-demo.js
+++ b/time-picker-demo.js
@@ -8,8 +8,15 @@
     return;
   }
 
-  const pad = n => String(n).padStart(2, '0');
-  const formatValue = ({ hour, minute, meridiem }) => `${hour}:${pad(minute)} ${meridiem}`;
+  const formatTimeDisplay = (window.CHSFormatUtils && window.CHSFormatUtils.formatTimeDisplay)
+    ? window.CHSFormatUtils.formatTimeDisplay
+    : ({ hour, minute, meridiem }) => {
+        const normalizedHour = ((Number(hour) || 0) % 12) || 12;
+        const paddedMinute = String(Number(minute) || 0).padStart(2,'0');
+        const suffix = (meridiem || '').toLowerCase() === 'pm' ? 'pm' : 'am';
+        return `${normalizedHour}:${paddedMinute}${suffix}`;
+      };
+  const formatValue = parts => formatTimeDisplay(parts);
 
   const dinnerRules = {
     5: new Set([0, 15]),
@@ -51,9 +58,9 @@
       title: 'Spa',
       description: '12-hour wheel, visible AM/PM, five minute granularity.',
       defaults: [
-        { label: 'Default 7:00 AM', value: { hour: 7, minute: 0, meridiem: 'AM' } },
-        { label: 'Default 9:05 AM', value: { hour: 9, minute: 5, meridiem: 'AM' } },
-        { label: 'Default 2:35 PM', value: { hour: 2, minute: 35, meridiem: 'PM' } }
+        { label: 'Default 7:00am', value: { hour: 7, minute: 0, meridiem: 'AM' } },
+        { label: 'Default 9:05am', value: { hour: 9, minute: 5, meridiem: 'AM' } },
+        { label: 'Default 2:35pm', value: { hour: 2, minute: 35, meridiem: 'PM' } }
       ],
       buildConfig(defaultValue, updateValue){
         return {
@@ -76,9 +83,9 @@
       description: 'Shared picker with Start/End buttons for arrivals and departures.',
       showHelpers: true,
       defaults: [
-        { label: 'Default 7:00 AM', value: { hour: 7, minute: 0, meridiem: 'AM' } },
-        { label: 'Default 8:45 AM', value: { hour: 8, minute: 45, meridiem: 'AM' } },
-        { label: 'Default 6:15 PM', value: { hour: 6, minute: 15, meridiem: 'PM' } }
+        { label: 'Default 7:00am', value: { hour: 7, minute: 0, meridiem: 'AM' } },
+        { label: 'Default 8:45am', value: { hour: 8, minute: 45, meridiem: 'AM' } },
+        { label: 'Default 6:15pm', value: { hour: 6, minute: 15, meridiem: 'PM' } }
       ],
       buildConfig(defaultValue, updateValue, helpers){
         return {
@@ -223,7 +230,7 @@
     controls.className = 'time-picker-demo-controls';
     card.appendChild(controls);
 
-    const resetButton = createButton('Reset both to 7:00 PM');
+    const resetButton = createButton('Reset both to 7:00pm');
     controls.appendChild(resetButton);
 
     const physicsGrid = document.createElement('div');

--- a/time-picker.js
+++ b/time-picker.js
@@ -776,7 +776,7 @@
     // Derive the first render snapshot (hour/minute/meridiem + disabled minutes)
     // synchronously so we never paint a greyed-out selection before the state is
     // ready. The fallback minute search also resolves blocked defaults up front,
-    // so opening at 7:00 PM lands perfectly centred with no transient grey :00.
+    // so opening at 7:00pm lands perfectly centred with no transient grey :00.
     const initialHour = defaultHour;
     const initialMeridiem = defaultMeridiem;
     let disabledMinutes = computeDisabledMinutes(initialHour, initialMeridiem);

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,0 +1,90 @@
+(function(global){
+  'use strict';
+
+  // Shared formatter keeps every surface aligned on the h:mmam/pm spec.
+  const pad = value => String(Math.trunc(Math.abs(value))).padStart(2,'0');
+
+  const normalizeHour = value => {
+    if(!Number.isFinite(value)) return null;
+    return ((Math.trunc(value) % 24) + 24) % 24;
+  };
+
+  const normalizeMinute = value => {
+    if(!Number.isFinite(value)) return null;
+    return ((Math.trunc(value) % 60) + 60) % 60;
+  };
+
+  const parseFromObject = value => {
+    const rawHour = value.hour ?? value.hours ?? value.h;
+    const rawMinute = value.minute ?? value.minutes ?? value.m;
+    if(rawHour == null) return null;
+    const hour = Number(rawHour);
+    const minute = Number(rawMinute ?? 0);
+    if(!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+    if(typeof value.meridiem === 'string'){
+      const mer = value.meridiem.trim().toLowerCase();
+      let hour12 = Math.trunc(hour) % 12;
+      if(hour12 < 0) hour12 += 12;
+      if(mer === 'pm'){
+        return { hour: hour12 + 12, minute };
+      }
+      return { hour: hour12 % 12, minute };
+    }
+    return { hour, minute };
+  };
+
+  const parseFromString = value => {
+    const str = String(value || '').trim();
+    if(!str) return null;
+    const strict = str.match(/^(\d{1,2}):(\d{2})$/);
+    if(strict){
+      const hour = Number(strict[1]);
+      const minute = Number(strict[2]);
+      if(Number.isFinite(hour) && Number.isFinite(minute)){
+        return { hour, minute };
+      }
+      return null;
+    }
+    const loose = str.match(/^(\d{1,2})(?::?(\d{2}))?\s*(am|pm)?$/i);
+    if(!loose) return null;
+    let hour = Number(loose[1]);
+    const minute = Number(loose[2] ?? 0);
+    if(!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+    const mer = loose[3] ? loose[3].toLowerCase() : null;
+    if(mer){
+      hour = ((Math.trunc(hour) % 12) + 12) % 12;
+      if(mer === 'pm'){
+        hour += 12;
+      }
+    }
+    return { hour, minute };
+  };
+
+  const extractTimeParts = value => {
+    if(value == null) return null;
+    if(value instanceof Date){
+      return { hour: value.getHours(), minute: value.getMinutes() };
+    }
+    if(typeof value === 'object'){
+      const fromObject = parseFromObject(value);
+      if(fromObject) return fromObject;
+    }
+    return parseFromString(value);
+  };
+
+  const formatTimeDisplay = value => {
+    const parts = extractTimeParts(value);
+    if(!parts) return '';
+    const hour = normalizeHour(parts.hour);
+    const minute = normalizeMinute(parts.minute);
+    if(hour == null || minute == null) return '';
+    const meridiem = hour >= 12 ? 'pm' : 'am';
+    let displayHour = hour % 12;
+    if(displayHour === 0) displayHour = 12;
+    return `${displayHour}:${pad(minute)}${meridiem}`;
+  };
+
+  global.CHSFormatUtils = Object.assign({}, global.CHSFormatUtils, {
+    formatTimeDisplay
+  });
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- add a shared `formatTimeDisplay` helper in `utils/format.js` and load it across the app
- route itinerary, picker, and preview surfaces through the helper so every time renders as h:mmam/pm
- clean up demo assets and styling so static text and meridiem labels no longer force uppercase output

## Testing
- Not run (frontend changes)


------
https://chatgpt.com/codex/tasks/task_e_68e6172933ec833080f7946fb0f3801a