### PR TITLE
Contain preview pane with inner scroller

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,13 +110,13 @@
           <div class="preview-card__content">
             <div id="email" class="email" spellcheck="false"></div>
           </div>
-          <div class="row stick-right preview-card__actions">
-            <button id="editPreview" title="Edit Email Preview" aria-label="Edit Email Preview">Edit</button>
-            <button id="lockPreview" title="Lock Email Preview" aria-label="Lock Email Preview" disabled>Lock</button>
-            <button id="resetPreview" title="Reset Email Edits" aria-label="Reset Email Edits" disabled>Reset</button>
-            <button id="copy" title="Copy">⧉</button>
-          </div>
         </div>
+      </div>
+      <div class="row stick-right preview-card__actions">
+        <button id="editPreview" title="Edit Email Preview" aria-label="Edit Email Preview">Edit</button>
+        <button id="lockPreview" title="Lock Email Preview" aria-label="Lock Email Preview" disabled>Lock</button>
+        <button id="resetPreview" title="Reset Email Edits" aria-label="Reset Email Edits" disabled>Reset</button>
+        <button id="copy" title="Copy">⧉</button>
       </div>
     </section>
   </div>

--- a/index.html
+++ b/index.html
@@ -101,16 +101,22 @@
     </section>
 
     <!-- Preview -->
-    <section class="right card preview-card">
-      <div class="card-section-header">
-        <h2>Preview</h2>
-      </div>
-      <div id="email" class="email" spellcheck="false"></div>
-      <div class="row stick-right">
-        <button id="editPreview" title="Edit Email Preview" aria-label="Edit Email Preview">Edit</button>
-        <button id="lockPreview" title="Lock Email Preview" aria-label="Lock Email Preview" disabled>Lock</button>
-        <button id="resetPreview" title="Reset Email Edits" aria-label="Reset Email Edits" disabled>Reset</button>
-        <button id="copy" title="Copy">⧉</button>
+    <section class="right card preview-card" data-area="preview" aria-label="Email preview">
+      <div class="preview-card__scroll">
+        <header class="card-section-header preview-card__header">
+          <h2>Preview</h2>
+        </header>
+        <div class="preview-card__body">
+          <div class="preview-card__content">
+            <div id="email" class="email" spellcheck="false"></div>
+          </div>
+          <div class="row stick-right preview-card__actions">
+            <button id="editPreview" title="Edit Email Preview" aria-label="Edit Email Preview">Edit</button>
+            <button id="lockPreview" title="Lock Email Preview" aria-label="Lock Email Preview" disabled>Lock</button>
+            <button id="resetPreview" title="Reset Email Edits" aria-label="Reset Email Edits" disabled>Reset</button>
+            <button id="copy" title="Copy">⧉</button>
+          </div>
+        </div>
       </div>
     </section>
   </div>

--- a/preview-demo.html
+++ b/preview-demo.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Preview Pane Demo · CHS Itinerary Builder</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .preview-demo-toolbar{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between;}
+    .preview-demo-note{margin:0;color:var(--muted);font-size:14px;}
+    .preview-demo-viewport{display:grid;place-items:stretch;}
+    .preview-demo-card{max-inline-size:560px;margin:0 auto;block-size:clamp(360px,70vh,520px);}
+    .preview-demo-card .preview-card__actions button[disabled]{opacity:.5;cursor:not-allowed;}
+  </style>
+</head>
+<body class="demo-page">
+  <div class="demo-container">
+    <header class="demo-header">
+      <h1>Preview pane scroll containment</h1>
+      <p class="demo-section-copy">This sandbox renders an extra-long itinerary so you can verify the preview content scrolls internally while the action row stays visible.</p>
+    </header>
+
+    <section class="demo-section" aria-labelledby="preview-demo-title">
+      <div class="preview-demo-toolbar">
+        <div class="demo-section-header">
+          <h2 id="preview-demo-title">Preview rail demo</h2>
+        </div>
+        <button id="previewDemoTheme" type="button">Toggle dark mode</button>
+      </div>
+      <p class="preview-demo-note">Scroll inside the preview below—the buttons remain flow-pinned to the card via grid layout.</p>
+      <div class="preview-demo-viewport">
+        <section class="card preview-card preview-demo-card" aria-label="Email preview demo">
+          <div class="preview-card__scroll">
+            <header class="card-section-header preview-card__header">
+              <h2>Preview</h2>
+            </header>
+            <div class="preview-card__body">
+              <div class="preview-card__content">
+                <div id="previewDemoEmail" class="email" aria-live="polite"></div>
+              </div>
+            </div>
+          </div>
+          <!-- Buttons remain inside the grid so they sit beneath the scroller without sticky positioning. -->
+          <div class="row stick-right preview-card__actions">
+            <button type="button">Edit</button>
+            <button type="button" disabled>Lock</button>
+            <button type="button" disabled>Reset</button>
+            <button type="button" aria-label="Copy preview">⧉</button>
+          </div>
+        </section>
+      </div>
+    </section>
+  </div>
+
+  <script src="preview-demo.js"></script>
+</body>
+</html>

