### PR TITLE
Default new SPA appointments to 8:00am

### DIFF
--- a/script.js
+++ b/script.js
@@ -189,7 +189,7 @@
     { id: 'in-room', label: 'In-Room' }
   ];
 
-  const defaultSpaStartTime = '14:00';
+  const defaultSpaStartTime = '08:00'; // Default SPA time = 8:00am when unset.
   const generateSpaEntryId = () => (crypto.randomUUID ? crypto.randomUUID() : `spa_${Date.now()}_${Math.random().toString(16).slice(2)}`);
 
   const SPA_CATEGORY_BLUEPRINT = [


### PR DESCRIPTION
## Summary
- set the shared default SPA start time constant to 8:00am so new appointments prefill the updated default when they open
- document the behavior with an inline comment to keep intent clear

## Testing
- Manually opened the SPA modal to verify 8:00am defaults for new bookings

## Screenshots
- ![SPA modal defaulting to 8am](browser:/invocations/ydsaixeo/artifacts/artifacts/spa-default-8am.png)


------
https://chatgpt.com/codex/tasks/task_e_68e7489f3dd88330bead8c057b6350db