### PR TITLE
Clamp AM/PM toggle navigation

### DIFF
--- a/time-picker.js
+++ b/time-picker.js
@@ -964,9 +964,11 @@
       meridiemGroup = group;
       const meridiemIdPrefix = `time-picker-meridiem-${Date.now()}-${Math.random().toString(16).slice(2)}`;
       const stepMeridiem = direction => {
-        if(!meridiems.length) return;
+        if(!meridiems.length || !direction) return;
         const index = meridiems.indexOf(currentMeridiem);
-        const nextIndex = (index + direction + meridiems.length) % meridiems.length;
+        const safeIndex = index === -1 ? (direction > 0 ? 0 : meridiems.length - 1) : index;
+        const nextIndex = Math.max(0, Math.min(meridiems.length - 1, safeIndex + direction));
+        if(nextIndex === safeIndex) return; // AM/PM is non-cyclic; clamp index 0..1.
         const nextValue = meridiems[nextIndex];
         syncMeridiem(nextValue);
       };


### PR DESCRIPTION
Context: Prevent the shared AM/PM column from looping when scrolling.
Approach: Clamp the meridiem step handler so AM/PM behaves like a non-cyclic two-item list, ignoring deltas past either end.
Guardrails upheld: Picker styling/layout untouched, shared wheel physics preserved, no prop or API changes.
Screenshots: ![Time picker AM selected](browser:/invocations/nayemfrg/artifacts/artifacts/time-picker-am-pm.png)
Notes: Column still snaps and updates other picker columns without regressions.

------
https://chatgpt.com/codex/tasks/task_e_68e74bc791608330822e9ef803e51590