### PR TITLE
Custom modal: 2×2 body grid layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -4161,24 +4161,32 @@
     body.className='modal-body spa-body custom-body';
     dialog.appendChild(body);
 
-    const shell=document.createElement('div');
-    shell.className='custom-modal-shell';
-    body.appendChild(shell);
+    const bodyGrid=document.createElement('div');
+    bodyGrid.className='custom-body-grid';
+    body.appendChild(bodyGrid);
 
-    const timeBlock=document.createElement('div');
-    timeBlock.className='custom-time-block';
-    shell.appendChild(timeBlock);
+    const topGrid=document.createElement('section');
+    topGrid.className='top-grid';
+    bodyGrid.appendChild(topGrid);
 
-    const timeVisual=document.createElement('div');
-    timeVisual.className='custom-time-visual';
-    timeBlock.appendChild(timeVisual);
+    const timePickerArea=document.createElement('div');
+    timePickerArea.className='top-left time-picker-area';
+    topGrid.appendChild(timePickerArea);
 
-    const timeActions=document.createElement('div');
-    timeActions.className='custom-time-actions';
-    timeBlock.appendChild(timeActions);
+    const timePillsSection=document.createElement('div');
+    timePillsSection.className='top-right time-pills';
+    topGrid.appendChild(timePillsSection);
+
+    const startRow=document.createElement('div');
+    startRow.className='start-row';
+    timePillsSection.appendChild(startRow);
+
+    const endRow=document.createElement('div');
+    endRow.className='end-row';
+    timePillsSection.appendChild(endRow);
 
     const startPill=document.createElement('div');
-    startPill.className='pill custom-time-pill';
+    startPill.className='pill time-pill start-pill custom-time-pill';
     startPill.tabIndex=0;
     startPill.setAttribute('aria-label','Start time not set');
     startPill.setAttribute('aria-live','polite');
@@ -4188,7 +4196,7 @@
     startPill.appendChild(startValueNode);
 
     const endPill=document.createElement('div');
-    endPill.className='pill custom-time-pill';
+    endPill.className='pill time-pill end-pill custom-time-pill';
     endPill.tabIndex=0;
     endPill.setAttribute('aria-label','End time not set');
     endPill.setAttribute('aria-live','polite');
@@ -4224,19 +4232,22 @@
     const timeError=document.createElement('p');
     timeError.className='custom-time-error';
     timeError.hidden=true;
-    timeBlock.appendChild(timeError);
 
-    const divider=document.createElement('div');
-    divider.className='custom-divider';
-    shell.appendChild(divider);
+    const bottomGrid=document.createElement('section');
+    bottomGrid.className='bottom-grid';
+    bodyGrid.appendChild(bottomGrid);
 
-    const pickerRow=document.createElement('div');
-    pickerRow.className='custom-picker-row';
-    shell.appendChild(pickerRow);
+    const titleRow=document.createElement('div');
+    titleRow.className='row title-row';
+    bottomGrid.appendChild(titleRow);
+
+    const locationRow=document.createElement('div');
+    locationRow.className='row location-row';
+    bottomGrid.appendChild(locationRow);
 
     const namePicker=document.createElement('div');
     namePicker.className='custom-picker custom-picker-name';
-    pickerRow.appendChild(namePicker);
+    titleRow.appendChild(namePicker);
 
     const nameActionBtn=document.createElement('button');
     nameActionBtn.type='button';
@@ -4297,7 +4308,7 @@
 
     const locationPicker=document.createElement('div');
     locationPicker.className='custom-picker custom-picker-location';
-    pickerRow.appendChild(locationPicker);
+    locationRow.appendChild(locationPicker);
 
     const locationField=document.createElement('button');
     locationField.type='button';
