### PR TITLE
Add persistent email preview editing

### DIFF
--- a/custom-demo.html
+++ b/custom-demo.html
@@ -120,7 +120,9 @@
       </div>
       <div id="email" class="email" spellcheck="false"></div>
       <div class="row stick-right">
-        <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>
+        <button id="editPreview" title="Edit Email Preview" aria-label="Edit Email Preview">Edit</button>
+        <button id="lockPreview" title="Lock Email Preview" aria-label="Lock Email Preview" disabled>Lock</button>
+        <button id="resetPreview" title="Reset Email Edits" aria-label="Reset Email Edits" disabled>Reset</button>
         <button id="copy" title="Copy">⧉</button>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,9 @@
       </div>
       <div id="email" class="email" spellcheck="false"></div>
       <div class="row stick-right">
-        <button id="toggleEdit" title="Edit/Lock (Cmd/Ctrl + Dbl-Click)">✎</button>
+        <button id="editPreview" title="Edit Email Preview" aria-label="Edit Email Preview">Edit</button>
+        <button id="lockPreview" title="Lock Email Preview" aria-label="Lock Email Preview" disabled>Lock</button>
+        <button id="resetPreview" title="Reset Email Edits" aria-label="Reset Email Edits" disabled>Reset</button>
         <button id="copy" title="Copy">⧉</button>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -424,7 +424,6 @@ h2{margin:0 0 12px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercas
 button{border:1px solid var(--border);background:#f1f5f9;border-radius:10px;padding:8px 10px;cursor:pointer;touch-action:manipulation}
 button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .lock-icon{width:1em;height:1em;display:block}
-#toggleEdit{display:flex;align-items:center;justify-content:center;gap:0;line-height:1}
 .muted{color:var(--muted)}
 .grid{
   display:grid;


### PR DESCRIPTION
## Summary
- add edit/lock/reset controls and stable anchors so email preview blocks carry persistent keys
- capture per-block patches, sanitize payloads, and persist them per itinerary for reorder-safe reapplication
- refresh copy handling to read the patched DOM and trim line endings while keeping existing formatting

## Testing
- Manual QA via Playwright script exercising edit → lock, day switching, item add/remove, and guest toggles

------
https://chatgpt.com/codex/tasks/task_e_68e6341582988330938c70ec0c1ca005