### PR TITLE
Refresh SPA modal layout for new responsive spec

### DIFF
--- a/script.js
+++ b/script.js
@@ -2653,52 +2653,45 @@
         return;
       }
 
+      // Render each guest with the shared initial chip styling so the inline footer
+      // cluster matches the rest of the app without altering any toggle handlers.
       visibleGuests.forEach(guest => {
         const guestLabel = buildGuestLabel(guest);
         const isOn = assignedSet.has(guest.id);
         const row=document.createElement('button');
         row.type='button';
-        row.className='spa-option-row spa-guest-row';
+        row.className='chip spa-guest-chip spa-guest-row';
         row.dataset.guestId = guest.id;
         row.dataset.spaNoSubmit='true';
+        row.dataset.guestChip='true';
         row.setAttribute('role','option');
         row.setAttribute('aria-selected', isOn ? 'true' : 'false');
         row.classList.toggle('is-selected', isOn);
         row.classList.toggle('is-off', !isOn);
+        row.title = guestLabel;
+        const ariaLabel = guest.primary ? `${guestLabel} (Primary guest)` : guestLabel;
+        row.setAttribute('aria-label', ariaLabel);
+        if(guest.color){
+          row.style.setProperty('--chip-color', guest.color);
+        }
+
+        const initial=document.createElement('span');
+        initial.className='initial';
+        const initialsSource = (guestLabel || '').trim();
+        initial.textContent = initialsSource ? initialsSource.charAt(0).toUpperCase() : '';
+        row.appendChild(initial);
+
+        if(guest.primary){
+          const star=document.createElement('span');
+          star.className='spa-guest-chip-star';
+          star.textContent='★';
+          star.setAttribute('aria-hidden','true');
+          row.appendChild(star);
+        }
+
         row.addEventListener('click',()=>{
           toggleGuest(guest.id);
         });
-
-        const swatch=document.createElement('span');
-        swatch.className='spa-guest-swatch';
-        swatch.setAttribute('aria-hidden','true');
-        if(guest.color){
-          swatch.style.setProperty('--spa-guest-color', guest.color);
-        }
-
-        const labelWrapper=document.createElement('span');
-        labelWrapper.className='spa-option-label';
-        labelWrapper.title = guestLabel;
-        if(guest.primary){
-          const star=document.createElement('span');
-          star.className='spa-guest-star';
-          star.textContent='★';
-          star.setAttribute('aria-hidden','true');
-          labelWrapper.appendChild(star);
-        }
-        const labelText=document.createElement('span');
-        labelText.className='spa-option-text';
-        labelText.textContent=guestLabel;
-        labelWrapper.appendChild(labelText);
-
-        const checkSpan=document.createElement('span');
-        checkSpan.className='spa-option-check';
-        checkSpan.innerHTML=checkmarkSvg;
-        checkSpan.setAttribute('aria-hidden','true');
-
-        row.appendChild(swatch);
-        row.appendChild(labelWrapper);
-        row.appendChild(checkSpan);
 
         guestList.appendChild(row);
       });

--- a/script.js
+++ b/script.js
@@ -2681,13 +2681,9 @@
         initial.textContent = initialsSource ? initialsSource.charAt(0).toUpperCase() : '';
         row.appendChild(initial);
 
