### PR TITLE
Default ETA/ETD notes when unset

### DIFF
--- a/script.js
+++ b/script.js
@@ -345,6 +345,12 @@
   const TimePickerKit = window.TimePickerKit || {};
   const { createTimePicker } = TimePickerKit;
 
+  // Default ETA/ETD when unset: 12:00pm / 1:00pm.
+  const stayNoteDefaults = Object.freeze({
+    arrival: '12:00',
+    departure: '13:00'
+  });
+
 
 
   // ---------- State ----------
@@ -353,8 +359,8 @@
     focus: zero(new Date()),
     arrival: null,
     departure: null,
-    arrivalNote: null, // Visual ETA note only; intentionally not wired into stay logic.
-    departureNote: null, // Visual ETD note only; intentionally not wired into stay logic.
+    arrivalNote: stayNoteDefaults.arrival, // Visual ETA note only; intentionally not wired into stay logic.
+    departureNote: stayNoteDefaults.departure, // Visual ETD note only; intentionally not wired into stay logic.
     guests: [], // {id,name,color,active,primary}
     colors: ['#6366f1','#06b6d4','#22c55e','#f59e0b','#ef4444','#a855f7','#10b981','#f43f5e','#0ea5e9'],
     schedule: {}, // dateKey -> [{type:'activity',title,start,end,guestIds:Set}]
@@ -6062,7 +6068,12 @@
   if(clearAllBtn){
     clearAllBtn.onclick=()=>{
       if(!confirm('Clear all itinerary data?')) return;
-      state.arrival=null; state.departure=null; state.arrivalNote=null; state.departureNote=null; state.guests.length=0; state.schedule={};
+      state.arrival=null;
+      state.departure=null;
+      state.arrivalNote=stayNoteDefaults.arrival;
+      state.departureNote=stayNoteDefaults.departure;
+      state.guests.length=0;
+      state.schedule={};
       markPreviewDirty();
       renderAll();
     };


### PR DESCRIPTION
Context: Default ETA/ETD state when building a new itinerary.
Approach: Seed the stay note state with 12:00pm / 1:00pm defaults and reapply those defaults when the itinerary is cleared so blank sessions show the expected times without overwriting existing edits.
Guardrails upheld: Calendar layout, activity row sizing, shared time picker behavior, preview layout.
Screenshots: ![Default ETA/ETD inputs](browser:/invocations/siydxdng/artifacts/artifacts/default-eta-etd.png)
Notes: Verified that editing an ETA/ETD value persists within the session and that clearing the itinerary returns the controls to the new defaults.

------
https://chatgpt.com/codex/tasks/task_e_68e7571b710c833091277a63e05f728e