### PR TITLE
Refine calendar column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,32 +29,29 @@
             <button id="yNext" class="nav-btn" title="Next Year" aria-label="Next Year">»</button>
           </div>
         </div>
-
-        <div id="dow" class="grid dow" aria-hidden="true"></div>
-        <div id="calGrid" class="grid days" role="grid" aria-label="Calendar grid"></div>
-        <div class="calendar-actions">
-          <!-- Full-width Today button anchors the control stack so it reads as the primary action without shifting nearby content. -->
-          <button id="btnToday" class="calendar-today-button" title="Today" aria-label="Today">Today</button>
-        </div>
-        <div class="stay-note-row" aria-label="Stay arrival and departure tools">
-          <!-- Group arrival controls so the note input sits inline with the button while keeping keyboard order logical. -->
-          <div class="stay-note">
-            <button id="btnArrival" class="stay-note-button" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
-            <input id="arrivalEta" class="stay-time-input" type="text" placeholder="ETA" aria-label="Arrival time note" aria-haspopup="dialog" readonly>
+        <!-- Clip overflow at the column edge and allow the interactive stack to scroll without disturbing the toolbar. -->
+        <div class="calendar-scroll" role="presentation">
+          <div id="dow" class="grid dow" aria-hidden="true"></div>
+          <div id="calGrid" class="grid days" role="grid" aria-label="Calendar grid"></div>
+          <div class="calendar-actions">
+            <!-- Full-width Today button anchors the control stack so it reads as the primary action without shifting nearby content. -->
+            <button id="btnToday" class="calendar-today-button" title="Today" aria-label="Today">Today</button>
           </div>
-          <div class="stay-note">
-            <button id="btnDeparture" class="stay-note-button" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
-            <input id="departureEtd" class="stay-time-input" type="text" placeholder="ETD" aria-label="Departure time note" aria-haspopup="dialog" readonly>
+          <div class="stay-note-row" aria-label="Stay arrival and departure tools">
+            <!-- Buttons + notes share a grid so they stay aligned while respecting keyboard order. -->
+            <button id="btnArrival" class="stay-note-button calendar-control" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
+            <input id="arrivalEta" class="stay-time-input calendar-control" type="text" placeholder="ETA" aria-label="Arrival time note" aria-haspopup="dialog" readonly>
+            <button id="btnDeparture" class="stay-note-button calendar-control" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
+            <input id="departureEtd" class="stay-time-input calendar-control" type="text" placeholder="ETD" aria-label="Departure time note" aria-haspopup="dialog" readonly>
           </div>
-        </div>
-        <!-- Guest tools sit in the calendar flow so iPad can stack header → nav → grid → controls → guests without JS shuffles. -->
-        <div class="section guest-section">
-          <div class="card-section-header guests-header">
-            <h2>Guests</h2>
-            <!-- Keep guest entry inline with the header so the divider still separates chips from controls. -->
-            <div class="guest-tools">
-              <input id="guestName" class="guest-input" type="text" placeholder="Who..?" aria-label="Guest name">
-              <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
+          <!-- Guest tools sit in the calendar flow so iPad can stack header → nav → grid → controls → guests without JS shuffles. -->
+          <div class="section guest-section">
+            <div class="card-section-header guests-header">
+              <h2>Guests</h2>
+              <!-- Keep guest entry inline with the header so the divider still separates chips from controls. -->
+              <div class="guest-tools">
+                <input id="guestName" class="guest-input" type="text" placeholder="Who..?" aria-label="Guest name">
+                <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
               <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
                 <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>
@@ -63,7 +60,7 @@
               </button>
             </div>
           </div>
-          <div id="guests" class="chips" aria-label="Guests"></div>
+          <div id="guests" class="chips guest-list" aria-label="Guests"></div>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,8 @@
             </div>
           </div>
           <div id="guests" class="chips guest-list" aria-label="Guests"></div>