--- a/preview-demo.js
+++ b/preview-demo.js
@@ -1,0 +1,70 @@
+(() => {
+  const email = document.getElementById('previewDemoEmail');
+  if (email) {
+    email.innerHTML = `
+      <p style="margin-top:0;">Hi Taylor,</p>
+      <p>Below is the working itinerary for the Arcadia weekend. It captures every confirmed touchpoint so you can share an accurate preview with the guests.</p>
+      <h3>Friday, May 12</h3>
+      <ul>
+        <li><strong>2:30&nbsp;PM · Arrival</strong> — Private car service direct to the Manor portico with chilled towels on hand.</li>
+        <li><strong>3:00&nbsp;PM · Welcome tea</strong> — Conservatory lounge with jasmine blend, seasonal fruit, and pastry trio.</li>
+        <li><strong>5:00&nbsp;PM · Sunset sail</strong> — Dockside crew will greet the party; light bites and rosé stocked on board.</li>
+        <li><strong>7:30&nbsp;PM · Chef's table</strong> — Eight-course tasting in the glasshouse. Dietary notes already with the kitchen.</li>
+      </ul>
+      <h3>Saturday, May 13</h3>
+      <p>The day balances exploration with restorative time on property. Massage slots are staggered so everyone rotates through the experiences.</p>
+      <ol>
+        <li><strong>7:30&nbsp;AM</strong> — Guided shoreline hike with hot cider at the finish.</li>
+        <li><strong>9:15&nbsp;AM</strong> — Breakfast in the Orchard Room. Smoothie bar stays open through 11.</li>
+        <li><strong>11:00&nbsp;AM</strong> — Choice blocks begin (mixology workshop, falconry intro, or e-bike tour).</li>
+        <li><strong>2:00&nbsp;PM</strong> — Picnic and lawn games on the upper terrace.</li>
+        <li><strong>6:30&nbsp;PM</strong> — Fireside tasting menu with string trio accompaniment.</li>
+        <li><strong>9:00&nbsp;PM</strong> — Nighttime observatory visit with astronomer Riley Snow.</li>
+      </ol>
+      <h3>Sunday, May 14</h3>
+      <p>The departure window remains flexible; late checkout guaranteed. Team will pack luggage while guests enjoy the final tasting.</p>
+      <table role="presentation" style="width:100%;border-collapse:collapse;margin:16px 0;">
+        <thead>
+          <tr style="text-align:left;border-bottom:1px solid currentColor;opacity:0.6;">
+            <th scope="col" style="padding:6px 0;">Time</th>
+            <th scope="col" style="padding:6px 0;">Experience</th>
+            <th scope="col" style="padding:6px 0;">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding:6px 0;">8:00&nbsp;AM</td>
+            <td style="padding:6px 0;">Greenhouse breakfast</td>
+            <td style="padding:6px 0;">Chef Lena hosting; cold-pressed juices on rotation.</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;">10:30&nbsp;AM</td>
+            <td style="padding:6px 0;">Departure prep</td>
+            <td style="padding:6px 0;">Bell staff collecting luggage from suites.</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;">11:15&nbsp;AM</td>
+            <td style="padding:6px 0;">Fond-farewell toast</td>
+            <td style="padding:6px 0;">Sparkling elderflower + local chocolates.</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;">12:00&nbsp;PM</td>
+            <td style="padding:6px 0;">Staggered departures</td>
+            <td style="padding:6px 0;">SUV transfers &mdash; drivers will text upon arrival.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Guest preferences, allergies, and transfer details live in the shared sheet. Let us know if you'd like additional signage or printed cards for the suites.</p>
+      <p>Warmly,<br>Amelia</p>
+      <p style="margin-bottom:0;font-size:12px;opacity:0.7;">Concierge · Arcadia Manor · 415-555-0128</p>
+    `;
+  }
+
+  const themeToggle = document.getElementById('previewDemoTheme');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const next = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+      document.body.dataset.theme = next;
+    });
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -362,13 +362,19 @@ body{
   overflow:hidden;
   isolation:isolate;
   contain:content;
+  /* Grid reserves a dedicated row for buttons so they stay pinned without position hacks. */
+  display:grid;
+  grid-template-rows:minmax(0,1fr) auto;
+  gap:var(--space-4);
+  /* Reassert min-block-size:0 so the grid row can shrink in Safari flex/grid combos. */
+  min-block-size:0;
   /* Remove the default padding so the scroll container can own spacing without jitter. */
   padding:0;
 }
 
 .preview-card__scroll{
   /* Inner scroller: fills the card while keeping layout localized. */
-  flex:1 1 auto;
+  /* min-block-size:0 stops Safari from forcing extra height so the grid row can shrink. */
   min-block-size:0;
   display:flex;
   flex-direction:column;
@@ -390,7 +396,7 @@ body{
 
 /* Content wrapper prevents margin-collapse and wraps long HTML fragments safely. */
 .preview-card__body{
-  /* Layout column keeps actions attached to the preview content. */
+  /* Layout column allows email markup to grow independently from the header. */
   display:flex;
   flex-direction:column;
   gap:var(--space-4);
@@ -422,9 +428,11 @@ body{
 }
 
 .preview-card__actions{
+  /* Buttons stay flow-pinned by the grid row—no sticky/fixed positioning. */
   display:flex;
   justify-content:flex-end;
   gap:8px;
+  padding:0 var(--space-4) var(--space-4);
 }
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 /*

--- a/style.css
+++ b/style.css
@@ -235,6 +235,8 @@ body{
 .left,.center,.right{
   /* Allow cards to shrink within their tracks so content wraps instead of overflowing. */
   min-inline-size:0;
+  /* min-block-size keeps the preview scroller honest when grid rows share the track. */
+  min-block-size:0;
 }
 
 /*
@@ -318,10 +320,6 @@ body{
     min-block-size:0;
   }
   .right.card.preview-card{
-    overflow:auto;
-    overscroll-behavior:contain;
-    scrollbar-gutter:stable both-edges;
-    -webkit-overflow-scrolling:touch;
     block-size:calc(100vh - var(--app-block-padding));
     block-size:calc(100svh - var(--app-block-padding));
     block-size:calc(100dvh - var(--app-block-padding));
@@ -356,6 +354,77 @@ body{
   flex-direction:column;
   block-size:100%;
   min-block-size:0;
+}
+
+/* Preview containment: outer card masks overflow while inner scroller handles the scroll. */
+.preview-card{
+  /* Hide anything escaping and isolate paint so calendar/activities stay unaffected. */
+  overflow:hidden;
+  isolation:isolate;
+  contain:content;
+  /* Remove the default padding so the scroll container can own spacing without jitter. */
+  padding:0;
+}
+
+.preview-card__scroll{
+  /* Inner scroller: fills the card while keeping layout localized. */
+  flex:1 1 auto;
+  min-block-size:0;
+  display:flex;
+  flex-direction:column;
+  overflow:auto;
+  overscroll-behavior:contain;
+  scrollbar-gutter:stable both-edges;
+  -webkit-overflow-scrolling:touch;
+  padding:var(--space-4);
+  background:var(--surface);
+}
+
+/* Sticky header remains local to the preview instead of the document. */
+.preview-card__header{
+  position:sticky;
+  top:0;
+  z-index:var(--z-sticky, 1);
+  background:var(--surface);
+}
+
+/* Content wrapper prevents margin-collapse and wraps long HTML fragments safely. */
+.preview-card__body{
+  /* Layout column keeps actions attached to the preview content. */
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-4);
+  flex:1 1 auto;
+  min-block-size:0;
+}
+
+.preview-card__content{
+  /* flow-root stops the email markup from collapsing margins into the header. */
+  display:flow-root;
+  max-inline-size:100%;
+  overflow-wrap:anywhere;
+  word-break:break-word;
+  min-block-size:0;
+}
+
+.preview-card__content img,
+.preview-card__content table,
+.preview-card__content iframe,
+.preview-card__content video{
+  max-inline-size:100%;
+  block-size:auto;
+}
+
+.preview-card__content pre,
+.preview-card__content code{
+  white-space:pre-wrap;
+  word-break:break-word;
+}
+
+.preview-card__actions{
+  display:flex;
+  justify-content:flex-end;
+  gap:8px;
 }
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 /*


### PR DESCRIPTION
Context: Contain the Preview pane so overflow never bleeds into adjacent columns.

Approach: Wrapped the Preview card in an outer mask with an inner scroll container, added flow-root/body wrappers to clamp email markup, and ensured the column ancestors all expose min-block-size: 0 so the scroll region can engage.

Guardrails upheld: Tokens only, preview sticks under iPad layout, no public API changes.

Screenshots:
![Preview containment](browser:/invocations/iukylsxr/artifacts/artifacts/preview-full.png)

Notes: Preview header now sticks within the card and internal content wraps media safely without touching neighboring rails.


------
https://chatgpt.com/codex/tasks/task_e_68e693dbaef88330a65f7056747f7dfb