-        if(guest.primary){
-          const star=document.createElement('span');
-          star.className='spa-guest-chip-star';
-          star.textContent='★';
-          star.setAttribute('aria-hidden','true');
-          row.appendChild(star);
-        }
+        // Primary guests continue to read as such via the aria-label, but the
+        // visual star is removed per the follow-up so the inline chips stay
+        // uniformly sized beside the toggle.
 
         row.addEventListener('click',()=>{
           toggleGuest(guest.id);

--- a/script.js
+++ b/script.js
@@ -2554,6 +2554,21 @@
     const layout=document.createElement('div');
     layout.className='modal-sections spa-layout';
     body.appendChild(layout);
+    // Layout wrapper keeps the original service/detail trees intact while the
+    // two-column grid + hairline divider handle the updated visual spec.
+    const layoutGrid=document.createElement('div');
+    layoutGrid.className='spa-layout-grid';
+    layout.appendChild(layoutGrid);
+    const serviceColumn=document.createElement('div');
+    serviceColumn.className='spa-layout-column spa-layout-column-services';
+    layoutGrid.appendChild(serviceColumn);
+    const layoutDivider=document.createElement('div');
+    layoutDivider.className='spa-layout-divider';
+    layoutDivider.setAttribute('aria-hidden','true');
+    layoutGrid.appendChild(layoutDivider);
+    const detailsColumn=document.createElement('div');
+    detailsColumn.className='spa-layout-column spa-layout-column-details';
+    layoutGrid.appendChild(detailsColumn);
 
     const guestSection=document.createElement('section');
     guestSection.className='modal-section spa-section spa-section-guests spa-block spa-guest-card spa-detail-card spa-detail-card-guests';
@@ -2565,6 +2580,7 @@
     const guestToggleAllBtn=document.createElement('button');
     guestToggleAllBtn.type='button';
     guestToggleAllBtn.className='icon-btn spa-toggle-all';
+    guestToggleAllBtn.classList.add('spa-guest-switch');
     guestToggleAllBtn.dataset.spaNoSubmit='true';
     guestToggleAllBtn.setAttribute('aria-pressed','false');
     guestToggleAllBtn.setAttribute('aria-label','Turn all guests on');
@@ -2574,6 +2590,7 @@
     guestSection.appendChild(guestHeader);
     const guestList=document.createElement('div');
     guestList.className='spa-option-list spa-option-list-guests list-hairline';
+    guestList.classList.add('spa-guest-chip-list');
     guestList.setAttribute('role','listbox');
     guestList.setAttribute('aria-label','Guests');
     guestList.setAttribute('aria-multiselectable','true');
@@ -2781,6 +2798,7 @@
     serviceCard.className='spa-block spa-service-card';
     const serviceHeading=document.createElement('h3');
     serviceHeading.textContent='Service';
+    serviceHeading.classList.add('sr-only');
     serviceCard.appendChild(serviceHeading);
     const serviceList=document.createElement('div');
     serviceList.className='spa-service-list';
@@ -3086,15 +3104,18 @@
 
     applyCascadeState();
 
-    layout.appendChild(serviceSection);
+    serviceColumn.appendChild(serviceSection);
 
     const detailsSection=document.createElement('section');
     detailsSection.className='modal-section spa-section spa-section-details';
     const detailsGrid=document.createElement('div');
-    // SPA right pane → 2×4 grid; pills → scrollable hairline lists.
+    // Details column now stacks the time block above the picker stack while
+    // keeping each wheel/list wired to the existing handlers.
     detailsGrid.className='spa-details-grid';
     detailsSection.appendChild(detailsGrid);
-    layout.appendChild(detailsSection);
+    detailsColumn.appendChild(detailsSection);
+    const pickerStack=document.createElement('div');
+    pickerStack.className='spa-picker-stack';
 
     const durationGroup=document.createElement('div');
     durationGroup.className='spa-block spa-detail-card spa-detail-card-duration';
@@ -3116,7 +3137,9 @@
     timeGroup.className='spa-block spa-detail-card spa-detail-card-time';
     const timeHeading=document.createElement('h3');
     timeHeading.textContent='Start Time';
+    timeHeading.classList.add('sr-only');
     timeGroup.appendChild(timeHeading);
+    timeGroup.classList.add('spa-time-block');
     const timeContainer=document.createElement('div');
     timeContainer.className='spa-time-picker';
     timeGroup.appendChild(timeContainer);
@@ -3150,6 +3173,7 @@
     therapistGroup.className='spa-block spa-detail-card spa-detail-card-therapist';
     const therapistHeading=document.createElement('h3');
     therapistHeading.textContent='Therapist Preference';
+    therapistHeading.classList.add('sr-only');
     therapistHeading.id = `${pickerNamespace}-therapist-heading`;
     therapistGroup.appendChild(therapistHeading);
     const therapistPickerContainer=document.createElement('div');
@@ -3266,18 +3290,18 @@
     // tech without reserving vertical space, preventing layout shifts when
     // availability toggles.
     locationGroup.appendChild(locationHelper);
-    detailsGrid.appendChild(therapistGroup);
-    detailsGrid.appendChild(locationGroup);
-    detailsGrid.appendChild(durationGroup);
     detailsGrid.appendChild(timeGroup);
-    detailsGrid.appendChild(guestSection);
+    pickerStack.appendChild(therapistGroup);
+    pickerStack.appendChild(locationGroup);
+    pickerStack.appendChild(durationGroup);
+    detailsGrid.appendChild(pickerStack);
 
     const footer=document.createElement('div');
     footer.className='modal-footer';
     const footerStart=document.createElement('div');
-    footerStart.className='modal-footer-start';
+    footerStart.className='modal-footer-start spa-footer-start';
     const footerEnd=document.createElement('div');
-    footerEnd.className='modal-footer-end';
+    footerEnd.className='modal-footer-end spa-footer-end';
     const confirmIsEdit = mode==='edit' && !!existing;
     const confirmLabel = confirmIsEdit ? 'Save spa appointment' : 'Add spa appointment';
     const confirmIcon = confirmIsEdit ? saveIconSvg : addIconSvg;
@@ -3290,8 +3314,13 @@
       // Editing exposes a destructive control that clears the entire merged
       // appointment; inline chips remain responsible for single-guest removals.
       removeBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete spa appointment', extraClass: 'btn-icon--subtle' });
-      footerStart.appendChild(removeBtn);
+      footerEnd.insertBefore(removeBtn, confirmBtn);
     }
+    // Footer keeps the original guest toggle logic; only the container shifts so
+    // the chips render beside the light switch while actions stay right-aligned.
+    guestSection.classList.add('spa-footer-guests');
+    guestHeading.classList.add('sr-only');
+    footerStart.appendChild(guestSection);
     footer.appendChild(footerStart);
     footer.appendChild(footerEnd);
     dialog.appendChild(footer);

--- a/script.js
+++ b/script.js
@@ -3121,6 +3121,7 @@
     durationGroup.className='spa-block spa-detail-card spa-detail-card-duration';
     const durationHeading=document.createElement('h3');
     durationHeading.textContent='Duration';
+    durationHeading.classList.add('sr-only');
     durationHeading.id = `${pickerNamespace}-duration-heading`;
     durationGroup.appendChild(durationHeading);
     const durationPickerContainer=document.createElement('div');
@@ -3158,7 +3159,8 @@
     endPreview.appendChild(startTimeDisplay);
     endPreview.appendChild(timeSeparator);
     endPreview.appendChild(endTimeValue);
-    timeGroup.appendChild(endPreview);
+    // Keep the preview nodes wired for assistive updates, but skip mounting the
+    // range row so the redundant "start – end" line stays hidden.
     const timeHint=document.createElement('p');
     timeHint.className='spa-helper-text spa-time-hint';
     timeHint.id='spa-time-hint';
@@ -3229,6 +3231,7 @@
     locationGroup.className='spa-block spa-detail-card spa-detail-card-location';
     const locationHeading=document.createElement('h3');
     locationHeading.textContent='Location';
+    locationHeading.classList.add('sr-only');
     locationHeading.id = `${pickerNamespace}-location-heading`;
     locationGroup.appendChild(locationHeading);
     const locationPickerContainer=document.createElement('div');

--- a/spa-modal-preview.html
+++ b/spa-modal-preview.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>SPA Modal Layout Preview</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    :root{color-scheme:light;}
+    body{margin:0;padding:32px clamp(24px,5vw,48px);font:15px/1.45 -apple-system,system-ui,"Helvetica Neue",Segoe UI,Roboto,sans-serif;background:var(--color-bg);color:var(--ink);display:flex;flex-direction:column;gap:32px;}
+    h1{margin:0;font-size:28px;font-weight:650;letter-spacing:-0.01em;color:var(--ink);}
+    p{margin:0;color:var(--muted);max-width:720px;}
+    [data-preview-root]{display:flex;flex-direction:column;gap:32px;}
+    .preview-section{display:flex;flex-direction:column;gap:16px;}
+    .preview-section-title{margin:0;font-size:18px;font-weight:600;letter-spacing:0.01em;color:var(--ink);}
+    .preview-grid{display:grid;gap:28px;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));align-items:start;}
+    .preview-card{display:flex;flex-direction:column;gap:12px;align-items:stretch;}
+    .preview-label{font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);}
+    .preview-overlay{position:relative;inset:auto;background:transparent;padding:0;z-index:1;display:flex;justify-content:center;}
+    .preview-overlay .spa-dialog{margin:0 auto;}
+    .preview-overlay--desktop .spa-dialog{--spa-dialog-max-width:880px;--spa-dialog-min-height:600px;--spa-dialog-max-height:680px;}
+    .preview-overlay--ipad .spa-dialog{--spa-dialog-max-width:700px;--spa-dialog-min-height:600px;--spa-dialog-max-height:660px;}
+    .preview-overlay--mobile .spa-dialog{--spa-dialog-max-width:420px;--spa-dialog-min-height:600px;--spa-dialog-max-height:640px;}
+    @media (prefers-color-scheme: dark){body{background:var(--color-bg);color:var(--ink);}}
+  </style>
+  <script src="time-picker.js"></script>
+  <script defer src="spa-modal-preview.js"></script>
+</head>
+<body>
+  <h1>SPA Modal Responsive Preview</h1>
+  <p>Preview the refreshed SPA modal layout across desktop, iPad, and mobile breakpoints in both Add and Edit states.</p>
+  <div data-preview-root></div>
+</body>
+</html>

--- a/spa-modal-preview.js
+++ b/spa-modal-preview.js
@@ -417,39 +417,28 @@
       const isSelected = mode.guestsOn;
       const row = document.createElement('button');
       row.type = 'button';
-      row.className = 'spa-option-row spa-guest-row';
+      row.className = 'chip spa-guest-chip spa-guest-row';
+      row.dataset.guestChip = 'true';
       if(isSelected){
         row.classList.add('is-selected');
       }else{
         row.classList.add('is-off');
       }
+      row.style.setProperty('--chip-color', guest.color);
 
-      const swatch = document.createElement('span');
-      swatch.className = 'spa-guest-swatch';
-      swatch.style.setProperty('--spa-guest-color', guest.color);
-      swatch.setAttribute('aria-hidden','true');
+      const initial = document.createElement('span');
+      initial.className = 'initial';
+      initial.textContent = guest.name.charAt(0).toUpperCase();
+      row.appendChild(initial);
 
-      const label = document.createElement('span');
-      label.className = 'spa-option-label';
       if(guest.primary){
         const star = document.createElement('span');
-        star.className = 'spa-guest-star';
+        star.className = 'spa-guest-chip-star';
         star.textContent = '★';
         star.setAttribute('aria-hidden','true');
-        label.appendChild(star);
+        row.appendChild(star);
       }
-      const text = document.createElement('span');
-      text.className = 'spa-option-text';
-      text.textContent = guest.name;
-      label.appendChild(text);
 
-      const check = document.createElement('span');
-      check.className = 'spa-option-check';
-      check.innerHTML = '<span aria-hidden="true">✓</span>';
-
-      row.appendChild(swatch);
-      row.appendChild(label);
-      row.appendChild(check);
       list.appendChild(row);
     });
 

--- a/spa-modal-preview.js
+++ b/spa-modal-preview.js
@@ -431,13 +431,8 @@
       initial.textContent = guest.name.charAt(0).toUpperCase();
       row.appendChild(initial);
 
-      if(guest.primary){
-        const star = document.createElement('span');
-        star.className = 'spa-guest-chip-star';
-        star.textContent = '★';
-        star.setAttribute('aria-hidden','true');
-        row.appendChild(star);
-      }
+      // Preview keeps parity with production: aria-labels still call out primary
+      // guests, but the decorative star is removed so the chips stay inline.
 
       list.appendChild(row);
     });