+          <!-- Overlay thumb renders inside the scroll container so the custom scrollbar can fade in without shifting layout. -->
+          <div class="calendar-scroll__thumb" aria-hidden="true"></div>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -31,40 +31,45 @@
         </div>
         <!-- Clip overflow at the column edge and allow the interactive stack to scroll without disturbing the toolbar. -->
         <div class="calendar-scroll" role="presentation">
-          <div id="dow" class="grid dow" aria-hidden="true"></div>
-          <div id="calGrid" class="grid days" role="grid" aria-label="Calendar grid"></div>
-          <div class="calendar-actions">
-            <!-- Full-width Today button anchors the control stack so it reads as the primary action without shifting nearby content. -->
-            <button id="btnToday" class="calendar-today-button" title="Today" aria-label="Today">Today</button>
+          <div class="calendar-scroll__content">
+            <div id="dow" class="grid dow" aria-hidden="true"></div>
+            <div id="calGrid" class="grid days" role="grid" aria-label="Calendar grid"></div>
           </div>
-          <div class="stay-note-row" aria-label="Stay arrival and departure tools">
-            <!-- Buttons + notes share a grid so they stay aligned while respecting keyboard order. -->
-            <button id="btnArrival" class="stay-note-button calendar-control" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
-            <input id="arrivalEta" class="stay-time-input calendar-control" type="text" placeholder="ETA" aria-label="Arrival time note" aria-haspopup="dialog" readonly>
-            <button id="btnDeparture" class="stay-note-button calendar-control" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
-            <input id="departureEtd" class="stay-time-input calendar-control" type="text" placeholder="ETD" aria-label="Departure time note" aria-haspopup="dialog" readonly>
-          </div>
-          <!-- Guest tools sit in the calendar flow so iPad can stack header → nav → grid → controls → guests without JS shuffles. -->
-          <div class="section guest-section">
-            <div class="card-section-header guests-header">
-              <h2>Guests</h2>
-              <!-- Keep guest entry inline with the header so the divider still separates chips from controls. -->
-              <div class="guest-tools">
-                <input id="guestName" class="guest-input" type="text" placeholder="Who..?" aria-label="Guest name">
-                <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
-              <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
-                <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>
-                <rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/>
-              </svg>
-              </button>
-            </div>
-          </div>
-          <div id="guests" class="chips guest-list" aria-label="Guests"></div>
           <!-- Overlay thumb renders inside the scroll container so the custom scrollbar can fade in without shifting layout. -->
           <div class="calendar-scroll__thumb" aria-hidden="true"></div>
         </div>
-      </div>
+        <div class="calendar-actions">
+          <!-- Full-width Today button anchors the control stack so it reads as the primary action without shifting nearby content. -->
+          <button id="btnToday" class="calendar-today-button" title="Today" aria-label="Today">Today</button>
+        </div>
+        <div class="stay-note-row" aria-label="Stay arrival and departure tools">
+          <!-- Buttons + notes share a grid so they stay aligned while respecting keyboard order. -->
+          <button id="btnArrival" class="stay-note-button calendar-control" title="Set Arrival (Cmd/Ctrl+A)" aria-label="Set Arrival">Arrival</button>
+          <input id="arrivalEta" class="stay-time-input calendar-control" type="text" placeholder="ETA" aria-label="Arrival time note" aria-haspopup="dialog" readonly>
+          <button id="btnDeparture" class="stay-note-button calendar-control" title="Set Departure (Cmd/Ctrl+D)" aria-label="Set Departure">Departure</button>
+          <input id="departureEtd" class="stay-time-input calendar-control" type="text" placeholder="ETD" aria-label="Departure time note" aria-haspopup="dialog" readonly>
+        </div>
+        <!-- Guest tools sit in the calendar flow so iPad can stack header → nav → grid → controls → guests without JS shuffles. -->
+        <div class="section guest-section">
+          <div class="card-section-header guests-header">
+            <h2>Guests</h2>
+            <!-- Keep guest entry inline with the header so the divider still separates chips from controls. -->
+            <div class="guest-tools">
+              <input id="guestName" class="guest-input" type="text" placeholder="Who..?" aria-label="Guest name">
+              <button id="toggleAll" class="icon-btn" aria-label="Toggle all guests" title="Toggle all guests">
+                <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <rect x="7" y="3.5" width="10" height="17" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+                  <line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" opacity="0.6"/>
+                  <rect x="8.2" y="5" width="7.6" height="6" rx="1.4" fill="currentColor" opacity="0.18"/>
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="guest-pill-viewport">
+            <div id="guests" class="chips guest-list" aria-label="Guests"></div>
+          </div>
+        </div>
+        </div>
     </section>
 
     <!-- Activities -->

