### PR TITLE
Align spa, custom, and dinner modal layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -2223,14 +2223,29 @@
       }
     }) : null;
 
+    const layout=document.createElement('div');
+    layout.className='modal-sections dinner-layout';
+    body.appendChild(layout);
+
+    const timeSection=document.createElement('section');
+    // Unified modal layout structure keeps dinner controls aligned with spa/custom flows.
+    timeSection.className='modal-section dinner-section';
+    const timeHeading=document.createElement('h3');
+    timeHeading.textContent='Time';
+    timeSection.appendChild(timeHeading);
+
+    const pickerShell=document.createElement('div');
+    pickerShell.className='dinner-picker-shell';
     if(!timePicker){
       const fallback = document.createElement('div');
       fallback.className = 'time-picker-fallback';
       fallback.textContent = 'Time picker failed to load.';
-      body.appendChild(fallback);
+      pickerShell.appendChild(fallback);
     }else{
-      body.appendChild(timePicker.element);
+      pickerShell.appendChild(timePicker.element);
     }
+    timeSection.appendChild(pickerShell);
+    layout.appendChild(timeSection);
 
     dialog.appendChild(body);
 
@@ -2525,11 +2540,11 @@
     // service → duration → start time → therapist → location. Mutating one
     // step immediately cascades the data updates so the preview stays in sync.
     const layout=document.createElement('div');
-    layout.className='spa-layout';
+    layout.className='modal-sections spa-layout';
     body.appendChild(layout);
 
     const guestSection=document.createElement('section');
-    guestSection.className='spa-section spa-section-guests spa-block spa-guest-card spa-detail-card spa-detail-card-guests';
+    guestSection.className='modal-section spa-section spa-section-guests spa-block spa-guest-card spa-detail-card spa-detail-card-guests';
     const guestHeader=document.createElement('div');
     guestHeader.className='spa-guest-header';
     const guestHeading=document.createElement('h3');
@@ -2749,7 +2764,7 @@
     }
 
     const serviceSection=document.createElement('section');
-    serviceSection.className='spa-section spa-section-services';
+    serviceSection.className='modal-section spa-section spa-section-services';
     const serviceCard=document.createElement('div');
     serviceCard.className='spa-block spa-service-card';
     const serviceHeading=document.createElement('h3');
@@ -3062,7 +3077,7 @@
     layout.appendChild(serviceSection);
 
     const detailsSection=document.createElement('section');
-    detailsSection.className='spa-section spa-section-details';
+    detailsSection.className='modal-section spa-section spa-section-details';
     const detailsGrid=document.createElement('div');
     // SPA right pane → 2×4 grid; pills → scrollable hairline lists.
     detailsGrid.className='spa-details-grid';
@@ -4057,7 +4072,7 @@
 
     const titleSection=document.createElement('section');
     // Reuse the spa card shell so Custom cards share the established spacing + radius tokens.
-    titleSection.className='custom-section custom-section-title spa-section spa-block custom-card custom-title-card';
+    titleSection.className='modal-section custom-section custom-section-title spa-section spa-block custom-card custom-title-card';
     titleSection.setAttribute('role','group');
     const titleHeaderRow=document.createElement('div');
     titleHeaderRow.className='custom-title-header';
@@ -4141,14 +4156,14 @@
     dialog.appendChild(body);
 
     const layout=document.createElement('div');
-    layout.className='custom-layout';
+    layout.className='modal-sections custom-layout';
     body.appendChild(layout);
 
     // Custom modal grid: Title → cols 1–2, rows 1–3.
     layout.appendChild(titleSection);
 
     const timeSection=document.createElement('section');
-    timeSection.className='custom-section custom-section-time spa-section spa-block custom-card';
+    timeSection.className='modal-section custom-section custom-section-time spa-section spa-block custom-card';
     // Custom modal: Time section reflow; stack hourglass buttons on right; no internal scroll.
     const timeShell=document.createElement('div');
     timeShell.className='custom-time-shell';
@@ -4241,7 +4256,7 @@
     layout.appendChild(timeSection);
 
     const locationSection=document.createElement('section');
