### PR TITLE
Add inline time inputs synced with time picker wheels

### DIFF
--- a/style.css
+++ b/style.css
@@ -1379,6 +1379,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .time-picker-wheels{display:flex;align-items:center;gap:12px;}
 .time-picker-column{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}
 .time-picker-column::after{content:"";position:absolute;left:8px;right:8px;top:50%;height:44px;margin-top:-22px;border-radius:12px;border:1px solid rgba(42,107,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);pointer-events:none;}
+.time-picker-inline-field{width:100%;display:flex;justify-content:center;}
+.time-picker-inline-input{border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);padding:6px 14px;font:inherit;font-size:15px;color:var(--ink);min-width:148px;text-align:center;box-shadow:0 2px 6px rgba(15,23,42,.08);}
+.time-picker-inline-input:focus{outline:2px solid var(--brand);outline-offset:2px;}
+.time-picker-inline-input[aria-invalid='true']{border-color:var(--brand);box-shadow:0 0 0 2px rgba(42,107,255,.16);}
 .time-picker-meridiem-static{font-size:18px;font-weight:600;color:var(--muted);display:flex;align-items:center;justify-content:center;height:176px;padding:0 4px;}
 .time-picker-column.time-picker-meridiem::after{content:none;}
 .time-picker-meridiem-toggle{width:100%;min-height:176px;padding:12px;border-radius:18px;border:1px solid var(--border-hairline);background:var(--surface,#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.08);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;position:relative;}

--- a/utils/format.js
+++ b/utils/format.js
@@ -4,6 +4,12 @@
   // Shared formatter keeps every surface aligned on the h:mmam/pm spec.
   const pad = value => String(Math.trunc(Math.abs(value))).padStart(2,'0');
 
+  const upperMeridiem = value => {
+    if(typeof value !== 'string') return null;
+    const trimmed = value.trim().toUpperCase();
+    return trimmed === 'AM' || trimmed === 'PM' ? trimmed : null;
+  };
+
   const normalizeHour = value => {
     if(!Number.isFinite(value)) return null;
     return ((Math.trunc(value) % 24) + 24) % 24;
@@ -84,7 +90,69 @@
     return `${displayHour}:${pad(minute)}${meridiem}`;
   };
 
+  const formatMeridiemTime = value => {
+    const parts = extractTimeParts(value);
+    if(!parts) return '';
+    const minute = normalizeMinute(parts.minute);
+    if(minute == null) return '';
+    const meridiem = upperMeridiem(value?.meridiem) || (normalizeHour(parts.hour) ?? 0) >= 12 ? 'PM' : 'AM';
+    let hour = Number(parts.hour);
+    if(!Number.isFinite(hour)) return '';
+    hour = Math.trunc(hour);
+    if(meridiem === 'AM'){
+      hour = ((hour % 12) + 12) % 12;
+    }else{
+      const normalized = ((hour % 12) + 12) % 12;
+      hour = normalized === 0 ? 12 : normalized;
+    }
+    if(hour === 0){
+      hour = 12;
+    }
+    if(hour < 0){
+      hour = ((hour % 12) + 12) % 12 || 12;
+    }
+    return `${hour}:${pad(minute)} ${meridiem}`;
+  };
+
+  const parseFlexibleMeridiemTime = value => {
+    if(value == null) return null;
+    const compact = String(value).trim();
+    if(!compact) return null;
+    const normalised = compact.replace(/\s+/g, '').toLowerCase();
+    if(normalised.length < 3) return null;
+    const meridiem = normalised.slice(-2);
+    if(meridiem !== 'am' && meridiem !== 'pm') return null;
+    const body = normalised.slice(0, -2);
+    if(!body) return null;
+    let hour = null;
+    let minute = 0;
+    if(body.includes(':')){
+      const parts = body.split(':');
+      if(parts.length !== 2) return null;
+      const [rawHour, rawMinute] = parts;
+      if(!/^\d{1,2}$/.test(rawHour) || !/^\d{2}$/.test(rawMinute)) return null;
+      hour = Number(rawHour);
+      minute = Number(rawMinute);
+    }else{
+      if(!/^\d{1,4}$/.test(body)) return null;
+      if(body.length <= 2){
+        hour = Number(body);
+      }else{
+        const rawHour = body.slice(0, body.length - 2);
+        const rawMinute = body.slice(-2);
+        if(!/^\d{1,2}$/.test(rawHour) || !/^\d{2}$/.test(rawMinute)) return null;
+        hour = Number(rawHour);
+        minute = Number(rawMinute);
+      }
+    }
+    if(!Number.isInteger(hour) || hour < 1 || hour > 12) return null;
+    if(!Number.isInteger(minute) || minute < 0 || minute > 59) return null;
+    return { hour, minute, meridiem: meridiem.toUpperCase() };
+  };
+
   global.CHSFormatUtils = Object.assign({}, global.CHSFormatUtils, {
-    formatTimeDisplay
+    formatTimeDisplay,
+    formatMeridiemTime,
+    parseFlexibleMeridiemTime
   });
 })(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- add a compact inline time field beneath the shared wheel picker and keep it in sync with hour/minute/meridiem changes
- expand the shared formatter to parse typed AM/PM strings like “830pm” and surface a normalized `8:30 PM` display
- style the new field with existing tokens and reuse wheel APIs so dinner, spa, ETA/ETD all pick up the feature automatically

## Testing
- Playwright: dinner modal accepts `7:30pm` and formats to `7:30 PM`; spa modal rejects disallowed combinations and accepts `7:10am`

## Screenshots
- ![Inline input under dinner & spa pickers](browser:/invocations/nzdvhexi/artifacts/artifacts/time-picker-demo.png)


------
https://chatgpt.com/codex/tasks/task_e_68e8a72f1e688330aadf9c5f63b84211