--- a/style.css
+++ b/style.css
@@ -369,18 +369,37 @@ body{
   padding-block-end:var(--space-4);
   overflow:auto;
   overscroll-behavior:contain;
-  scrollbar-gutter:stable both-edges;
+  scrollbar-gutter:stable both-edges; /* Fallback guard so native gutters stay stable if the overlay is unavailable. */
   -webkit-overflow-scrolling:touch;
-  scrollbar-width:none;
+  scrollbar-width:none; /* Firefox: suppress the native thumb so the overlay handles visibility. */
+  position:relative;
 }
-.left.card > #calendar .calendar-scroll:hover{scrollbar-width:thin;}
-.left.card > #calendar .calendar-scroll::-webkit-scrollbar{width:0;height:0;}
-.left.card > #calendar .calendar-scroll:hover::-webkit-scrollbar{width:6px;height:6px;}
-.left.card > #calendar .calendar-scroll:hover::-webkit-scrollbar-thumb{
-  background:color-mix(in srgb,var(--muted) 45%,transparent);
+/* WebKit/Blink: hide the scrollbar track entirely so the overlay can paint without shrinking content. */
+.left.card > #calendar .calendar-scroll::-webkit-scrollbar{display:none;}
+
+/* Overlay thumb stays pinned to the trailing edge and fades in when the user scrolls or hovers. */
+.calendar-scroll__thumb{
+  --calendar-thumb-size:0px;
+  --calendar-thumb-offset:0px;
+  position:absolute;
+  inset-inline-end:var(--space-3);
+  inset-block-start:var(--space-4);
+  inline-size:max(4px,var(--space-1));
+  block-size:var(--calendar-thumb-size);
   border-radius:999px;
+  background:color-mix(in srgb,var(--muted) 55%,transparent);
+  opacity:0;
+  pointer-events:none;
+  transition:opacity 120ms ease;
+  transform:translate3d(0,var(--calendar-thumb-offset),0);
 }
-.left.card > #calendar .calendar-scroll:hover::-webkit-scrollbar-track{background:transparent;}
+.left.card > #calendar .calendar-scroll.is-scrolling .calendar-scroll__thumb,
+.left.card > #calendar .calendar-scroll:hover .calendar-scroll__thumb{
+  opacity:0.88;
+}
+@media (prefers-reduced-motion: reduce){
+  .calendar-scroll__thumb{transition:none;}
+}
 
 /* Preview containment: outer card masks overflow while inner scroller handles the scroll. */
 .preview-card{

--- a/style.css
+++ b/style.css
@@ -300,20 +300,6 @@ body{
     overflow:hidden;
     overflow:clip;
   }
-  .left.card > #calendar{
-    /*
-     * Calendar stack: flex so the header/nav stay pinned while the grid + guests scroll
-     * together. The min-block-size guard keeps Split View heights stable when space is tight.
-     */
-    display:flex;
-    flex-direction:column;
-    flex:1 1 auto;
-    min-block-size:0;
-    overflow:auto;
-    overscroll-behavior:contain;
-    scrollbar-gutter:stable both-edges;
-    -webkit-overflow-scrolling:touch;
-  }
   .center.card > #activities{
     /* Activities column scrolls internally so the shared row never grows beyond the viewport. */
     block-size:100%;
