### PR TITLE
Add wheel pickers to spa modal options

### DIFF
--- a/style.css
+++ b/style.css
@@ -1566,6 +1566,15 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 /* Guests: non-scrollable; note removed; Start Time vertically centered. */
 .spa-option-list-guests{flex:0 0 auto;overflow:visible;max-block-size:none;}
 .spa-option-list-guests.list-hairline{overflow:visible;}
+.spa-single-picker{align-items:center;display:flex;justify-content:center;padding:0;}
+.spa-single-picker.list-hairline{overflow:hidden;}
+.spa-single-picker .wheel-viewport{width:100%;height:44px;border-radius:12px;}
+.spa-single-picker .wheel-viewport::before,.spa-single-picker .wheel-viewport::after{display:none;}
+.spa-single-picker .wheel-list{width:100%;}
+.spa-single-picker .wheel-option{font-size:15px;font-weight:500;color:var(--ink);}
+.spa-single-picker .wheel-option.selected{color:var(--brand);}
+.spa-single-picker .wheel-option.disabled{color:var(--muted);}
+.spa-single-wheel{width:100%;}
 .spa-option-row{display:flex;align-items:center;gap:12px;padding:12px 16px;border:0;background:transparent;font:inherit;font-size:15px;font-weight:500;color:var(--ink);text-align:left;cursor:pointer;transition:background-color .16s ease,color .16s ease;}
 .spa-option-row + .spa-option-row{border-top:1px solid var(--hairline);}
 .spa-option-row.is-selected{color:var(--brand);}


### PR DESCRIPTION
## Summary
- convert the therapist, location, and duration rows in the spa modal to use single-value wheel pickers with accessible value announcements
- update the shared wheel controller to support non-looping lists and pointer clicks so the new pickers scroll and snap cleanly
- add styling for the spa single-value pickers to preserve layout tokens while showing one value at a time

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e8961cec008330902a540f2da935b8