--- a/spa-modal-preview.js
+++ b/spa-modal-preview.js
@@ -227,7 +227,7 @@
     }));
     pickerStack.appendChild(buildPickerCard({
       title:'Location',
-      srOnly:false,
+      srOnly:true,
       options:locationOptions,
       selected:viewport.location,
       className:'spa-detail-card spa-detail-card-location',
@@ -283,7 +283,8 @@
     preview.appendChild(start);
     preview.appendChild(separator);
     preview.appendChild(endValue);
-    card.appendChild(preview);
+    // Mirror the production tweak by leaving the preview row unmounted so the
+    // mock reflects the cleaned layout without changing the data wiring.
 
     const hint = document.createElement('p');
     hint.className = 'spa-helper-text spa-time-hint';
@@ -336,6 +337,7 @@
 
     const heading = document.createElement('h3');
     heading.textContent = 'Duration';
+    heading.className = 'sr-only';
     card.appendChild(heading);
 
     const list = document.createElement('div');

--- a/spa-modal-preview.js
+++ b/spa-modal-preview.js
@@ -1,0 +1,477 @@
+(function(){
+  const addIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M11 11V5a1 1 0 1 1 2 0v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6z" fill="currentColor"/></svg>';
+  const saveIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M17 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7l-2-2zm-1 0v5H8V3h8zM8 20v-6h8v6H8z" fill="currentColor"/></svg>';
+  const deleteIconSvg = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M9 3h6a1 1 0 0 1 1 1v1h4a1 1 0 1 1 0 2h-1l-1 13a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 7H4a1 1 0 1 1 0-2h4V4a1 1 0 0 1 1-1zm1 6a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V10a1 1 0 0 0-1-1zm4 0a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V10a1 1 0 0 0-1-1z" fill="currentColor"/></svg>';
+  const chevronSvg = '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M5.22 2.97a.75.75 0 0 0 0 1.06L9.19 8l-3.97 3.97a.75.75 0 1 0 1.06 1.06l4.5-4.5a.75.75 0 0 0 0-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0Z" fill="currentColor"/></svg>';
+  const toggleOnSvg = '<svg viewBox="0 0 44 26" aria-hidden="true" focusable="false"><rect x="1" y="1" width="42" height="24" rx="12" fill="currentColor" opacity=".18"/><circle cx="31" cy="13" r="9" fill="currentColor"/></svg>';
+  const toggleOffSvg = '<svg viewBox="0 0 44 26" aria-hidden="true" focusable="false"><rect x="1" y="1" width="42" height="24" rx="12" fill="currentColor" opacity=".12"/><circle cx="13" cy="13" r="9" fill="currentColor" opacity=".45"/></svg>';
+  const createTimePicker = typeof window !== 'undefined' && window.TimePickerKit && typeof window.TimePickerKit.createTimePicker === 'function'
+    ? window.TimePickerKit.createTimePicker
+    : null;
+
+  const categories = [
+    { label:'Massages', services:['Desert Stone Massage','Hot Springs Reflexology'] },
+    { label:'Treatments', services:['Forest Aroma Facial','Springs Body Polish'] },
+    { label:'Therapies', services:['Sound Bowl Therapy','Breathwork Reset'] },
+    { label:'Wellness Sessions', services:['Guided Meditation','Mindful Stretch'] }
+  ];
+
+  const therapistOptions = [
+    { id:'no-preference', label:'No Preference' },
+    { id:'female', label:'Female Therapist' },
+    { id:'male', label:'Male Therapist' }
+  ];
+
+  const locationOptions = [
+    { id:'any', label:'Any Location' },
+    { id:'same-cabana', label:'Same Cabana' },
+    { id:'in-room', label:'In-Room' }
+  ];
+
+  const durationOptions = [60, 90, 120];
+
+  const viewports = [
+    { key:'desktop', label:'Desktop', time:{ hour:9, minute:15, meridiem:'AM' }, end:'10:45 AM', therapist:'no-preference', location:'any', duration:90 },
+    { key:'ipad', label:'iPad', time:{ hour:8, minute:0, meridiem:'AM' }, end:'10:00 AM', therapist:'female', location:'same-cabana', duration:120 },
+    { key:'mobile', label:'Mobile', time:{ hour:9, minute:0, meridiem:'AM' }, end:'10:30 AM', therapist:'no-preference', location:'same-cabana', duration:90 }
+  ];
+
+  const guests = [
+    { id:'alex', name:'Alex', initial:'A', color:'#4C6EF5', primary:true },
+    { id:'jordan', name:'Jordan', initial:'J', color:'#F59F00', primary:false }
+  ];
+
+  const modes = [
+    { key:'edit', label:'Edit', confirmLabel:'Save spa appointment', confirmIcon:saveIconSvg, showDelete:true, guestsOn:true, guestHint:'' },
+    { key:'add', label:'Add', confirmLabel:'Add spa appointment', confirmIcon:addIconSvg, showDelete:false, guestsOn:false, guestHint:'Turn all guests on to add these settings.' }
+  ];
+
+  const root = document.querySelector('[data-preview-root]');
+  if(!root) return;
+
+  modes.forEach(mode => {
+    const section = document.createElement('section');
+    section.className = 'preview-section';
+
+    const heading = document.createElement('h2');
+    heading.className = 'preview-section-title';
+    heading.textContent = `SPA — ${mode.label}`;
+    section.appendChild(heading);
+
+    const grid = document.createElement('div');
+    grid.className = 'preview-grid';
+
+    viewports.forEach(view => {
+      grid.appendChild(buildCard(mode, view));
+    });
+
+    section.appendChild(grid);
+    root.appendChild(section);
+  });
+
+  function buildCard(mode, viewport){
+    const card = document.createElement('div');
+    card.className = 'preview-card';
+
+    const label = document.createElement('div');
+    label.className = 'preview-label';
+    label.textContent = viewport.label;
+    card.appendChild(label);
+
+    card.appendChild(buildModal(mode, viewport));
+    return card;
+  }
+
+  function buildModal(mode, viewport){
+    const overlay = document.createElement('div');
+    overlay.className = `spa-overlay preview-overlay preview-overlay--${viewport.key}`;
+
+    const dialog = document.createElement('div');
+    dialog.className = 'spa-dialog';
+    overlay.appendChild(dialog);
+
+    dialog.appendChild(buildHeader());
+    dialog.appendChild(buildBody(viewport));
+    dialog.appendChild(buildFooter(mode));
+
+    return overlay;
+  }
+
+  function buildHeader(){
+    const header = document.createElement('div');
+    header.className = 'modal-header';
+
+    const title = document.createElement('h2');
+    title.className = 'modal-title';
+    title.textContent = 'SPA';
+    header.appendChild(title);
+
+    const closeBtn = createIconButton({ icon:'<span aria-hidden="true">×</span>', label:'Close', extraClass:'modal-close' });
+    header.appendChild(closeBtn);
+
+    return header;
+  }
+
+  function buildBody(viewport){
+    const body = document.createElement('div');
+    body.className = 'modal-body spa-body';
+
+    const layout = document.createElement('div');
+    layout.className = 'modal-sections spa-layout';
+    body.appendChild(layout);
+
+    const grid = document.createElement('div');
+    grid.className = 'spa-layout-grid';
+    layout.appendChild(grid);
+
+    const serviceColumn = document.createElement('div');
+    serviceColumn.className = 'spa-layout-column spa-layout-column-services';
+    grid.appendChild(serviceColumn);
+    serviceColumn.appendChild(buildServiceSection());
+
+    const divider = document.createElement('div');
+    divider.className = 'spa-layout-divider';
+    divider.setAttribute('aria-hidden','true');
+    grid.appendChild(divider);
+
+    const detailsColumn = document.createElement('div');
+    detailsColumn.className = 'spa-layout-column spa-layout-column-details';
+    grid.appendChild(detailsColumn);
+    detailsColumn.appendChild(buildDetailsSection(viewport));
+
+    return body;
+  }
+
+  function buildServiceSection(){
+    const section = document.createElement('section');
+    section.className = 'modal-section spa-section spa-section-services';
+
+    const card = document.createElement('div');
+    card.className = 'spa-block spa-service-card';
+    section.appendChild(card);
+
+    const heading = document.createElement('h3');
+    heading.className = 'sr-only';
+    heading.textContent = 'Service';
+    card.appendChild(heading);
+
+    const scroll = document.createElement('div');
+    scroll.className = 'spa-service-scroll';
+    card.appendChild(scroll);
+
+    const list = document.createElement('div');
+    list.className = 'spa-service-list';
+    scroll.appendChild(list);
+
+    categories.forEach((category, index) => {
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'spa-cascade-row spa-category-row';
+      if(index === 0){
+        row.classList.add('open');
+      }
+      const label = document.createElement('span');
+      label.className = 'spa-cascade-label';
+      label.textContent = category.label;
+      row.appendChild(label);
+      const icon = document.createElement('span');
+      icon.className = 'spa-cascade-chevron';
+      icon.innerHTML = chevronSvg;
+      row.appendChild(icon);
+      list.appendChild(row);
+
+      const panel = document.createElement('div');
+      panel.className = 'spa-cascade-panel';
+      panel.dataset.open = index === 0 ? 'true' : 'false';
+      panel.setAttribute('aria-hidden', index === 0 ? 'false' : 'true');
+      const inner = document.createElement('div');
+      inner.className = 'spa-cascade-panel-inner';
+      panel.appendChild(inner);
+
+      category.services.forEach((service, serviceIndex) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'spa-service-button';
+        btn.textContent = service;
+        if(index === 0 && serviceIndex === 0){
+          btn.classList.add('selected');
+        }
+        inner.appendChild(btn);
+      });
+
+      list.appendChild(panel);
+    });
+
+    return section;
+  }
+
+  function buildDetailsSection(viewport){
+    const section = document.createElement('section');
+    section.className = 'modal-section spa-section spa-section-details';
+
+    const grid = document.createElement('div');
+    grid.className = 'spa-details-grid';
+    section.appendChild(grid);
+
+    grid.appendChild(buildTimeCard(viewport));
+
+    const pickerStack = document.createElement('div');
+    pickerStack.className = 'spa-picker-stack';
+    pickerStack.appendChild(buildPickerCard({
+      title:'Therapist Preference',
+      srOnly:true,
+      options:therapistOptions,
+      selected:viewport.therapist,
+      className:'spa-detail-card spa-detail-card-therapist',
+      listClass:'spa-option-list spa-option-list-therapist list-hairline'
+    }));
+    pickerStack.appendChild(buildPickerCard({
+      title:'Location',
+      srOnly:false,
+      options:locationOptions,
+      selected:viewport.location,
+      className:'spa-detail-card spa-detail-card-location',
+      listClass:'spa-option-list spa-option-list-location list-hairline'
+    }));
+    pickerStack.appendChild(buildDurationCard(viewport.duration));
+    grid.appendChild(pickerStack);
+
+    return section;
+  }
+
+  function buildTimeCard(viewport){
+    const card = document.createElement('div');
+    card.className = 'spa-block spa-detail-card spa-detail-card-time spa-time-block';
+
+    const heading = document.createElement('h3');
+    heading.className = 'sr-only';
+    heading.textContent = 'Start Time';
+    card.appendChild(heading);
+
+    const container = document.createElement('div');
+    container.className = 'spa-time-picker';
+    card.appendChild(container);
+
+    if(typeof createTimePicker === 'function'){
+      const picker = createTimePicker({
+        hourRange:[1,12],
+        minuteStep:5,
+        showAmPm:true,
+        defaultValue:{ hour:viewport.time.hour, minute:viewport.time.minute, meridiem:viewport.time.meridiem },
+        ariaLabels:{ hours:'Hours', minutes:'Minutes', meridiem:'AM or PM' }
+      });
+      container.appendChild(picker.element);
+    }else{
+      const fallback = document.createElement('div');
+      fallback.className = 'time-picker-fallback';
+      fallback.textContent = 'Time picker unavailable.';
+      container.appendChild(fallback);
+    }
+
+    const preview = document.createElement('div');
+    preview.className = 'spa-end-preview';
+    const start = document.createElement('button');
+    start.type = 'button';
+    start.className = 'spa-start-time-display';
+    start.textContent = formatTime(viewport.time);
+    const separator = document.createElement('span');
+    separator.className = 'spa-time-separator';
+    separator.textContent = '–';
+    const endValue = document.createElement('span');
+    endValue.className = 'spa-end-time-value';
+    endValue.textContent = viewport.end;
+    preview.appendChild(start);
+    preview.appendChild(separator);
+    preview.appendChild(endValue);
+    card.appendChild(preview);
+
+    const hint = document.createElement('p');
+    hint.className = 'spa-helper-text spa-time-hint';
+    hint.hidden = true;
+    card.appendChild(hint);
+
+    return card;
+  }
+
+  function buildPickerCard({ title, srOnly, options, selected, className, listClass = 'spa-option-list list-hairline' }){
+    const card = document.createElement('div');
+    card.className = `spa-block spa-detail-card ${className}`;
+
+    const heading = document.createElement('h3');
+    heading.textContent = title;
+    if(srOnly){
+      heading.className = 'sr-only';
+    }
+    card.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = listClass;
+    card.appendChild(list);
+
+    options.forEach(option => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'spa-option-row';
+      btn.dataset.value = option.id;
+      const label = document.createElement('span');
+      label.className = 'spa-option-label';
+      label.textContent = option.label;
+      const check = document.createElement('span');
+      check.className = 'spa-option-check';
+      check.innerHTML = '<span aria-hidden="true">✓</span>';
+      btn.appendChild(label);
+      btn.appendChild(check);
+      if(option.id === selected){
+        btn.classList.add('is-selected');
+      }
+      list.appendChild(btn);
+    });
+
+    return card;
+  }
+
+  function buildDurationCard(selected){
+    const card = document.createElement('div');
+    card.className = 'spa-block spa-detail-card spa-detail-card-duration';
+
+    const heading = document.createElement('h3');
+    heading.textContent = 'Duration';
+    card.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'spa-option-list spa-option-list-duration list-hairline';
+    card.appendChild(list);
+
+    durationOptions.forEach(value => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'spa-option-row';
+      btn.dataset.value = String(value);
+      const label = document.createElement('span');
+      label.className = 'spa-option-label';
+      label.textContent = `${value} Minutes`;
+      const check = document.createElement('span');
+      check.className = 'spa-option-check';
+      check.innerHTML = '<span aria-hidden="true">✓</span>';
+      btn.appendChild(label);
+      btn.appendChild(check);
+      if(value === selected){
+        btn.classList.add('is-selected');
+      }
+      list.appendChild(btn);
+    });
+
+    return card;
+  }
+
+  function buildFooter(mode){
+    const footer = document.createElement('div');
+    footer.className = 'modal-footer';
+
+    const start = document.createElement('div');
+    start.className = 'modal-footer-start spa-footer-start';
+    start.appendChild(buildGuestSection(mode));
+    footer.appendChild(start);
+
+    const end = document.createElement('div');
+    end.className = 'modal-footer-end spa-footer-end';
+    if(mode.showDelete){
+      end.appendChild(createIconButton({ icon: deleteIconSvg, label: 'Delete spa appointment', extraClass: 'btn-icon--subtle' }));
+    }
+    const confirmBtn = createIconButton({ icon: mode.confirmIcon, label: mode.confirmLabel, extraClass: 'btn-icon--primary' });
+    confirmBtn.classList.add('spa-confirm');
+    end.appendChild(confirmBtn);
+    footer.appendChild(end);
+
+    return footer;
+  }
+
+  function buildGuestSection(mode){
+    const section = document.createElement('section');
+    section.className = 'modal-section spa-section spa-section-guests spa-block spa-guest-card spa-detail-card spa-detail-card-guests spa-footer-guests';
+
+    const header = document.createElement('div');
+    header.className = 'spa-guest-header';
+
+    const heading = document.createElement('h3');
+    heading.className = 'sr-only';
+    heading.textContent = 'Guests';
+    header.appendChild(heading);
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'icon-btn spa-toggle-all spa-guest-switch';
+    toggle.setAttribute('aria-label', mode.guestsOn ? 'Guests on' : 'Guests off');
+    toggle.innerHTML = mode.guestsOn ? toggleOnSvg : toggleOffSvg;
+    toggle.style.color = mode.guestsOn ? 'var(--brand)' : 'var(--muted)';
+    header.appendChild(toggle);
+    section.appendChild(header);
+
+    const list = document.createElement('div');
+    list.className = 'spa-option-list spa-option-list-guests list-hairline spa-guest-chip-list';
+    section.appendChild(list);
+
+    guests.forEach(guest => {
+      const isSelected = mode.guestsOn;
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'spa-option-row spa-guest-row';
+      if(isSelected){
+        row.classList.add('is-selected');
+      }else{
+        row.classList.add('is-off');
+      }
+
+      const swatch = document.createElement('span');
+      swatch.className = 'spa-guest-swatch';
+      swatch.style.setProperty('--spa-guest-color', guest.color);
+      swatch.setAttribute('aria-hidden','true');
+
+      const label = document.createElement('span');
+      label.className = 'spa-option-label';
+      if(guest.primary){
+        const star = document.createElement('span');
+        star.className = 'spa-guest-star';
+        star.textContent = '★';
+        star.setAttribute('aria-hidden','true');
+        label.appendChild(star);
+      }
+      const text = document.createElement('span');
+      text.className = 'spa-option-text';
+      text.textContent = guest.name;
+      label.appendChild(text);
+
+      const check = document.createElement('span');
+      check.className = 'spa-option-check';
+      check.innerHTML = '<span aria-hidden="true">✓</span>';
+
+      row.appendChild(swatch);
+      row.appendChild(label);
+      row.appendChild(check);
+      list.appendChild(row);
+    });
+
+    const hint = document.createElement('p');
+    hint.className = 'spa-helper-text spa-guest-hint';
+    hint.textContent = mode.guestHint;
+    hint.hidden = !mode.guestHint;
+    section.appendChild(hint);
+
+    return section;
+  }
+
+  function createIconButton({ icon, label, extraClass='' }){
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = ['btn-icon', extraClass].filter(Boolean).join(' ');
+    button.setAttribute('aria-label', label);
+    button.title = label;
+    button.innerHTML = icon;
+    return button;
+  }
+
+  function formatTime({ hour, minute, meridiem }){
+    const paddedMinute = String(minute).padStart(2,'0');
+    return `${hour}:${paddedMinute} ${meridiem}`;
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -2145,16 +2145,17 @@ body.custom-lock{overflow:hidden;}
   justify-content:center;
   text-align:center;
 }
-/* Follow-up aligns the footer into a single row; the 10px gap keeps the toggle
- * and first chip tight without letting the group wrap under the switch. */
+/* Follow-up aligns the footer into a single row so the toggle + chips stay
+ * inline. Gap mirrors the spec’s 8px spacing between the switch and chips. */
 .spa-footer-start{
   flex:1 1 auto;
   min-width:0;
   display:flex;
+  flex-direction:row;
   align-items:center;
-  gap:10px;
-  flex-wrap:nowrap;
   justify-content:flex-start;
+  gap:8px;
+  flex-wrap:nowrap;
 }
 .spa-footer-end{
   flex:0 0 auto;
@@ -2169,20 +2170,21 @@ body.custom-lock{overflow:hidden;}
  * actions stay aligned while long guest lists scroll horizontally. */
 .spa-footer-guests{
   display:flex;
+  flex-direction:row;
   align-items:center;
-  gap:10px;
+  justify-content:flex-start;
+  gap:8px;
   min-width:0;
   width:100%;
   flex:1 1 auto;
-  overflow:hidden;
   flex-wrap:nowrap;
-  justify-content:flex-start;
 }
 .spa-footer-guests .spa-guest-header{
   display:flex;
+  flex-direction:row;
   align-items:center;
-  gap:10px;
   justify-content:flex-start;
+  gap:8px;
   flex:0 0 auto;
   flex-wrap:nowrap;
 }
@@ -2198,7 +2200,10 @@ body.custom-lock{overflow:hidden;}
   padding:0;
   transition:background-color .18s ease,border-color .18s ease,box-shadow .18s ease;
 }
-.spa-footer-guests .spa-guest-switch{flex:0 0 auto;}
+.spa-footer-guests .spa-guest-switch{
+  flex:0 0 auto;
+  align-self:center;
+}
 .spa-guest-switch:hover{
   border-color:color-mix(in srgb,var(--brand) 32%,var(--border));
   box-shadow:0 6px 16px rgba(42,107,255,.12);
@@ -2211,19 +2216,21 @@ body.custom-lock{overflow:hidden;}
  * fixed across desktop/iPad/mobile breakpoints. */
 .spa-guest-chip-list{
   display:flex;
+  flex-direction:row;
   align-items:center;
-  flex-wrap:nowrap;
+  justify-content:flex-start;
   gap:6px;
   border:0;
   background:transparent;
   padding:0;
   max-block-size:none;
+  flex:1 1 auto;
+  min-width:0;
+  flex-wrap:nowrap;
+  white-space:nowrap;
   overflow-x:auto;
   overflow-y:hidden;
   -webkit-overflow-scrolling:touch;
-  flex:1 1 auto;
-  min-width:0;
-  white-space:nowrap;
 }
 /* Maintain inline chips beside the toggle; horizontal scroll absorbs overflow
  * instead of wrapping so the footer height never changes. */

--- a/style.css
+++ b/style.css
@@ -1930,3 +1930,339 @@ body.custom-lock{overflow:hidden;}
 .time-picker-demo-physics-column h4{margin:0;font-size:15px;}
 .time-picker-demo-physics-hint{margin:0;font-size:13px;color:var(--muted);}
 .time-picker-demo-host--physics{justify-content:center;}
+/*
+ * SPA modal responsive shell refresh (layout only).
+ * Device clamp variables map to the desktop/iPad/mobile presets so the body avoids
+ * internal scrolling at the reference sizes.
+ */
+.spa-dialog{
+  --spa-dialog-max-width:880px;
+  --spa-dialog-min-height:600px;
+  --spa-dialog-max-height:680px;
+  width:min(var(--spa-dialog-max-width), calc(100vw - 2*var(--spa-viewport-gutter)));
+  max-width:var(--spa-dialog-max-width);
+  min-height:var(--spa-dialog-min-height);
+  height:min(var(--spa-dialog-max-height), calc(100vh - 2*var(--spa-viewport-gutter)));
+  max-height:min(var(--spa-dialog-max-height), calc(100vh - 2*var(--spa-viewport-gutter)));
+  block-size:min(var(--spa-dialog-max-height), calc(100vh - 2*var(--spa-viewport-gutter)));
+  max-block-size:min(var(--spa-dialog-max-height), calc(100vh - 2*var(--spa-viewport-gutter)));
+}
+@supports (height:100svh){
+  .spa-dialog{
+    height:min(var(--spa-dialog-max-height), calc(100svh - 2*var(--spa-viewport-gutter)));
+    block-size:min(var(--spa-dialog-max-height), calc(100svh - 2*var(--spa-viewport-gutter)));
+    max-height:min(var(--spa-dialog-max-height), calc(100svh - 2*var(--spa-viewport-gutter)));
+    max-block-size:min(var(--spa-dialog-max-height), calc(100svh - 2*var(--spa-viewport-gutter)));
+  }
+}
+@supports (height:100dvh){
+  .spa-dialog{
+    height:min(var(--spa-dialog-max-height), calc(100dvh - 2*var(--spa-viewport-gutter)));
+    block-size:min(var(--spa-dialog-max-height), calc(100dvh - 2*var(--spa-viewport-gutter)));
+    max-height:min(var(--spa-dialog-max-height), calc(100dvh - 2*var(--spa-viewport-gutter)));
+    max-block-size:min(var(--spa-dialog-max-height), calc(100dvh - 2*var(--spa-viewport-gutter)));
+  }
+}
+/* Sticky header/footer keep actions visible while the body scrolls. */
+.spa-dialog .modal-header,
+.spa-dialog .modal-footer{
+  position:sticky;
+  z-index:3;
+  background:var(--surface);
+}
+.spa-dialog .modal-header{top:0;}
+.spa-dialog .modal-footer{
+  bottom:0;
+  align-items:flex-start;
+  flex-wrap:wrap;
+  gap:var(--space-4);
+}
+.spa-body{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-6);
+  flex:1 1 auto;
+  min-height:0;
+  overflow:auto;
+  --spa-body-padding:clamp(var(--space-6),5vw,var(--space-7));
+  padding:var(--spa-body-padding);
+  padding-block-end:calc(var(--spa-body-padding) + env(safe-area-inset-bottom));
+}
+.spa-layout{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-6);
+  flex:1 1 auto;
+  min-height:0;
+}
+/* Two-column grid + hairline live here so the interactive subtrees stay intact. */
+.spa-layout-grid{
+  display:grid;
+  grid-template-columns:minmax(0,1fr) 1px minmax(0,1fr);
+  gap:var(--space-6);
+  flex:1 1 auto;
+  min-height:0;
+}
+.spa-layout-column{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-5);
+  min-height:0;
+}
+.spa-layout-divider{
+  width:1px;
+  background:var(--hairline);
+  border-radius:999px;
+  align-self:stretch;
+  min-height:0;
+}
+.spa-dialog .spa-block{
+  padding:0;
+  border:0;
+  border-radius:16px;
+  background:transparent;
+  box-shadow:none;
+}
+.spa-section{gap:var(--space-5);}
+.spa-section-services{min-height:0;}
+.spa-service-card{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-4);
+  min-height:0;
+}
+.spa-service-list{
+  border:0;
+  border-radius:16px;
+  background:var(--surface);
+  box-shadow:none;
+}
+.spa-service-scroll{
+  flex:1 1 auto;
+  min-height:0;
+  padding:0;
+  padding-inline-end:0;
+}
+.spa-cascade-row{
+  padding:12px 18px;
+  min-height:46px;
+}
+.spa-subcategory-row{padding-inline-start:30px;}
+.spa-cascade-row::after,
+.spa-service-button::after{
+  inset-inline:18px;
+}
+.spa-subcategory-row::after{left:30px;right:18px;}
+.spa-service-button{
+  padding:12px 18px 12px 52px;
+}
+.spa-service-button::after{left:52px;right:18px;}
+.spa-cascade-panel::before{left:18px;right:18px;}
+.spa-details-grid{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-6);
+  min-height:0;
+}
+.spa-time-block{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-5);
+  align-items:center;
+}
+.spa-time-block .spa-time-picker{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:var(--space-4);
+  width:100%;
+}
+.spa-time-block .time-picker-wheels{
+  width:100%;
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  gap:var(--space-4);
+}
+.spa-time-block .time-picker-column{
+  border:1px solid var(--border-hairline);
+  border-radius:16px;
+  background:var(--surface);
+  min-height:108px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:12px;
+}
+.spa-time-block .time-picker-inline-field{
+  width:100%;
+  display:flex;
+  justify-content:center;
+}
+.spa-time-block .time-picker-inline-input{
+  width:100%;
+  max-width:220px;
+  height:44px;
+  border-radius:12px;
+  border:1px solid var(--border);
+  padding:0 16px;
+  font-size:16px;
+  font-weight:600;
+  text-align:center;
+  color:var(--ink);
+  background:var(--surface);
+  box-shadow:0 2px 6px rgba(15,23,42,.08);
+}
+.spa-time-block .time-picker-inline-input[aria-invalid='true']{
+  border-color:var(--brand);
+  box-shadow:0 0 0 2px rgba(42,107,255,.16);
+}
+.spa-time-block .spa-end-preview{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  justify-content:center;
+  gap:var(--space-3);
+  font-size:14px;
+  color:var(--muted);
+}
+.spa-time-block .spa-time-hint{text-align:center;}
+.spa-picker-stack{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-5);
+  min-height:0;
+}
+.spa-picker-stack .spa-detail-card{
+  align-items:center;
+  gap:var(--space-4);
+}
+.spa-picker-stack .spa-option-list{
+  width:100%;
+  border:1px solid var(--border-hairline);
+  border-radius:16px;
+  background:var(--surface);
+  box-shadow:0 1px 0 rgba(15,23,42,.04);
+}
+.spa-picker-stack .spa-single-picker{padding-block:12px;}
+.spa-picker-stack .spa-option-row{
+  justify-content:center;
+  text-align:center;
+}
+.spa-footer-start{
+  flex:1 1 auto;
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.spa-footer-end{
+  flex:0 0 auto;
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:var(--space-3);
+  margin-inline-start:auto;
+}
+.spa-footer-guests{
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:8px;
+  min-width:0;
+  width:100%;
+}
+.spa-footer-guests .spa-guest-header{
+  display:flex;
+  align-items:center;
+  gap:var(--space-3);
+  justify-content:flex-start;
+}
+.spa-guest-switch{
+  width:48px;
+  height:28px;
+  border-radius:999px;
+  border:1px solid var(--border);
+  background:var(--surface);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:0;
+  transition:background-color .18s ease,border-color .18s ease,box-shadow .18s ease;
+}
+.spa-guest-switch:hover{
+  border-color:color-mix(in srgb,var(--brand) 32%,var(--border));
+  box-shadow:0 6px 16px rgba(42,107,255,.12);
+}
+.spa-guest-switch:focus-visible{
+  outline:2px solid var(--activity-focus-ring);
+  outline-offset:2px;
+}
+.spa-guest-chip-list{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  border:0;
+  background:transparent;
+  padding:0;
+  max-block-size:none;
+  overflow:visible;
+}
+.spa-footer-guests .spa-option-row{
+  border-radius:999px;
+  border:1px solid var(--border-hairline);
+  background:var(--surface);
+  padding:6px 12px;
+  min-height:0;
+  font-size:14px;
+  font-weight:600;
+  gap:8px;
+  color:var(--ink);
+}
+.spa-footer-guests .spa-option-row.is-selected{
+  background:color-mix(in srgb,var(--brand) 12%,var(--surface));
+  border-color:color-mix(in srgb,var(--brand) 56%,var(--border-hairline));
+}
+.spa-footer-guests .spa-option-row.is-off{opacity:.6;}
+.spa-footer-guests .spa-option-check{display:none;}
+.spa-footer-guests .spa-option-label{gap:6px;}
+.spa-footer-guests .spa-option-text{font-weight:600;}
+.spa-footer-guests .spa-guest-swatch{
+  width:18px;
+  height:18px;
+  border-radius:999px;
+  box-shadow:none;
+}
+.spa-footer-guests .spa-guest-hint{
+  margin:0;
+  font-size:12px;
+  color:var(--muted);
+}
+@media (max-width:900px){
+  .spa-dialog{
+    --spa-dialog-max-width:700px;
+    --spa-dialog-max-height:660px;
+  }
+  .spa-body{
+    --spa-body-padding:clamp(var(--space-5),6vw,var(--space-6));
+  }
+  .spa-time-block .time-picker-column{min-height:100px;}
+}
+@media (max-width:760px){
+  .spa-layout-grid{
+    grid-template-columns:1fr;
+    gap:var(--space-5);
+  }
+  .spa-layout-divider{display:none;}
+  .spa-time-block .time-picker-wheels{display:none;}
+  .spa-body{
+    --spa-body-padding:clamp(var(--space-4),6vw,var(--space-5));
+  }
+}
+@media (max-width:540px){
+  .spa-dialog{
+    --spa-dialog-max-width:420px;
+    --spa-dialog-max-height:640px;
+  }
+  .spa-footer-end{width:100%;justify-content:flex-end;}
+}

--- a/style.css
+++ b/style.css
@@ -2188,15 +2188,16 @@ body.custom-lock{overflow:hidden;}
   flex:0 0 auto;
   flex-wrap:nowrap;
 }