@@ -358,6 +344,43 @@ body{
   block-size:100%;
   min-block-size:0;
 }
+/*
+ * Calendar rail containment: clip at the card edge and let the internal stack
+ * manage its own scrolling so Today/guest tools never collide with nav.
+ */
+.left.card{
+  overflow:hidden;
+  overflow:clip;
+}
+.left.card > #calendar{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-5);
+  flex:1 1 auto;
+  min-block-size:0;
+}
+.left.card > #calendar .calendar-scroll{
+  /* Keep the interactive stack scrollable with the disappearing scrollbar pattern. */
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-4);
+  flex:1 1 auto;
+  min-block-size:0;
+  padding-block-end:var(--space-4);
+  overflow:auto;
+  overscroll-behavior:contain;
+  scrollbar-gutter:stable both-edges;
+  -webkit-overflow-scrolling:touch;
+  scrollbar-width:none;
+}
+.left.card > #calendar .calendar-scroll:hover{scrollbar-width:thin;}
+.left.card > #calendar .calendar-scroll::-webkit-scrollbar{width:0;height:0;}
+.left.card > #calendar .calendar-scroll:hover::-webkit-scrollbar{width:6px;height:6px;}
+.left.card > #calendar .calendar-scroll:hover::-webkit-scrollbar-thumb{
+  background:color-mix(in srgb,var(--muted) 45%,transparent);
+  border-radius:999px;
+}
+.left.card > #calendar .calendar-scroll:hover::-webkit-scrollbar-track{background:transparent;}
 
 /* Preview containment: outer card masks overflow while inner scroller handles the scroll. */
 .preview-card{
@@ -735,7 +758,6 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 /* The calendar stack now uses token spacing so the live route matches the preview cadence. */
 .calendar-actions{
   margin:0;
-  margin-block-start:var(--space-5);
 }
 /*
  * Softly elevate the Today button and stretch it full-width so it reads as the
@@ -767,17 +789,23 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   box-shadow:0 6px 18px color-mix(in srgb,var(--brand) 18%, transparent);
 }
 .stay-note-row{
-  display:flex;
+  /* Grid keeps Arrival/Departure + ETA/ETD on one line with flexible inputs. */
+  display:grid;
+  grid-template-columns:auto minmax(0,1fr) auto minmax(0,1fr);
+  align-items:center;
   gap:var(--space-3);
-  flex-wrap:wrap;
   margin:0;
-  margin-block-start:var(--space-4);
 }