-    locationSection.className='custom-section custom-section-location spa-section spa-block custom-card';
+    locationSection.className='modal-section custom-section custom-section-location spa-section spa-block custom-card';
     const locationHeading=document.createElement('h3');
     locationHeading.id='custom-location-heading';
     locationHeading.textContent='Location (optional)';
@@ -4342,7 +4357,7 @@
     layout.appendChild(locationSection);
 
     const guestSection=document.createElement('section');
-    guestSection.className='custom-section custom-section-guests spa-section spa-block custom-card';
+    guestSection.className='modal-section custom-section custom-section-guests spa-section spa-block custom-card';
     const guestHeading=document.createElement('h3');
     guestHeading.textContent='Guests';
     guestSection.appendChild(guestHeading);

--- a/style.css
+++ b/style.css
@@ -1341,6 +1341,22 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   background:var(--surface);
   min-height:0;
 }
+/* Unified modal layout structure keeps spacing + hierarchy consistent across flows. */
+.modal-sections{
+  --modal-section-gap:clamp(var(--space-4),5vw,var(--space-5));
+  display:grid;
+  gap:var(--modal-section-gap);
+  align-content:flex-start;
+  grid-auto-flow:row;
+  grid-auto-rows:minmax(0,auto);
+  min-height:0;
+}
+.modal-section{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-4);
+  min-height:0;
+}
 .modal-footer{
   display:flex;
   align-items:center;
@@ -1354,8 +1370,11 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .modal-footer-start,.modal-footer-end{display:flex;align-items:center;gap:var(--space-3);}
 .modal-footer-end{justify-content:flex-end;}
 .dinner-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:24px;z-index:2000;}
-.dinner-dialog{background:#fff;border-radius:20px;min-width:280px;max-width:320px;width:100%;box-shadow:0 22px 44px rgba(12,18,32,.18);border:1px solid rgba(226,232,240,.8);display:flex;flex-direction:column;overflow:hidden;}
-.dinner-body{display:flex;justify-content:center;align-items:center;padding:var(--space-5);}
+.dinner-dialog{background:#fff;border-radius:20px;min-width:280px;max-width:384px;width:100%;box-shadow:0 22px 44px rgba(12,18,32,.18);border:1px solid rgba(226,232,240,.8);display:flex;flex-direction:column;overflow:hidden;}
+.dinner-body{display:flex;flex-direction:column;gap:var(--space-4);padding:clamp(var(--space-5),6vw,var(--space-6));}
+.dinner-layout{grid-template-columns:minmax(0,1fr);}
+.dinner-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;color:var(--ink);}
+.dinner-picker-shell{display:flex;justify-content:center;}
 .time-picker{display:flex;flex-direction:column;align-items:center;gap:16px;}
 .time-picker-wheels{display:flex;align-items:center;gap:12px;}
 .time-picker-column{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}
@@ -1474,11 +1493,8 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
  * can own all vertical overflow without forcing the shell to resize.
  */
 .spa-layout{
-  display:grid;
   grid-template-columns:repeat(2,minmax(0,1fr));
-  gap:24px;
   align-items:stretch;
-  min-height:0;
   flex:1 1 auto;
   grid-auto-rows:1fr;
 }
@@ -1605,10 +1621,8 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 }
 /* Custom modal → 4×4 grid; Title/Location/Time scroll; Guests non-scrollable. */
 .custom-layout{
-  display:grid;
   grid-template-columns:repeat(4,minmax(0,1fr));
   grid-template-rows:repeat(4,minmax(0,1fr));
-  gap:24px;
   flex:1 1 auto;
   min-height:0;
   align-content:start;


### PR DESCRIPTION
Context: Visual refresh to keep the spa, custom, and dinner editors consistent.
Approach: Introduced a shared modal grid/section scaffold, migrated each modal to that structure (with a heading for dinner), and tuned the spacing helpers so the pickers/cards stay aligned at every breakpoint.
Guardrails upheld: Activities row height, design tokens, unified time picker physics, spa grid behavior, guest assignment rules, iPad preview layout.
Screenshots: ![Spa modal layout](browser:/invocations/ihwjrmqg/artifacts/artifacts/spa-modal.png)
Notes: Verified spa, custom, and dinner modals at 1440px desktop.


------
https://chatgpt.com/codex/tasks/task_e_68e88a96a0d88330804d3d251927543d