### PR TITLE
Align dinner modal layout with responsive reference

### DIFF
--- a/dinner-modal-preview.html
+++ b/dinner-modal-preview.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Dinner Modal Layout Preview</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    :root{
+      color-scheme:light;
+    }
+    body{
+      margin:0;
+      padding:32px clamp(24px,5vw,48px);
+      font:15px/1.45 -apple-system,system-ui,"Helvetica Neue",Segoe UI,Roboto,sans-serif;
+      background:var(--color-bg);
+      color:var(--ink);
+      display:flex;
+      flex-direction:column;
+      gap:32px;
+    }
+    h1{margin:0;font-size:28px;font-weight:650;letter-spacing:-0.01em;color:var(--ink);}
+    p{margin:0;color:var(--muted);max-width:720px;}
+    [data-preview-root]{display:flex;flex-direction:column;gap:32px;}
+    .preview-section{display:flex;flex-direction:column;gap:16px;}
+    .preview-section-title{margin:0;font-size:18px;font-weight:600;letter-spacing:0.01em;color:var(--ink);}
+    .preview-grid{display:grid;gap:28px;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));align-items:start;}
+    .preview-card{display:flex;flex-direction:column;gap:12px;align-items:stretch;}
+    .preview-label{font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--muted);}
+    .preview-overlay{position:relative;inset:auto;background:transparent;padding:0;z-index:1;display:flex;justify-content:center;}
+    .preview-overlay .dinner-dialog{margin:0 auto;}
+    .preview-overlay--desktop{--dinner-modal-width:560px;--dinner-modal-min-height:360px;--dinner-modal-max-height:420px;--dinner-time-visual-min-height:112px;}
+    .preview-overlay--ipad{--dinner-modal-width:520px;--dinner-modal-min-height:340px;--dinner-modal-max-height:400px;--dinner-time-visual-min-height:100px;}
+    .preview-overlay--mobile{--dinner-modal-width:360px;--dinner-modal-min-height:360px;--dinner-modal-max-height:420px;--dinner-time-visual-min-height:92px;}
+    @media (prefers-color-scheme: dark){
+      body{background:var(--color-bg);color:var(--ink);}
+    }
+  </style>
+  <script src="time-picker.js"></script>
+  <script defer src="dinner-modal-preview.js"></script>
+</head>
+<body>
+  <h1>Dinner Modal Responsive Preview</h1>
+  <p>Preview the Dinner modal’s Add and Edit layouts across desktop, iPad, and mobile breakpoints without tying into the live scheduler state.</p>
+  <div data-preview-root></div>
+</body>
+</html>

