### PR TITLE
Align SPA picker stack defaults

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,7 +67,7 @@
   // inside the fixed grid cell; downstream outputs continue to call the full
   // label helper so confirmation copy retains the "-Minute" suffix.
   const formatDurationLabel = minutes => `${minutes}-Minute`;
-  const formatDurationButtonLabel = minutes => minutes.toString();
+  const formatDurationButtonLabel = minutes => `${minutes} Minutes`;
   const keyDate = d => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
 
   // Utility focus helper so we can safely focus elements without the browser
@@ -182,7 +182,7 @@
   ];
 
   const SPA_LOCATION_OPTIONS = [
-    { id: 'not-applicable', label: 'N/A' },
+    { id: 'not-applicable', label: 'No Preference' },
     { id: 'same-cabana', label: 'Same Cabana' },
     { id: 'separate-cabanas', label: 'Separate Cabanas' },
     { id: 'couples-massage', label: 'Couple’s Massage' },
@@ -2386,7 +2386,7 @@
     const defaultLocationId = singleGuestStay ? 'not-applicable' : 'same-cabana';
     const knownLocationIds = new Set(SPA_LOCATION_OPTIONS.map(opt => opt.id));
     // Normalise persisted location selections so single-guest stays resolve to
-    // “N/A” while multi-guest itineraries always fall back to Same Cabana. This
+    // “No Preference” while multi-guest itineraries always fall back to Same Cabana. This
     // keeps historic data valid without exposing unsupported choices.
     const normalizeLocationId = (value, { supportsInRoom = true } = {}) => {
       let next = value;
@@ -3140,10 +3140,12 @@
     // Details column now stacks the time block above the picker stack while
     // keeping each wheel/list wired to the existing handlers.
     detailsGrid.className='spa-details-grid';
+    detailsGrid.classList.add('col-body');
     detailsSection.appendChild(detailsGrid);
     detailsColumn.appendChild(detailsSection);
     const pickerStack=document.createElement('div');
     pickerStack.className='spa-picker-stack';
+    pickerStack.classList.add('picker-stack');
 
     const durationGroup=document.createElement('div');
     durationGroup.className='spa-block spa-detail-card spa-detail-card-duration';
@@ -3169,6 +3171,7 @@
     timeHeading.classList.add('sr-only');
     timeGroup.appendChild(timeHeading);
     timeGroup.classList.add('spa-time-block');
+    timeGroup.classList.add('time-block');
     const timeContainer=document.createElement('div');
     timeContainer.className='spa-time-picker';
     timeGroup.appendChild(timeContainer);
@@ -3577,7 +3580,7 @@
               loop: false,
               idPrefix: `${pickerNamespace}-duration`,
               formatValue: value => formatDurationButtonLabel(value),
-              getOptionLabel: value => formatDurationLabel(value),
+              getOptionLabel: value => formatDurationButtonLabel(value),
               ariaLabel: 'Duration',
               onChange(value){
                 selectDuration(value);
@@ -3586,6 +3589,7 @@
             durationWheel.element.classList.add('spa-single-wheel');
             durationWheel.element.setAttribute('aria-labelledby', `${durationHeading.id} ${durationValueLabel.id}`);
             durationPickerContainer.appendChild(durationWheel.element);
+            durationPickerContainer.classList.add('picker-field');
           }
         }
         if(durationWheel){
@@ -3593,7 +3597,7 @@
           const fallback = durations.includes(canonical) ? canonical : durations[0];
           if(fallback !== undefined){
             durationWheel.setValue(fallback);
-            const label = formatDurationLabel(fallback);
+            const label = formatDurationButtonLabel(fallback);
             durationValueLabel.textContent = label;
             durationWheel.element.setAttribute('aria-label', `Duration, ${label}`);
           }else{
@@ -3619,7 +3623,7 @@
           const labelSpan=document.createElement('span');
           labelSpan.className='spa-option-label';
           labelSpan.textContent=formatDurationButtonLabel(minutes);
-          btn.setAttribute('aria-label', formatDurationLabel(minutes));
+          btn.setAttribute('aria-label', formatDurationButtonLabel(minutes));
           const checkSpan=document.createElement('span');
           checkSpan.className='spa-option-check';
           checkSpan.innerHTML=checkmarkSvg;
@@ -3634,9 +3638,9 @@
         });
         let fallbackLabel='';
         if(canonical !== undefined){
-          fallbackLabel = formatDurationLabel(canonical);
+          fallbackLabel = formatDurationButtonLabel(canonical);
         }else if(durations.length){
-          fallbackLabel = formatDurationLabel(durations[0]);
+          fallbackLabel = formatDurationButtonLabel(durations[0]);
         }
         durationValueLabel.textContent = fallbackLabel;
         durationPickerContainer.setAttribute('aria-label', fallbackLabel ? `Duration, ${fallbackLabel}` : 'Duration');
@@ -3651,6 +3655,7 @@
         therapistWheel.setValue(current);
         therapistValueLabel.textContent = label;
         therapistWheel.element.setAttribute('aria-label', `Therapist Preference, ${label}`);
+        therapistPickerContainer.classList.add('picker-field');
       }else{
         const rows = therapistPickerContainer.querySelectorAll('.spa-option-row');
         rows.forEach(btn => {
@@ -3676,7 +3681,7 @@
         }
         return false;
       };
-      // Ensure every selection reflects the latest availability so stale “N/A”
+      // Ensure every selection reflects the latest availability so stale “No Preference”
       // or In-Room values snap to a valid choice when guest counts or services
       // change while the modal is open.
       selections.forEach(sel => {
@@ -3696,6 +3701,7 @@
         const label = locationLabelById.get(fallbackLocation) || '';
         locationValueLabel.textContent = label;
         locationWheel.element.setAttribute('aria-label', label ? `Location, ${label}` : 'Location');
+        locationPickerContainer.classList.add('picker-field');
       }else{
         const buttons = locationPickerContainer.querySelectorAll('.spa-option-row');
         buttons.forEach(btn => {
@@ -3719,7 +3725,7 @@
         helperMessages.push('In-Room service is unavailable for this treatment.');
       }
       if(singleGuestStay){
-        helperMessages.push('Location defaults to N/A until another guest is added to the stay.');
+        helperMessages.push('Location defaults to No Preference until another guest is added to the stay.');
       }
       locationHelper.textContent = helperMessages.join(' ');
     }

--- a/spa-modal-preview.js
+++ b/spa-modal-preview.js
@@ -23,7 +23,7 @@
   ];
 
   const locationOptions = [
-    { id:'not-applicable', label:'N/A' },
+    { id:'not-applicable', label:'No Preference' },
     { id:'same-cabana', label:'Same Cabana' },
     { id:'separate-cabanas', label:'Separate Cabanas' },
     { id:'couples-massage', label:'Couple’s Massage' },
@@ -213,12 +213,14 @@
 
     const grid = document.createElement('div');
     grid.className = 'spa-details-grid';
+    grid.classList.add('col-body');
     section.appendChild(grid);
 
     grid.appendChild(buildTimeCard(viewport));
 
     const pickerStack = document.createElement('div');
     pickerStack.className = 'spa-picker-stack';
+    pickerStack.classList.add('picker-stack');
     pickerStack.appendChild(buildPickerCard({
       title:'Therapist Preference',
       srOnly:true,
@@ -244,6 +246,7 @@
   function buildTimeCard(viewport){
     const card = document.createElement('div');
     card.className = 'spa-block spa-detail-card spa-detail-card-time spa-time-block';
+    card.classList.add('time-block');
 
     const heading = document.createElement('h3');
     heading.className = 'sr-only';

--- a/style.css
+++ b/style.css
@@ -22,6 +22,7 @@
   --chipText:#1e1b4b;
   --fg:var(--text-primary);
   --hairline:var(--border-hairline);
+  --line:var(--border-hairline);
   /* Slightly stronger hairline for elements that need an outline against accent fills. */
   --hairline-strong:color-mix(in srgb,var(--text-primary) 12%,transparent);
   --surface-tint:color-mix(in srgb,var(--surface) 92%,var(--brand) 8%);
@@ -2050,19 +2051,23 @@ body.custom-lock{overflow:hidden;}
 }
 .spa-service-button::after{left:52px;right:18px;}
 .spa-cascade-panel::before{left:18px;right:18px;}
+.col-body{
+  display:grid;
+  gap:var(--space-6);
+  align-content:start;
+  justify-items:stretch;
+}
 .spa-details-grid{
   --spa-detail-max-width:min(100%,420px);
-  display:flex;
-  flex-direction:column;
-  align-items:center;
-  gap:0;
   min-height:0;
 }
-.spa-time-block{
-  display:flex;
-  flex-direction:column;
+.time-block{
+  display:grid;
   gap:var(--space-5);
-  align-items:stretch;
+  justify-items:stretch;
+}
+.spa-time-block{
+  gap:var(--space-5);
 }
 .spa-time-block .spa-time-picker{
   display:flex;
@@ -2120,12 +2125,15 @@ body.custom-lock{overflow:hidden;}
   color:var(--muted);
 }
 .spa-time-block .spa-time-hint{text-align:center;}
-.spa-picker-stack{
+.picker-stack{
   display:grid;
   gap:var(--space-5);
+  justify-items:stretch;
+  margin-top:var(--space-5);
+}
+.spa-picker-stack{
   min-height:0;
   width:100%;
-  margin-top:var(--space-5);
 }
 .spa-picker-stack .spa-detail-card{
   align-items:stretch;
@@ -2133,15 +2141,29 @@ body.custom-lock{overflow:hidden;}
 }
 .spa-picker-stack .spa-option-list{
   width:100%;
-  border:1px solid var(--border-hairline);
-  border-radius:16px;
+  border:1px solid var(--line);
+  border-radius:10px;
   background:var(--surface);
-  box-shadow:0 1px 0 rgba(15,23,42,.04);
+  box-shadow:none;
 }
-.spa-picker-stack .spa-single-picker{padding-block:12px;}
 .spa-picker-stack .spa-option-row{
   justify-content:center;
   text-align:center;
+}
+.picker-field{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  height:44px;
+  padding:0 var(--space-4);
+  border:1px solid var(--line);
+  border-radius:10px;
+  background:var(--surface);
+  color:var(--ink);
+}
+.picker-field .wheel-viewport{
+  height:100%;
+  width:100%;
 }
 /* Follow-up aligns the footer into a single row so the toggle + chips stay
  * inline. Gap mirrors the spec’s 8px spacing between the switch and chips. */


### PR DESCRIPTION
Context: SPA modal pickers rendered blank under the time selector and spacing drifted off spec.
Approach: Restyled the details column as a grid, mapped the existing wheel containers to the picker-stack classes, and refreshed copy so Therapist/Location/Durations surface their defaults (No Preference / Same Cabana / 60 Minutes) immediately.
Guardrails upheld: Reused existing picker DOM, preserved time picker behavior, honored modal spacing tokens across desktop/iPad/mobile.
Screenshots: Full-screen desktop — SPA Add modal defaults (browser:/invocations/hukcdhve/artifacts/artifacts/spa_modal_after.png)
Notes: None.


------
https://chatgpt.com/codex/tasks/task_e_68ed6d0fabb08330a6b1d80ef25be4b7