### PR TITLE
Add hover scroll to AM/PM toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -1362,9 +1362,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .time-picker-column::after{content:"";position:absolute;left:8px;right:8px;top:50%;height:44px;margin-top:-22px;border-radius:12px;border:1px solid rgba(42,107,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);pointer-events:none;}
 .time-picker-meridiem-static{font-size:18px;font-weight:600;color:var(--muted);display:flex;align-items:center;justify-content:center;height:176px;padding:0 4px;}
 .time-picker-column.time-picker-meridiem::after{content:none;}
-.time-picker-meridiem-toggle{width:100%;min-height:176px;padding:12px;border-radius:18px;border:1px solid var(--border-hairline);background:var(--surface,#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.08);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;}
+.time-picker-meridiem-toggle{width:100%;min-height:176px;padding:12px;border-radius:18px;border:1px solid var(--border-hairline);background:var(--surface,#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.08);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;position:relative;}
 .time-picker-meridiem-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.time-picker-meridiem-option{border:0;border-radius:999px;padding:8px 18px;font:inherit;font-size:14px;font-weight:600;color:var(--muted);background:transparent;cursor:pointer;transition:background-color .18s ease,color .18s ease,box-shadow .18s ease;}
+.time-picker-meridiem-ring{position:absolute;top:0;left:0;border-radius:999px;border:1px solid rgba(42,107,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);pointer-events:none;transform:translate3d(0,0,0);transition:transform .16s ease;}
+.time-picker-meridiem-option{border:0;border-radius:999px;padding:8px 18px;font:inherit;font-size:14px;font-weight:600;color:var(--muted);background:transparent;cursor:pointer;transition:background-color .18s ease,color .18s ease,box-shadow .18s ease;position:relative;z-index:1;}
 .time-picker-meridiem-option.selected{background:var(--brand);color:#fff;box-shadow:0 12px 24px rgba(42,107,255,.24);}
 .time-picker-meridiem-option:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 @media(hover:hover){.time-picker-meridiem-option:not(.selected):hover{background:color-mix(in srgb,var(--brand) 14%,var(--surface));color:var(--brand);}}


### PR DESCRIPTION
## Summary
- enable wheel and trackpad scrolling on the shared AM/PM toggle with two-item clamping
- add a selection ring that mirrors the hour/minute wheel styling and defaults to PM when unset
- preserve existing click/tap behavior while reusing the wheel snap timing for smooth hover gestures

## Testing
- Manual QA on `time-picker-demo.html`

## Screenshot
- ![Time picker AM/PM ring](browser:/invocations/ucvzyona/artifacts/artifacts/time-picker-ampm.png)


------
https://chatgpt.com/codex/tasks/task_e_68e7518297448330948ca52d35b87e5a