--- a/dinner-modal-preview.js
+++ b/dinner-modal-preview.js
@@ -1,0 +1,147 @@
+(function(){
+  const addIconSvg = '<svg viewBox="0 0 256 256" aria-hidden="true" focusable="false"><circle cx="128" cy="128" r="112" fill="none" stroke="currentColor" stroke-width="16"/><path d="M 80,128 H 176" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round"/><path d="M 128,80 V 176" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round"/></svg>';
+  const saveIconSvg = '<svg viewBox="-3 -3 24 24" aria-hidden="true" focusable="false"><path d="M2 0h11.22a2 2 0 0 1 1.345.52l2.78 2.527A2 2 0 0 1 18 4.527V16a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2zm0 2v14h14V4.527L13.22 2H2zm4 8h6a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2zm0 2v4h6v-4H6zm7-9a1 1 0 0 1 1 1v3a1 1 0 0 1-2 0V4a1 1 0 0 1 1-1zM5 3h5a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm1 3h3V5H6v1z" fill="currentColor"/></svg>';
+  const deleteIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 4a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2h4a1 1 0 1 1 0 2h-1.069l-.867 12.142A2 2 0 0 1 17.069 22H6.93a2 2 0 0 1-1.995-1.858L4.07 8H3a1 1 0 0 1 0-2h4V4zm2 2h6V4H9v2zM6.074 8l.857 12H17.07l.857-12H6.074zM10 10a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0v-6a1 1 0 0 1 1-1zm4 0a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0v-6a1 1 0 0 1 1-1z" fill="currentColor"/></svg>';
+
+  const dinnerHours = [5,6,7,8];
+  const minuteRules = {
+    5: new Set([0,15]),
+    6: new Set([45]),
+    7: new Set(),
+    8: new Set([15,30,45])
+  };
+
+  const viewports = [
+    { key:'desktop', label:'Desktop', time:{ hour:7, minute:30 } },
+    { key:'ipad', label:'iPad', time:{ hour:7, minute:15 } },
+    { key:'mobile', label:'Mobile', time:{ hour:7, minute:0 } }
+  ];
+
+  const modes = [
+    { key:'edit', label:'Edit', showDelete:true },
+    { key:'add', label:'Add', showDelete:false }
+  ];
+
+  const root = document.querySelector('[data-preview-root]');
+  if(!root) return;
+
+  modes.forEach(mode => {
+    const section = document.createElement('section');
+    section.className = 'preview-section';
+
+    const heading = document.createElement('h2');
+    heading.className = 'preview-section-title';
+    heading.textContent = `Dinner — ${mode.label}`;
+    section.appendChild(heading);
+
+    const grid = document.createElement('div');
+    grid.className = 'preview-grid';
+
+    viewports.forEach(view => {
+      grid.appendChild(buildCard(mode, view));
+    });
+
+    section.appendChild(grid);
+    root.appendChild(section);
+  });
+
+  function buildCard(mode, viewport){
+    const card = document.createElement('div');
+    card.className = 'preview-card';
+
+    const label = document.createElement('div');
+    label.className = 'preview-label';
+    label.textContent = viewport.label;
+    card.appendChild(label);
+
+    card.appendChild(buildModal(mode, viewport));
+    return card;
+  }
+
+  function buildModal(mode, viewport){
+    const overlay = document.createElement('div');
+    overlay.className = `dinner-overlay preview-overlay preview-overlay--${viewport.key}`;
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dinner-dialog';
+    overlay.appendChild(dialog);
+
+    const header = document.createElement('div');
+    header.className = 'modal-header';
+    const title = document.createElement('h2');
+    title.className = 'modal-title';
+    title.textContent = 'Dinner';
+    header.appendChild(title);
+    header.appendChild(createIconButton({ icon: '<span aria-hidden="true">×</span>', label: 'Close', extraClass: 'modal-close' }));
+    dialog.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body dinner-body';
+    dialog.appendChild(body);
+
+    const shell = document.createElement('div');
+    shell.className = 'dinner-time-shell';
+    body.appendChild(shell);
+
+    const section = document.createElement('section');
+    section.className = 'dinner-time-section';
+    const heading = document.createElement('h3');
+    heading.className = 'dinner-time-heading';
+    heading.textContent = 'Time';
+    section.appendChild(heading);
+
+    const content = document.createElement('div');
+    content.className = 'dinner-time-content';
+    section.appendChild(content);
+
+    if(typeof createTimePicker === 'function'){
+      const timePicker = createTimePicker({
+        hourRange: [dinnerHours[0], dinnerHours[dinnerHours.length-1]],
+        minuteStep: 15,
+        showAmPm: false,
+        fixedMeridiem: 'PM',
+        staticMeridiemLabel: 'pm',
+        defaultValue: { hour: viewport.time.hour, minute: viewport.time.minute, meridiem: 'PM' },
+        isMinuteDisabled: ({hour, minute}) => {
+          const disabledSet = minuteRules[hour] || new Set();
+          return disabledSet.has(minute);
+        }
+      });
+      timePicker.element.classList.add('dinner-time-picker');
+      content.appendChild(timePicker.element);
+    }else{
+      const fallback = document.createElement('div');
+      fallback.className = 'time-picker-fallback';
+      fallback.textContent = 'Time picker unavailable.';
+      content.appendChild(fallback);
+    }
+
+    shell.appendChild(section);
+
+    const footer = document.createElement('div');
+    footer.className = 'modal-footer dinner-footer';
+    // Dinner is always all-guests; guest UI removed.
+    const footerEnd = document.createElement('div');
+    footerEnd.className = 'modal-footer-end dinner-footer-end';
+    if(mode.showDelete){
+      footerEnd.appendChild(createIconButton({ icon: deleteIconSvg, label: 'Delete dinner', extraClass: 'btn-icon--subtle' }));
+    }
+    const confirmIcon = mode.showDelete ? saveIconSvg : addIconSvg;
+    const confirmLabel = mode.showDelete ? 'Save dinner time' : 'Add dinner time';
+    footerEnd.appendChild(createIconButton({ icon: confirmIcon, label: confirmLabel, extraClass: 'btn-icon--primary' }));
+    footer.appendChild(footerEnd);
+
+    dialog.appendChild(footer);
+    return overlay;
+  }
+
+  function createIconButton({ icon, label, extraClass='' }){
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = ['btn-icon', extraClass].filter(Boolean).join(' ');
+    button.setAttribute('aria-label', label);
+    button.title = label;
+    button.innerHTML = icon;
+    return button;
+  }
+})();

