### PR TITLE
Sync custom modal shell with SPA

### DIFF
--- a/script.js
+++ b/script.js
@@ -4136,9 +4136,24 @@
     dialog.setAttribute('aria-modal','true');
     dialog.setAttribute('aria-labelledby','custom-dialog-title');
 
-    const header=document.createElement('div');
-    header.className='modal-header custom-header';
-    const title=document.createElement('h2');
+    // Custom modal: header/footer synced to SPA shell (visual only, no logic changes)
+    const createFooterIcon = markup => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = markup;
+      const svg = wrapper.firstElementChild;
+      if(svg){
+        svg.classList.add('icon');
+        if(!svg.hasAttribute('aria-hidden')){
+          svg.setAttribute('aria-hidden','true');
+        }
+        svg.setAttribute('focusable','false');
+      }
+      return svg;
+    };
+
+    const header=document.createElement('header');
+    header.className='modal-header';
+    const title=document.createElement('div');
     title.className='modal-title';
     title.id='custom-dialog-title';
     title.textContent='Custom';
@@ -4146,13 +4161,16 @@
     customModeDescriptor.className='sr-only';
     customModeDescriptor.textContent = existing ? ' – Editing custom activity' : ' – Add custom activity';
     title.appendChild(customModeDescriptor);
-    const headerBar=document.createElement('div');
-    headerBar.className='custom-header-bar';
-    headerBar.appendChild(title);
+    header.appendChild(title);
 
-    const closeBtn=createModalCloseButton(()=> closeCustomBuilder({returnFocus:true}));
-    headerBar.appendChild(closeBtn);
-    header.appendChild(headerBar);
+    const closeBtn=document.createElement('button');
+    closeBtn.type='button';
+    closeBtn.className='close-btn modal-close';
+    closeBtn.setAttribute('aria-label','Close');
+    closeBtn.title='Close';
+    closeBtn.textContent='×';
+    closeBtn.addEventListener('click',()=> closeCustomBuilder({returnFocus:true}));
+    header.appendChild(closeBtn);
 
     dialog.appendChild(header);
 
@@ -4514,24 +4532,35 @@
 
     updateLocationDisplay();
 
-    const footer=document.createElement('div');
+    const footer=document.createElement('footer');
     footer.className='modal-footer';
-    const footerStart=document.createElement('div');
-    footerStart.className='modal-footer-start';
-    const footerEnd=document.createElement('div');
-    footerEnd.className='modal-footer-end';
+    const footerContent=document.createElement('div');
+    footerContent.className='footer-content';
+    const btnRow=document.createElement('div');
+    btnRow.className='btn-row';
+    footerContent.appendChild(btnRow);
+    footer.appendChild(footerContent);
     const saveIsEdit = !!existing;
-    const saveLabel = saveIsEdit ? 'Save custom activity' : 'Add custom activity';
-    const saveIcon = saveIsEdit ? saveIconSvg : addIconSvg;
-    const saveBtn=createIconButton({ icon: saveIcon, label: saveLabel, extraClass: 'btn-icon--primary' });
-    footerEnd.appendChild(saveBtn);
     let deleteBtn=null;
     if(saveIsEdit){
-      deleteBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete custom activity', extraClass: 'btn-icon--subtle' });
-      footerStart.appendChild(deleteBtn);
+      deleteBtn=document.createElement('button');
+      deleteBtn.type='button';
+      deleteBtn.className='btn';
+      deleteBtn.setAttribute('aria-label','Delete custom activity');
+      deleteBtn.title='Delete custom activity';
+      const deleteIconNode=createFooterIcon(deleteIconSvg);
+      if(deleteIconNode){ deleteBtn.appendChild(deleteIconNode); }
+      btnRow.appendChild(deleteBtn);
     }
-    footer.appendChild(footerStart);
-    footer.appendChild(footerEnd);
+    const saveBtn=document.createElement('button');
+    saveBtn.type='button';
+    saveBtn.className='btn primary';
+    const saveLabel = saveIsEdit ? 'Save custom activity' : 'Add custom activity';
+    saveBtn.setAttribute('aria-label', saveLabel);
+    saveBtn.title = saveLabel;
+    const saveIconNode=createFooterIcon(saveIsEdit ? saveIconSvg : addIconSvg);
+    if(saveIconNode){ saveBtn.appendChild(saveIconNode); }
+    btnRow.appendChild(saveBtn);
     dialog.appendChild(footer);
 
     overlay.appendChild(dialog);