@@ -4866,7 +4877,7 @@
     }
 
     if(timePicker){
-      timeVisual.appendChild(timePicker.element);
+      timePickerArea.appendChild(timePicker.element);
       const inlineField=timePicker.element.querySelector('.time-picker-inline-field');
       if(inlineField){ inlineField.remove(); }
       const rangeActions=timePicker.element.querySelector('.time-picker-range-actions');
@@ -4875,7 +4886,7 @@
         if(rangeButtons[0]){
           startButton = rangeButtons[0];
           startButton.classList.remove('time-picker-range-btn');
-          startButton.classList.add('square-btn','custom-hourglass-btn');
+          startButton.classList.add('square-btn','start-btn');
           startButton.innerHTML = hourglassStartSvg;
           startButton.setAttribute('aria-label','Set Start Time');
           startButton.title = 'Set Start Time';
@@ -4883,7 +4894,7 @@
         if(rangeButtons[1]){
           endButton = rangeButtons[1];
           endButton.classList.remove('time-picker-range-btn');
-          endButton.classList.add('square-btn','custom-hourglass-btn');
+          endButton.classList.add('square-btn','end-btn');
           endButton.innerHTML = hourglassEndSvg;
           endButton.setAttribute('aria-label','Set End Time');
           endButton.title = 'Set End Time';
@@ -4894,13 +4905,13 @@
       const fallback=document.createElement('div');
       fallback.className='custom-picker-fallback';
       fallback.textContent='Time picker unavailable.';
-      timeVisual.appendChild(fallback);
+      timePickerArea.appendChild(fallback);
     }
 
     if(!startButton){
       startButton=document.createElement('button');
       startButton.type='button';
-      startButton.className='square-btn custom-hourglass-btn';
+      startButton.className='square-btn start-btn';
       startButton.innerHTML=hourglassStartSvg;
       startButton.disabled=true;
       startButton.setAttribute('aria-label','Set Start Time');
@@ -4909,17 +4920,20 @@
     if(!endButton){
       endButton=document.createElement('button');
       endButton.type='button';
-      endButton.className='square-btn custom-hourglass-btn';
+      endButton.className='square-btn end-btn';
       endButton.innerHTML=hourglassEndSvg;
       endButton.disabled=true;
       endButton.setAttribute('aria-label','Set End Time');
       endButton.title='Set End Time';
     }
 
-    timeActions.appendChild(startButton);
-    timeActions.appendChild(startPill);
-    timeActions.appendChild(endButton);
-    timeActions.appendChild(endPill);
+    startRow.appendChild(startButton);
+    startRow.appendChild(startPill);
+    endRow.appendChild(endButton);
+    endRow.appendChild(endPill);
+    // Keep the validation helper inside the End row so it spans the two-column
+    // grid without introducing another structural wrapper.
+    endRow.appendChild(timeError);
 
     const handleSave=()=>{
       const titleValue = resolveTitle();

--- a/style.css
+++ b/style.css
@@ -1732,13 +1732,10 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-overlay{z-index:2200;}
 .custom-body{
   overflow:auto;
-  padding-block-end:calc(var(--spa-body-padding) + env(safe-area-inset-bottom));
+  padding:0;
   overscroll-behavior:contain;
   scrollbar-gutter:stable both-edges;
-  display:grid;
-  gap:var(--rhythm);
-  padding:var(--rhythm);
-  align-content:start;
+  min-height:0;
 }
 /* Adopted new Custom modal shell (structure-only). */
 .custom-dialog{display:grid;grid-template-rows:auto 1fr auto;min-height:0;}
@@ -1746,31 +1743,125 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-dialog .modal-footer{position:sticky;z-index:2;background:var(--panel);padding:var(--rhythm);}
 .custom-dialog .modal-header{top:0;border-bottom:1px solid var(--border-hairline);}
 .custom-dialog .modal-footer{bottom:0;border-top:1px solid var(--border-hairline);}
-.custom-modal-shell{display:grid;gap:var(--rhythm);align-content:start;}
-.custom-time-block{display:grid;gap:var(--space-5);}
-.custom-time-visual{display:flex;justify-content:center;}
-.custom-time-visual > .time-picker{width:100%;display:flex;flex-direction:column;gap:var(--space-5);align-items:stretch;}
-.custom-time-visual .time-picker-wheels{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-5);align-items:center;}
-.custom-time-visual .time-picker-inline-field{display:none;}
-.custom-time-visual .time-picker-column{min-height:calc(5 * var(--space-3));}
-.custom-time-actions{display:grid;grid-template-columns:auto 1fr auto 1fr;gap:var(--space-4);align-items:center;}
-.custom-hourglass-btn{width:40px;height:40px;border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);display:grid;place-items:center;padding:0;transition:box-shadow .18s ease,border-color .18s ease;}
-.custom-hourglass-btn:focus-visible{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 6px 16px rgba(42,107,255,.16);}
-.custom-hourglass-btn:disabled{opacity:.45;cursor:default;}
-.custom-dialog .pill{position:relative;display:flex;align-items:center;justify-content:center;height:40px;border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);padding:0 var(--space-4);font-weight:600;letter-spacing:.01em;color:var(--ink);min-width:0;cursor:default;}
-.custom-dialog .pill:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.custom-time-pill[data-empty='true']{color:var(--muted);}
+/* // Custom modal: 2×2 body grid */
+.custom-body-grid{
+  display:grid;
+  grid-template-rows:1fr 1fr;
+  gap:var(--space-6);
+  padding:var(--rhythm);
+  padding-block-end:calc(var(--rhythm) + env(safe-area-inset-bottom));
+  min-height:0;
+}
+
+.top-grid{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:var(--space-6);
+  min-height:0;
+}
+
+.time-picker-area{
+  display:grid;
+  min-height:0;
+}
+
+.time-pills{
+  display:grid;
+  grid-template-rows:1fr 1fr;
+  gap:var(--space-6);
+  align-content:start;
+  min-height:0;
+}
+
+.start-row,
+.end-row{
+  display:grid;
+  grid-template-columns:auto 1fr;
+  align-items:center;
+  gap:12px;
+}
+
+.square-btn{
+  width:40px;
+  height:40px;
+  border-radius:10px;
+  border:1px solid var(--line);
+  background:var(--surface,#fff);
+  display:grid;
+  place-items:center;
+  padding:0;
+  transition:box-shadow .18s ease,border-color .18s ease;
+}
+
+.square-btn:focus-visible{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+  box-shadow:0 6px 16px rgba(42,107,255,.16);
+}
+
+.square-btn:disabled{opacity:.45;cursor:default;}
+
+.custom-dialog .time-pill{
+  position:relative;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  height:40px;
+  border-radius:10px;
+  border:1px solid var(--line);
+  background:var(--surface,#fff);
+  padding:0 var(--space-4);
+  font-weight:600;
+  letter-spacing:.01em;
+  color:var(--ink);
+  min-width:0;
+  cursor:default;
+}
+
+.custom-dialog .time-pill:focus-visible{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+}
+
+.time-pill[data-empty='true']{color:var(--muted);}
+
 .custom-time-value{font-size:15px;font-weight:600;color:inherit;white-space:nowrap;}
+
 .custom-clear-end{position:absolute;top:4px;right:6px;width:24px;height:24px;border:0;border-radius:8px;background:transparent;color:var(--muted);display:inline-flex;align-items:center;justify-content:center;padding:0;cursor:pointer;transition:color .18s ease,background-color .18s ease;}
 .custom-clear-end[hidden]{display:none;}
 .custom-clear-end:disabled{cursor:default;opacity:.35;}
 .custom-clear-end:not(:disabled):hover{color:var(--ink);background:color-mix(in srgb,var(--brand) 12%,transparent);}
 .custom-clear-end:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
-.custom-time-error{margin:0;font-size:13px;color:var(--brand);font-weight:600;}
-.custom-divider{height:1px;background:var(--border-hairline);}
-.custom-picker-row{display:grid;gap:var(--space-5);}
-@media (min-width:900px){
-  .custom-picker-row{grid-template-columns:1fr;}
+
+.custom-time-error{
+  margin:0;
+  font-size:13px;
+  color:var(--brand);
+  font-weight:600;
+}
+
+.end-row .custom-time-error{
+  grid-column:1 / -1;
+  margin-inline-start:calc(40px + 12px);
+  margin-block-start:4px;
+}
+
+.bottom-grid{
+  display:grid;
+  grid-template-rows:auto auto;
+  gap:var(--space-6);
+}
+
+.row > *{width:100%;}
+
+.custom-body-grid,
+.top-grid,
+.bottom-grid{box-sizing:border-box;}
+
+@media (max-width:840px){
+  .custom-body-grid{grid-template-rows:auto auto auto auto;}
+  .top-grid{grid-template-columns:1fr;grid-template-rows:auto auto;}
+  .time-pills{grid-template-rows:auto auto;}
 }
 .custom-picker{display:flex;align-items:center;gap:12px;}
 .custom-picker-name{position:relative;}


### PR DESCRIPTION
## Summary
- rebuild the custom modal body using a two-row grid so the time picker, pills, title, and location mount in the prescribed slots
- restyle the hourglass controls and pills with new square button/pill classes while keeping validation inline with the end row
- add responsive grid rules and spacing tokens to preserve SPA padding, alignment, and safe-area support

## Testing
- Manual QA via custom-demo.html

## Screenshots
![Custom modal body grid](browser:/invocations/shdeqvwy/artifacts/artifacts/custom-modal-grid.png)


------
https://chatgpt.com/codex/tasks/task_e_68f169e0cca883309286d92c69230146