--- a/script.js
+++ b/script.js
@@ -2223,54 +2223,54 @@
       }
     }) : null;
 
-    const layout=document.createElement('div');
-    layout.className='modal-sections dinner-layout';
-    body.appendChild(layout);
+    const timeShell=document.createElement('div');
+    timeShell.className='dinner-time-shell';
+    body.appendChild(timeShell);
 
     const timeSection=document.createElement('section');
-    // Unified modal layout structure keeps dinner controls aligned with spa/custom flows.
-    timeSection.className='modal-section dinner-section';
+    // Unified modal layout structure keeps the dinner modal aligned with other sheets while allowing the new sticky shell.
+    timeSection.className='dinner-time-section';
     const timeHeading=document.createElement('h3');
+    timeHeading.className='dinner-time-heading';
     timeHeading.textContent='Time';
     timeSection.appendChild(timeHeading);
 
-    const pickerShell=document.createElement('div');
-    pickerShell.className='dinner-picker-shell';
+    const timeContent=document.createElement('div');
+    timeContent.className='dinner-time-content';
     if(!timePicker){
       const fallback = document.createElement('div');
       fallback.className = 'time-picker-fallback';
       fallback.textContent = 'Time picker failed to load.';
-      pickerShell.appendChild(fallback);
+      timeContent.appendChild(fallback);
     }else{
-      pickerShell.appendChild(timePicker.element);
+      // The picker gets a scoped class so CSS can switch to the grid layout without touching other consumers.
+      timePicker.element.classList.add('dinner-time-picker');
+      timeContent.appendChild(timePicker.element);
     }
-    timeSection.appendChild(pickerShell);
-    layout.appendChild(timeSection);
+    timeSection.appendChild(timeContent);
+    timeShell.appendChild(timeSection);
 
     dialog.appendChild(body);
 
     const footer=document.createElement('div');
-    footer.className='modal-footer';
-    const footerStart=document.createElement('div');
-    footerStart.className='modal-footer-start';
+    footer.className='modal-footer dinner-footer';
+    // Dinner is always all-guests; guest UI removed.
     const footerEnd=document.createElement('div');
-    footerEnd.className='modal-footer-end';
-    // Shared footer layout keeps destructive controls on the left while primary
-    // actions stay grouped on the right for every modal.
+    footerEnd.className='modal-footer-end dinner-footer-end';
 
     const confirmIsEdit = mode==='edit' && !!existing;
     const confirmLabel = confirmIsEdit ? 'Save dinner time' : 'Add dinner time';
     const confirmIcon = confirmIsEdit ? saveIconSvg : addIconSvg;
     const confirmBtn = createIconButton({ icon: confirmIcon, label: confirmLabel, extraClass: 'btn-icon--primary' });
-    footerEnd.appendChild(confirmBtn);
 
     let removeBtn=null;
     if(confirmIsEdit){
       removeBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete dinner', extraClass: 'btn-icon--subtle' });
-      footerStart.appendChild(removeBtn);
+      footerEnd.appendChild(removeBtn);
     }
 
-    footer.appendChild(footerStart);
+    footerEnd.appendChild(confirmBtn);
+
     footer.appendChild(footerEnd);
     dialog.appendChild(footer);
 

--- a/style.css
+++ b/style.css
@@ -1369,12 +1369,130 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .modal-footer-start,.modal-footer-end{display:flex;align-items:center;gap:var(--space-3);}
 .modal-footer-end{justify-content:flex-end;}