+/* Follow-up aligns the guest toggle with the chip rail by switching to the
+ * square 40px button spec while keeping the existing toggle handlers. */
 .spa-guest-switch{
-  width:48px;
-  height:28px;
-  border-radius:999px;
-  border:1px solid var(--border);
+  width:40px;
+  height:40px;
+  border-radius:10px;
+  border:1px solid var(--border-hairline);
   background:var(--surface);
-  display:flex;
-  align-items:center;
-  justify-content:center;
+  display:grid;
+  place-items:center;
   padding:0;
   transition:background-color .18s ease,border-color .18s ease,box-shadow .18s ease;
 }

--- a/style.css
+++ b/style.css
@@ -1715,13 +1715,10 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-option-check{inline-size:20px;block-size:20px;border-radius:999px;border:1px solid var(--hairline);display:inline-flex;align-items:center;justify-content:center;color:var(--brand);opacity:0;transform:scale(.86);transition:opacity .16s ease,transform .16s ease,border-color .16s ease,background-color .16s ease,box-shadow .16s ease;}
 .spa-option-row.is-selected .spa-option-check{opacity:1;transform:scale(1);background:color-mix(in srgb,var(--brand) 18%,var(--surface));border-color:color-mix(in srgb,var(--brand) 56%,var(--hairline));box-shadow:0 6px 16px rgba(42,107,255,.16);}
 .spa-option-row.is-disabled .spa-option-check{opacity:0;box-shadow:none;}