--- a/style.css
+++ b/style.css
@@ -1320,8 +1320,37 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .modal-close{color:var(--muted);}
 .modal-close span[aria-hidden="true"]{font-size:24px;}
+.close-btn{
+  --close-size:40px;
+  inline-size:var(--close-size);
+  block-size:var(--close-size);
+  border-radius:999px;
+  border:1px solid var(--border-hairline);
+  background:var(--surface);
+  color:var(--muted);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  font-size:24px;
+  line-height:1;
+  cursor:pointer;
+  transition:background-color .18s ease,color .18s ease,border-color .18s ease,box-shadow .18s ease,transform .18s ease;
+}
+.close-btn:not([disabled]):hover{
+  color:var(--ink);
+  background:color-mix(in srgb,var(--brand) 12%,var(--surface));
+  border-color:color-mix(in srgb,var(--brand) 28%,var(--border-hairline));
+}
+.close-btn:not([disabled]):active{transform:translateY(1px);}
+.close-btn:focus-visible{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+  box-shadow:0 6px 18px rgba(42,107,255,.18);
+}
+.close-btn[disabled]{opacity:.45;cursor:not-allowed;box-shadow:none;}
 @media (prefers-reduced-motion:reduce){
   .btn-icon{transition:none;}
+  .close-btn{transition:none;}
 }
 
 .modal-header{
@@ -1373,6 +1402,61 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
 }
 .modal-footer-start,.modal-footer-end{display:flex;align-items:center;gap:var(--space-3);}
 .modal-footer-end{justify-content:flex-end;}
+.footer-content{
+  flex:1 1 auto;
+  display:flex;
+  justify-content:flex-end;
+  align-items:center;
+}
+.btn-row{display:flex;align-items:center;gap:var(--space-3);}
+.btn{
+  min-inline-size:44px;
+  min-block-size:44px;
+  border-radius:12px;
+  border:1px solid var(--border-hairline);
+  background:var(--surface);
+  color:var(--muted);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:0;
+  font:inherit;
+  line-height:1;
+  cursor:pointer;
+  transition:background-color .18s ease,border-color .18s ease,box-shadow .18s ease,color .18s ease,transform .18s ease;
+}
+.btn .icon{
+  --icon-size:22px;
+  inline-size:var(--icon-size);
+  block-size:var(--icon-size);
+}
+.btn.primary{
+  background:var(--brand);
+  border-color:var(--brand);
+  color:var(--surface,#fff);
+  box-shadow:0 10px 24px rgba(42,107,255,.18);
+}
+.btn:not(.primary){color:var(--muted);}
+.btn:not(.primary):not([disabled]):hover{
+  background:color-mix(in srgb,var(--brand) 12%,var(--surface));
+  border-color:color-mix(in srgb,var(--brand) 30%,var(--border-hairline));
+  color:var(--ink);
+}
+.btn.primary:not([disabled]):hover{
+  background:color-mix(in srgb,var(--brand) 88%,var(--surface,#fff));
+  border-color:color-mix(in srgb,var(--brand) 94%,var(--brand));
+  color:var(--surface,#fff);
+}
+.btn:not([disabled]):active{transform:translateY(1px);}
+.btn:focus-visible{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+  box-shadow:0 8px 20px rgba(42,107,255,.18);
+}
+.btn[disabled]{opacity:.45;cursor:not-allowed;box-shadow:none;}
+@media (prefers-reduced-motion:reduce){
+  .btn{transition:none;}
+}
 .dinner-overlay{
   position:fixed;
   inset:0;


### PR DESCRIPTION
Context: Align the Custom modal chrome with the SPA shell.
Approach: Replaced the Custom modal header/footer markup with the SPA structure, preserved existing handlers, and added the shared button/icon styling hooks.
Guardrails upheld: Tokens, modal stickiness, accessibility labels, and existing builder logic were left intact.
Screenshots: Unable to capture in this environment.
Notes: None.

------
https://chatgpt.com/codex/tasks/task_e_68f2651639fc8330bca32f5f32544898