-.dinner-overlay{position:fixed;inset:0;background:rgba(12,18,32,.46);display:flex;align-items:center;justify-content:center;padding:24px;z-index:2000;}
-.dinner-dialog{background:#fff;border-radius:20px;min-width:280px;max-width:384px;width:100%;box-shadow:0 22px 44px rgba(12,18,32,.18);border:1px solid rgba(226,232,240,.8);display:flex;flex-direction:column;overflow:hidden;}
-.dinner-body{display:flex;flex-direction:column;gap:var(--space-4);padding:clamp(var(--space-5),6vw,var(--space-6));}
-.dinner-layout{grid-template-columns:minmax(0,1fr);}
-.dinner-section h3{margin:0;font-size:16px;font-weight:600;letter-spacing:.01em;color:var(--ink);}
-.dinner-picker-shell{display:flex;justify-content:center;}
+.dinner-overlay{
+  position:fixed;
+  inset:0;
+  background:rgba(12,18,32,0.46);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:24px;
+  z-index:2000;
+  /* Breakpoint-specific sizing stays in CSS so the JS dialog logic can remain untouched. */
+  --dinner-modal-width:560px;
+  --dinner-modal-min-height:360px;
+  --dinner-modal-max-height:420px;
+  --dinner-time-visual-min-height:112px;
+}
+@media (max-width:1024px){
+  .dinner-overlay{
+    --dinner-modal-width:520px;
+    --dinner-modal-min-height:340px;
+    --dinner-modal-max-height:400px;
+    --dinner-time-visual-min-height:100px;
+  }
+}
+@media (max-width:640px){
+  .dinner-overlay{
+    --dinner-modal-width:360px;
+    --dinner-modal-min-height:360px;
+    --dinner-modal-max-height:420px;
+    --dinner-time-visual-min-height:92px;
+  }
+}
+.dinner-dialog{
+  background:var(--surface);
+  border-radius:20px;
+  width:min(var(--dinner-modal-width), calc(100vw - 32px));
+  min-height:min(var(--dinner-modal-min-height), calc(100dvh - 32px));
+  max-height:min(var(--dinner-modal-max-height), calc(100dvh - 32px));
+  box-shadow:0 22px 44px rgba(12,18,32,0.18);
+  border:1px solid color-mix(in srgb,var(--hairline) 65%,rgba(226,232,240,0.8));
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+  position:relative;
+}
+.dinner-dialog .modal-header,
+.dinner-dialog .modal-footer{
+  /* Sticky rails anchor the title/actions without introducing scroll handlers in JS. */
+  position:sticky;
+  left:0;
+  right:0;
+  background:var(--surface);
+  z-index:2;
+}
+.dinner-dialog .modal-header{top:0;}
+.dinner-dialog .modal-footer{bottom:0;}
+.dinner-body{
+  flex:1 1 auto;
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-5);
+  padding:clamp(var(--space-5),5vw,var(--space-6));
+  min-height:0;
+}
+.dinner-time-shell{
+  flex:1 1 auto;
+  display:flex;
+  flex-direction:column;
+  min-height:0;
+}
+.dinner-time-section{
+  flex:1 1 auto;
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-4);
+  min-height:0;
+}
+.dinner-time-heading{
+  margin:0;
+  font-size:16px;
+  font-weight:600;
+  letter-spacing:0.01em;
+  color:var(--ink);
+}
+.dinner-time-content{
+  flex:1 1 auto;
+  display:flex;
+}
+.dinner-time-picker{
+  width:100%;
+  display:grid;
+  grid-template-rows:1fr auto;
+  gap:var(--space-4);
+}
+.dinner-time-picker .time-picker{
+  width:100%;
+  display:grid;
+  grid-template-rows:1fr auto;
+  gap:var(--space-4);
+  align-items:stretch;
+  justify-items:stretch;
+}
+.dinner-time-picker .time-picker-wheels{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  gap:var(--space-4);
+  align-items:stretch;
+  justify-items:stretch;
+}
+.dinner-time-picker .time-picker-column,
+.dinner-time-picker .time-picker-meridiem-static{
+  min-height:var(--dinner-time-visual-min-height);
+}
+.dinner-time-picker .time-picker-inline-field{
+  justify-content:flex-start;
+}
+.dinner-time-picker .time-picker-inline-input{
+  width:100%;
+  max-width:none;
+}
+.dinner-footer{
+  gap:var(--space-3);
+  justify-content:flex-end;
+}
+.dinner-footer-end{gap:10px;}
 .time-picker{display:flex;flex-direction:column;align-items:center;gap:16px;}
 .time-picker-wheels{display:flex;align-items:center;gap:12px;}
 .time-picker-column{position:relative;padding:8px;border-radius:16px;background:linear-gradient(180deg,rgba(241,245,249,.9),#fff);box-shadow:inset 0 0 0 1px rgba(148,163,184,.25);}


### PR DESCRIPTION
## Summary
- restructure the dinner modal to use a sticky header/body/footer shell and keep the responsive time layout aligned with other modals
- refresh dinner modal styling with breakpoint-driven sizing and updated time picker grid treatment for desktop, iPad, and mobile
- add a dinner-modal-preview page that renders add/edit states for each device preset to aid visual QA
- remove guest chips from dinner modal footers so actions are right-aligned across add/edit variants

## Testing
- manual verification via dinner-modal-preview.html

------
https://chatgpt.com/codex/tasks/task_e_68eca4569fa88330a01db6f522826807