-.spa-guest-row{--spa-guest-color:var(--muted);}
-.spa-guest-row.is-off{color:var(--muted);}
-.spa-guest-row .spa-option-label{gap:10px;}
-.spa-guest-swatch{inline-size:12px;block-size:12px;border-radius:999px;background:var(--spa-guest-color);box-shadow:0 0 0 1px color-mix(in srgb,var(--spa-guest-color) 45%,transparent);}
-.spa-guest-row.is-off .spa-guest-swatch{opacity:.45;}
-.spa-guest-star{font-size:12px;color:var(--muted);line-height:1;}
-.spa-guest-row.is-selected .spa-guest-star{color:var(--brand);opacity:.85;}
+.spa-guest-row{--chip-color:var(--ink);}
+.spa-guest-row.is-off{opacity:.38;}
+.spa-guest-chip-star{font-size:11px;color:var(--muted);line-height:1;transition:color .18s ease;}
+.spa-guest-row.is-selected .spa-guest-chip-star{color:var(--brand);}
 .spa-time-picker{display:flex;flex-direction:column;align-items:center;gap:12px;}
 .spa-end-preview{display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;color:var(--muted);}
 .spa-start-time-display{border:0;border-radius:10px;padding:6px 14px;font:inherit;font-size:18px;font-weight:600;color:var(--ink);background:transparent;cursor:text;transition:background-color .16s ease,color .16s ease,box-shadow .16s ease;}