-.stay-note{display:flex;align-items:center;gap:var(--space-2);min-width:0}
-.stay-note-button{
-  min-height:36px;
+.calendar-control{
+  min-block-size:calc(var(--space-6) + var(--space-3));
   padding-inline:var(--space-3);
+  padding-block:var(--space-1);
   border-radius:12px;
+}
+.stay-note-button{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
   background:var(--surface);
   color:var(--text-primary);
   border:1px solid var(--border);
@@ -787,11 +815,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  min-height:36px;
-  padding-inline:var(--space-3);
   min-width:4.5rem;
+  inline-size:100%;
   border:1px solid var(--border-hairline);
-  border-radius:999px;
+  border-radius:12px;
   background:var(--surface);
   color:var(--text-primary);
   font:inherit;
@@ -815,11 +842,21 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .stay-time-input::placeholder{color:var(--text-muted);}
 @media(max-width:720px){
-  .stay-note-row{gap:var(--space-2)}
-  .stay-note{flex:1 1 100%}
-  .stay-note-button{flex:0 0 auto}
+  .stay-note-row{
+    grid-template-columns:minmax(0,1fr) minmax(0,1fr);
+    gap:var(--space-2);
+    row-gap:var(--space-3);
+  }
 }
-.guests-header{align-items:center;gap:var(--space-3)}
+.guest-section{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-3);
+}
+.guests-header{
+  align-items:center;
+  gap:var(--space-3);
+}
 .guests-header .guest-tools{
   margin-inline-start:auto;
   display:flex;
@@ -827,9 +864,35 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   gap:var(--space-2);
   flex-wrap:wrap;
   justify-content:flex-end;
+  flex:1 1 auto;
+  min-width:0;
 }
-.guests-header .guest-input{flex:1 1 auto;min-width:8rem}
+.guests-header .guest-input{
+  flex:1 1 min(16rem,100%);
+  min-width:0;
+}
 .guests-header .icon-btn{flex:0 0 auto}
+.guest-list{
+  /* Reserve room for chips and fall back to an internal scroll when crowded. */
+  display:flex;
+  gap:var(--space-2);
+  flex-wrap:wrap;
+  min-width:0;
+  padding-block:var(--space-1);
+  min-block-size:calc(var(--space-6) + var(--space-3));
+  max-block-size:calc(var(--space-6) * 4);
+  overflow:auto;
+  scrollbar-width:none;
+  overscroll-behavior:contain;
+}
+.guest-list:hover{scrollbar-width:thin;}
+.guest-list::-webkit-scrollbar{width:0;height:0;}
+.guest-list:hover::-webkit-scrollbar{width:6px;height:6px;}
+.guest-list:hover::-webkit-scrollbar-thumb{
+  background:color-mix(in srgb,var(--muted) 45%,transparent);
+  border-radius:999px;
+}
+.guest-list:hover::-webkit-scrollbar-track{background:transparent;}
 .stay-time-layer{position:fixed;inset:0;z-index:1200}
 .stay-time-scrim{position:absolute;inset:0;background:transparent}
 /* Anchor the floating picker near its trigger without breaking layout flow. */

--- a/style.css
+++ b/style.css
@@ -353,29 +353,88 @@ body{
   overflow:clip;
 }
 .left.card > #calendar{
+  /* Grid rows lock the header, grid, and control stack without requiring JS to juggle layout. */
+  --calendar-row-gap:var(--space-5);
+  --calendar-toolbar-gap:var(--space-3);
+  --calendar-weekday-gap:var(--space-2);
+  --calendar-cell-gap:calc(var(--space-2) - (var(--space-1) / 2));
+  --calendar-nav-gap:var(--space-3);
+  --calendar-nav-size:calc(var(--space-5) + var(--space-4));
+  --calendar-control-height:calc(var(--space-6) + var(--space-3));
+  --calendar-month-size:1rem;
+  --calendar-year-size:0.75rem;
+  --calendar-grid-scale:1;
+  display:grid;
+  grid-template-rows:auto minmax(0,1fr) auto auto auto;
+  row-gap:var(--calendar-row-gap);
+  flex:1 1 auto;
+  min-block-size:0; /* Allow the 1fr calendar row to shrink instead of forcing the card taller. */
+  overflow:hidden;
+}
+.left.card > #calendar .toolbar{
+  margin:0;
+  margin-block-end:var(--calendar-toolbar-gap);
+}
+.left.card > #calendar .calendar-scroll{
+  /* Grid viewport keeps the month visible while allowing scale/scroll fallbacks without impacting nearby controls. */
+  position:relative;
   display:flex;
   flex-direction:column;
-  gap:var(--space-5);
+  gap:var(--calendar-weekday-gap);
+  min-block-size:0;
+  padding-block-end:var(--space-4);
+  overflow:hidden;
+}
+.left.card > #calendar .calendar-scroll__content{
+  display:flex;
+  flex-direction:column;
+  gap:var(--calendar-weekday-gap);
+  /* Scaling happens on the inner stack so transform avoids reflow while the row height stays pegged by the grid track. */
+  transform:scale(var(--calendar-grid-scale, 1));
+  transform-origin:top center;
+}
+.left.card > #calendar .calendar-scroll__content > .grid{gap:var(--calendar-cell-gap);}
+.left.card > #calendar .calendar-scroll__content .dow{margin:0;}
+.left.card > #calendar .calendar-scroll__content .days{
   flex:1 1 auto;
   min-block-size:0;
 }
