### PR TITLE
Preserve activities scroll position on add

### DIFF
--- a/script.js
+++ b/script.js
@@ -1364,6 +1364,8 @@
 
       const activate = ()=>{
         if(disabled){ return; }
+        const listNode = activitiesEl?.parentElement || activitiesEl;
+        const savedScrollTop = listNode ? listNode.scrollTop : null; // preserve & restore scrollTop around row add
         const actives = state.guests.filter(g=>g.active);
         if(actives.length===0){ alert('Toggle at least one guest pill before assigning.'); return; }
         const d = getOrCreateDay(dateK);
@@ -1372,6 +1374,14 @@
         actives.forEach(g=> target.guestIds.add(g.id));
         sortDayEntries(dateK);
         renderActivities(); markPreviewDirty(); renderPreview();
+        if(listNode && savedScrollTop !== null){
+          const restore = () => { listNode.scrollTop = savedScrollTop; };
+          if(typeof requestAnimationFrame === 'function'){
+            requestAnimationFrame(restore);
+          }else{
+            restore();
+          }
+        }
       };
 
       // Guard against accidental scroll taps via shared pointer controller.


### PR DESCRIPTION
Context:
- Activities column scrolled position jumped when adding guests via row activation.

Approach:
- Capture the Activities scroller's scrollTop before the add handler mutates state and re-renders, then restore it on the next frame.
- Added an inline comment noting the scrollTop preservation around the row add.

Guardrails upheld:
- Activities row height and ordering untouched; only scroll position is persisted.
- No changes to data contracts, chip logic, or focus behavior.

Screenshots:
- Activities column stays put after adding a row: ![Activities column remains steady after add](browser:/invocations/eheungqb/artifacts/artifacts/activities-scroll.png)

Notes:
- Verified via Playwright automation that the scrollTop remains unchanged after pointer and keyboard activation.


------
https://chatgpt.com/codex/tasks/task_e_68e741b8b93c83308e991aead3fd637e