@@ -2153,7 +2150,6 @@ body.custom-lock{overflow:hidden;}
   flex:1 1 auto;
   min-width:0;
   display:flex;
-  flex-direction:row;
   align-items:center;
   gap:var(--space-3);
 }
@@ -2165,27 +2161,23 @@ body.custom-lock{overflow:hidden;}
   gap:var(--space-3);
   margin-inline-start:auto;
 }
-/* Footer guest grid keeps the toggle + chips locked to a single row while
- * letting the optional hint consume a full-width line when it appears. */
+/* Keep the footer as a single, non-wrapping row so the toggle, chips, and
+ * actions stay aligned while long guest lists scroll horizontally. */
 .spa-footer-guests{
-  display:grid;
-  grid-template-columns:auto minmax(0,1fr);
-  grid-template-rows:auto auto;
-  grid-template-areas:
-    "toggle chips"
-    "hint hint";
+  display:flex;
   align-items:center;
-  column-gap:var(--space-3);
-  row-gap:6px;
+  gap:var(--space-3);
   min-width:0;
   width:100%;
+  flex:1 1 auto;
+  overflow:hidden;
 }
 .spa-footer-guests .spa-guest-header{
   display:flex;
   align-items:center;
   gap:var(--space-3);
   justify-content:flex-start;
-  grid-area:toggle;
+  flex:0 0 auto;
 }
 .spa-guest-switch{
   width:48px;
@@ -2222,40 +2214,54 @@ body.custom-lock{overflow:hidden;}
   -webkit-overflow-scrolling:touch;
   flex:1 1 auto;
   min-width:0;
-  grid-area:chips;
 }
