### PR TITLE
Preserve activities scroll when adding guests

### DIFF
--- a/script.js
+++ b/script.js
@@ -382,6 +382,7 @@
   const calMonth=$('#calMonth'), calYear=$('#calYear'), calGrid=$('#calGrid'), dow=$('#dow');
   const arrivalEtaInput=$('#arrivalEta'), departureEtdInput=$('#departureEtd');
   const dayTitle=$('#dayTitle'), activitiesEl=$('#activities'), email=$('#email');
+  const activitiesScroller=document.querySelector('.activities__scroller');
   const seasonIndicator=$('#seasonIndicator'), seasonValue=$('#seasonValue');
   const guestsEl=$('#guests'), guestName=$('#guestName');
   const toggleAllBtn=$('#toggleAll');
@@ -1093,12 +1094,26 @@
   function addGuest(name){
     const trimmed = name.trim();
     if(!trimmed) return;
+    const previousScrollTop = activitiesScroller ? activitiesScroller.scrollTop : null;
+    const restoreActivitiesScroll = () => {
+      if(activitiesScroller && previousScrollTop != null){
+        activitiesScroller.scrollTop = previousScrollTop;
+      }
+    };
     const id = (crypto.randomUUID ? crypto.randomUUID() : `g_${Date.now()}_${Math.random().toString(16).slice(2)}`);
     const color = state.colors[state.guests.length % state.colors.length];
     const g = {id,name: trimmed, color, active:true, primary: state.guests.length===0};
     state.guests.push(g);
     guestName.value='';
     renderGuests(); renderActivities(); markPreviewDirty(); renderPreview();
+    if(previousScrollTop != null){
+      // preserve/restore scrollTop around add-guest; keep list keys stable
+      if(typeof requestAnimationFrame === 'function'){
+        requestAnimationFrame(restoreActivitiesScroll);
+      }else{
+        setTimeout(restoreActivitiesScroll,0);
+      }
+    }
   }
   function renderGuests(){
     syncDinnerGuests();


### PR DESCRIPTION
Context: Prevent the Activities column from jumping back to the top when a new guest is added.
Approach: Capture the Activities scroller scrollTop before dispatching the guest add flow and restore it on the next frame after renders so the DOM node stays stable.
Guardrails upheld: Activities row height, tokens, chip logic, preview width, iPad layout.
Screenshots: ![Activities scroll preserved](browser:/invocations/hhhsgdph/artifacts/artifacts/activities-guest-scroll.png)
Notes: Manual QA — scrolled Activities list + add guest via Enter/click keeps scrollTop in place.

------
https://chatgpt.com/codex/tasks/task_e_68e745cd107083309664bcae39836124