-.left.card > #calendar .calendar-scroll{
-  /* Keep the interactive stack scrollable with the disappearing scrollbar pattern. */
-  display:flex;
-  flex-direction:column;
-  gap:var(--space-4);
-  flex:1 1 auto;
-  min-block-size:0;
-  padding-block-end:var(--space-4);
+/* Compact density tokens collapse spacing when the card height drops under desktop guardrails. */
+.left.card > #calendar[data-density='compact']{
+  --calendar-row-gap:var(--space-4);
+  --calendar-toolbar-gap:var(--space-2);
+  --calendar-weekday-gap:var(--space-1);
+  --calendar-cell-gap:calc(var(--space-2) - var(--space-1));
+  --calendar-nav-gap:var(--space-2);
+  --calendar-nav-size:calc(var(--space-5) + var(--space-3));
+  --calendar-control-height:calc(var(--space-6) + var(--space-2));
+  --calendar-month-size:calc(1rem - (var(--space-1) / 4));
+  --calendar-year-size:calc(0.75rem - (var(--space-1) / 4));
+}
+.left.card > #calendar[data-density='compressed']{
+  --calendar-row-gap:var(--space-3);
+  --calendar-toolbar-gap:calc(var(--space-2) - (var(--space-1) / 2));
+  --calendar-weekday-gap:var(--space-1);
+  --calendar-cell-gap:calc(var(--space-2) - var(--space-1));
+  --calendar-nav-gap:calc(var(--space-2) - (var(--space-1) / 2));
+  --calendar-nav-size:calc(var(--space-4) + var(--space-3));
+  --calendar-control-height:calc(var(--space-6) + var(--space-1));
+  --calendar-month-size:calc(1rem - (var(--space-1) / 2));
+  --calendar-year-size:calc(0.75rem - (var(--space-1) / 2));
+}
+/* Calendar scroll containment only enables native scrolling when the column falls below the desktop height guardrail. */
+.left.card > #calendar.calendar--scrollable{
+  overflow:visible;
+}
+.left.card > #calendar.calendar--scrollable .calendar-scroll{
   overflow:auto;
   overscroll-behavior:contain;
   scrollbar-gutter:stable both-edges; /* Fallback guard so native gutters stay stable if the overlay is unavailable. */
   -webkit-overflow-scrolling:touch;
   scrollbar-width:none; /* Firefox: suppress the native thumb so the overlay handles visibility. */
-  position:relative;
 }
 /* WebKit/Blink: hide the scrollbar track entirely so the overlay can paint without shrinking content. */
-.left.card > #calendar .calendar-scroll::-webkit-scrollbar{display:none;}
+.left.card > #calendar.calendar--scrollable .calendar-scroll::-webkit-scrollbar{display:none;}
 
 /* Overlay thumb stays pinned to the trailing edge and fades in when the user scrolls or hovers. */
 .calendar-scroll__thumb{
@@ -765,15 +824,33 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .activity-row-rail{display:flex;align-items:center;gap:var(--space-2);flex-wrap:nowrap;min-width:0;flex:0 0 auto;}
 .stick-right{justify-content:flex-end}
 .section{margin-top:16px}
-#calMonth{font-weight:700;font-size:16px}
-#calYear{color:var(--muted);font-size:12px}
+#calMonth{font-weight:700;font-size:var(--calendar-month-size,1rem)}
+#calYear{color:var(--muted);font-size:var(--calendar-year-size,0.75rem)}
 .toolbar{
   margin:0;
   margin-block-end:var(--space-3);
 }
-.toolbar .nav-row{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:nowrap;width:100%}
+.left.card > #calendar .toolbar{
+  margin-block-end:var(--calendar-toolbar-gap);
+}
+.left.card > #calendar .toolbar .nav-row{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:var(--calendar-nav-gap);
+  flex-wrap:nowrap;
+  inline-size:100%;
+}
 .toolbar .monthyear-col{display:flex;flex-direction:column;line-height:1.05;align-items:center;text-align:center;flex:0 0 140px;white-space:nowrap}