-/* Keep the guest chips inline beside the toggle and prefer horizontal scroll
- * over wrapping so the footer height stays stable across breakpoints. */
+/* Maintain inline chips beside the toggle; horizontal scroll absorbs overflow
+ * instead of wrapping so the footer height never changes. */
 .spa-footer-guests .spa-guest-chip-list{scrollbar-width:thin;}
-.spa-footer-guests .spa-guest-hint{grid-area:hint;}
-.spa-footer-guests .spa-option-row{
-  border-radius:999px;
-  border:1px solid var(--border-hairline);
-  background:var(--surface);
-  padding:6px 12px;
-  min-height:0;
-  font-size:14px;
-  font-weight:600;
-  gap:8px;
-  color:var(--ink);
-}
-.spa-footer-guests .spa-option-row.is-selected{
-  background:color-mix(in srgb,var(--brand) 12%,var(--surface));
-  border-color:color-mix(in srgb,var(--brand) 56%,var(--border-hairline));
-}
-.spa-footer-guests .spa-option-row.is-off{opacity:.6;}
-.spa-footer-guests .spa-option-check{display:none;}
-.spa-footer-guests .spa-option-label{gap:6px;}
-.spa-footer-guests .spa-option-text{font-weight:600;}
-.spa-footer-guests .spa-guest-swatch{
-  width:18px;
-  height:18px;
-  border-radius:999px;
-  box-shadow:none;
-}
 .spa-footer-guests .spa-guest-hint{
   margin:0;
   font-size:12px;
+  color:var(--muted);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  flex:0 1 auto;
+  align-self:center;
+}
+.spa-footer-guests .spa-guest-chip{
+  --chip-size:32px;
+  --chip-color:var(--ink);
+  width:var(--chip-size);
+  height:var(--chip-size);
+  display:inline-grid;
+  place-items:center;
+  border-radius:50%;
+  border:1px solid var(--chip-color);
+  background:var(--surface);
+  color:var(--chip-color);
+  font-weight:600;
+  position:relative;
+  transition:box-shadow .18s ease,opacity .18s ease;
+}
+.spa-footer-guests .spa-guest-chip .initial{
+  font-size:14px;
+  font-weight:600;
+  color:inherit;
+}
+.spa-footer-guests .spa-guest-chip.is-selected{
+  background:color-mix(in srgb,var(--chip-color) 18%,var(--surface));
+  box-shadow:0 6px 14px rgba(15,23,42,.14);
+}
+.spa-footer-guests .spa-guest-chip.is-off{opacity:.38;}
+.spa-footer-guests .spa-guest-chip:focus-visible{
+  outline:2px solid var(--activity-focus-ring);
+  outline-offset:2px;
+}
+.spa-footer-guests .spa-guest-chip-star{
+  position:absolute;
+  top:-6px;
+  right:-6px;
+  font-size:10px;
   color:var(--muted);
 }
 @media (max-width:900px){

--- a/style.css
+++ b/style.css
@@ -1973,8 +1973,8 @@ body.custom-lock{overflow:hidden;}
 .spa-dialog .modal-header{top:0;}
 .spa-dialog .modal-footer{
   bottom:0;
-  align-items:flex-start;
-  flex-wrap:wrap;
+  align-items:center;
+  flex-wrap:nowrap;
   gap:var(--space-4);
 }
 .spa-body{
@@ -2153,8 +2153,9 @@ body.custom-lock{overflow:hidden;}
   flex:1 1 auto;
   min-width:0;
   display:flex;
-  flex-direction:column;
-  gap:6px;
+  flex-direction:row;
+  align-items:center;
+  gap:var(--space-3);
 }
 .spa-footer-end{
   flex:0 0 auto;
@@ -2164,11 +2165,18 @@ body.custom-lock{overflow:hidden;}
   gap:var(--space-3);
   margin-inline-start:auto;
 }
+/* Footer guest grid keeps the toggle + chips locked to a single row while
+ * letting the optional hint consume a full-width line when it appears. */
 .spa-footer-guests{
-  display:flex;
-  flex-direction:column;
-  align-items:flex-start;
-  gap:8px;
+  display:grid;
+  grid-template-columns:auto minmax(0,1fr);
+  grid-template-rows:auto auto;
+  grid-template-areas:
+    "toggle chips"
+    "hint hint";
+  align-items:center;
+  column-gap:var(--space-3);
+  row-gap:6px;
   min-width:0;
   width:100%;
 }
@@ -2177,6 +2185,7 @@ body.custom-lock{overflow:hidden;}
   align-items:center;
   gap:var(--space-3);
   justify-content:flex-start;
+  grid-area:toggle;
 }
 .spa-guest-switch{
   width:48px;
@@ -2190,6 +2199,7 @@ body.custom-lock{overflow:hidden;}
   padding:0;
   transition:background-color .18s ease,border-color .18s ease,box-shadow .18s ease;
 }