-.toolbar .nav-btn{width:36px;height:36px;display:flex;align-items:center;justify-content:center;border-radius:10px;padding:0}
+.left.card > #calendar .toolbar .nav-btn{
+  inline-size:var(--calendar-nav-size);
+  block-size:var(--calendar-nav-size);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:10px;
+  padding:0;
+}
 /* The calendar stack now uses token spacing so the live route matches the preview cadence. */
 .calendar-actions{
   margin:0;
@@ -816,7 +893,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   margin:0;
 }
 .calendar-control{
-  min-block-size:calc(var(--space-6) + var(--space-3));
+  min-block-size:var(--calendar-control-height);
   padding-inline:var(--space-3);
   padding-block:var(--space-1);
   border-radius:12px;
@@ -891,27 +968,29 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   min-width:0;
 }
 .guests-header .icon-btn{flex:0 0 auto}
+.guest-pill-viewport{
+  /* Keep chips inside the calendar rail while allowing long lists to scroll in place. */
+  min-block-size:calc(var(--space-6) + var(--space-3));
+  max-block-size:calc(var(--space-6) * 4);
+  overflow:auto;
+  padding-block:var(--space-1);
+  scrollbar-width:none;
+  overscroll-behavior:contain;
+}
+.guest-pill-viewport::-webkit-scrollbar{width:0;height:0;}
+.guest-pill-viewport:hover{scrollbar-width:thin;}
+.guest-pill-viewport:hover::-webkit-scrollbar{width:6px;height:6px;}
+.guest-pill-viewport:hover::-webkit-scrollbar-thumb{
+  background:color-mix(in srgb,var(--muted) 45%,transparent);
+  border-radius:999px;
+}
+.guest-pill-viewport:hover::-webkit-scrollbar-track{background:transparent;}
 .guest-list{
-  /* Reserve room for chips and fall back to an internal scroll when crowded. */
   display:flex;
   gap:var(--space-2);
   flex-wrap:wrap;
   min-width:0;
-  padding-block:var(--space-1);
-  min-block-size:calc(var(--space-6) + var(--space-3));
-  max-block-size:calc(var(--space-6) * 4);
-  overflow:auto;
-  scrollbar-width:none;
-  overscroll-behavior:contain;
 }
-.guest-list:hover{scrollbar-width:thin;}
-.guest-list::-webkit-scrollbar{width:0;height:0;}
-.guest-list:hover::-webkit-scrollbar{width:6px;height:6px;}
-.guest-list:hover::-webkit-scrollbar-thumb{
-  background:color-mix(in srgb,var(--muted) 45%,transparent);
-  border-radius:999px;
-}
-.guest-list:hover::-webkit-scrollbar-track{background:transparent;}
 .stay-time-layer{position:fixed;inset:0;z-index:1200}
 .stay-time-scrim{position:absolute;inset:0;background:transparent}
 /* Anchor the floating picker near its trigger without breaking layout flow. */
@@ -985,7 +1064,6 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .guest-section{
   /* Hairline divider + spacing align the relocated guest block with the calendar controls. */
   margin:0;
-  margin-block-start:var(--space-5);
   padding-block-start:var(--space-3);
   border-top:1px solid var(--border-hairline);
 }


### PR DESCRIPTION
Context: Calendar column visual polish
Approach: Routed the calendar stack through a contained scroll shell, reshaped the arrival/departure controls into a shared grid row, and updated guest tools/pills so everything fits without overflow.
Guardrails upheld: Calendar/activities row heights, token spacing, preview width, keyboard flows.
Screenshots: ![Calendar column](browser:/invocations/diajusbe/artifacts/artifacts/calendar-full.png)
Notes: Visual QA in Chromium @1280x720.

------
https://chatgpt.com/codex/tasks/task_e_68e6b4bd22dc83308b091af234a37f9b