+.spa-footer-guests .spa-guest-switch{flex:0 0 auto;}
 .spa-guest-switch:hover{
   border-color:color-mix(in srgb,var(--brand) 32%,var(--border));
   box-shadow:0 6px 16px rgba(42,107,255,.12);
@@ -2200,14 +2210,24 @@ body.custom-lock{overflow:hidden;}
 }
 .spa-guest-chip-list{
   display:flex;
-  flex-wrap:wrap;
+  align-items:center;
+  flex-wrap:nowrap;
   gap:8px;
   border:0;
   background:transparent;
   padding:0;
   max-block-size:none;
-  overflow:visible;
+  overflow-x:auto;
+  overflow-y:hidden;
+  -webkit-overflow-scrolling:touch;
+  flex:1 1 auto;
+  min-width:0;
+  grid-area:chips;
 }
+/* Keep the guest chips inline beside the toggle and prefer horizontal scroll
+ * over wrapping so the footer height stays stable across breakpoints. */
+.spa-footer-guests .spa-guest-chip-list{scrollbar-width:thin;}
+.spa-footer-guests .spa-guest-hint{grid-area:hint;}
 .spa-footer-guests .spa-option-row{
   border-radius:999px;
   border:1px solid var(--border-hairline);
@@ -2264,5 +2284,4 @@ body.custom-lock{overflow:hidden;}
     --spa-dialog-max-width:420px;
     --spa-dialog-max-height:640px;
   }
-  .spa-footer-end{width:100%;justify-content:flex-end;}
 }

--- a/style.css
+++ b/style.css
@@ -1366,6 +1366,7 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   background:var(--surface);
   border-top:1px solid var(--hairline);
   flex-shrink:0;
+  flex-wrap:nowrap;
 }
 .modal-footer-start,.modal-footer-end{display:flex;align-items:center;gap:var(--space-3);}
 .modal-footer-end{justify-content:flex-end;}
@@ -1717,8 +1718,6 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 .spa-option-row.is-disabled .spa-option-check{opacity:0;box-shadow:none;}
 .spa-guest-row{--chip-color:var(--ink);}
 .spa-guest-row.is-off{opacity:.38;}
-.spa-guest-chip-star{font-size:11px;color:var(--muted);line-height:1;transition:color .18s ease;}
-.spa-guest-row.is-selected .spa-guest-chip-star{color:var(--brand);}
 .spa-time-picker{display:flex;flex-direction:column;align-items:center;gap:12px;}
 .spa-end-preview{display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;color:var(--muted);}
 .spa-start-time-display{border:0;border-radius:10px;padding:6px 14px;font:inherit;font-size:18px;font-weight:600;color:var(--ink);background:transparent;cursor:text;transition:background-color .16s ease,color .16s ease,box-shadow .16s ease;}
@@ -2146,38 +2145,46 @@ body.custom-lock{overflow:hidden;}
   justify-content:center;
   text-align:center;
 }
+/* Follow-up aligns the footer into a single row; the 10px gap keeps the toggle
+ * and first chip tight without letting the group wrap under the switch. */
 .spa-footer-start{
   flex:1 1 auto;
   min-width:0;
   display:flex;
   align-items:center;
-  gap:var(--space-3);
+  gap:10px;
+  flex-wrap:nowrap;
+  justify-content:flex-start;
 }
 .spa-footer-end{
   flex:0 0 auto;
   display:flex;
   align-items:center;
   justify-content:flex-end;
-  gap:var(--space-3);
+  gap:var(--space-5);
   margin-inline-start:auto;
+  flex-wrap:nowrap;
 }
 /* Keep the footer as a single, non-wrapping row so the toggle, chips, and
  * actions stay aligned while long guest lists scroll horizontally. */
 .spa-footer-guests{
   display:flex;
   align-items:center;
-  gap:var(--space-3);
+  gap:10px;
   min-width:0;
   width:100%;
   flex:1 1 auto;
   overflow:hidden;
+  flex-wrap:nowrap;
+  justify-content:flex-start;
 }
 .spa-footer-guests .spa-guest-header{
   display:flex;
   align-items:center;
-  gap:var(--space-3);
+  gap:10px;
   justify-content:flex-start;
   flex:0 0 auto;
+  flex-wrap:nowrap;
 }
 .spa-guest-switch{
   width:48px;
@@ -2200,11 +2207,13 @@ body.custom-lock{overflow:hidden;}
   outline:2px solid var(--activity-focus-ring);
   outline-offset:2px;
 }
+/* Chips scroll horizontally instead of wrapping so the footer height stays
+ * fixed across desktop/iPad/mobile breakpoints. */
 .spa-guest-chip-list{
   display:flex;
   align-items:center;
   flex-wrap:nowrap;
-  gap:8px;
+  gap:6px;
   border:0;
   background:transparent;
   padding:0;
@@ -2214,6 +2223,7 @@ body.custom-lock{overflow:hidden;}
   -webkit-overflow-scrolling:touch;
   flex:1 1 auto;
   min-width:0;
+  white-space:nowrap;
 }
 /* Maintain inline chips beside the toggle; horizontal scroll absorbs overflow
  * instead of wrapping so the footer height never changes. */
@@ -2256,13 +2266,6 @@ body.custom-lock{overflow:hidden;}
 .spa-footer-guests .spa-guest-chip:focus-visible{
   outline:2px solid var(--activity-focus-ring);
   outline-offset:2px;
-}
-.spa-footer-guests .spa-guest-chip-star{
-  position:absolute;
-  top:-6px;
-  right:-6px;
-  font-size:10px;
-  color:var(--muted);
 }
 @media (max-width:900px){
   .spa-dialog{


### PR DESCRIPTION
Context:
- Align the SPA modal with the updated desktop/iPad/mobile reference layouts.

Approach:
- Wrapped the modal body in a two-column grid with a central hairline, kept the service and picker subtrees intact, and moved the guest toggles into the footer chips while preserving all handlers.
- Updated SPA-specific styling for sticky header/footer behavior, breakpoint-driven size clamps, refreshed service accordion visuals, the time block, and footer guest chips (mobile view hides the kinetic columns).
- Added a dedicated spa-modal-preview route showing desktop/iPad/mobile in both Add and Edit states.

Guardrails upheld:
- Preserved existing data flow, picker logic, guest semantics, and public APIs.
- Kept theming tokens, focus treatments, and time defaults intact.

Screenshots:
- spa-modal-preview.png (desktop)

Notes:
- None.

------
https://chatgpt.com/codex/tasks/task_e_68ecc1af77f48330a4bfbb0da9e4adbf