### PR TITLE
Sync Custom modal shell with SPA

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,6 +159,7 @@
   // the "×" glyph remains purely presentational under a uniform "Close" label.
   const createModalCloseButton = onClick => {
     const button = createIconButton({ icon: '<span aria-hidden="true">×</span>', label: 'Close', extraClass: 'modal-close' });
+    button.classList.add('close-btn');
     if(typeof onClick === 'function'){
       button.addEventListener('click', onClick);
     }
@@ -4136,23 +4137,23 @@
     dialog.setAttribute('aria-modal','true');
     dialog.setAttribute('aria-labelledby','custom-dialog-title');
 
-    const header=document.createElement('div');
+    // Custom modal: header/footer synced to SPA shell (visual only, no logic changes)
+    const header=document.createElement('header');
     header.className='modal-header custom-header';
-    const title=document.createElement('h2');
+    const title=document.createElement('div');
     title.className='modal-title';
     title.id='custom-dialog-title';
     title.textContent='Custom';
+    title.setAttribute('role','heading');
+    title.setAttribute('aria-level','2');
     const customModeDescriptor=document.createElement('span');
     customModeDescriptor.className='sr-only';
     customModeDescriptor.textContent = existing ? ' – Editing custom activity' : ' – Add custom activity';
     title.appendChild(customModeDescriptor);
-    const headerBar=document.createElement('div');
-    headerBar.className='custom-header-bar';
-    headerBar.appendChild(title);
+    header.appendChild(title);
 
     const closeBtn=createModalCloseButton(()=> closeCustomBuilder({returnFocus:true}));
-    headerBar.appendChild(closeBtn);
-    header.appendChild(headerBar);
+    header.appendChild(closeBtn);
 
     dialog.appendChild(header);
 
@@ -4514,24 +4515,41 @@
 
     updateLocationDisplay();
 
-    const footer=document.createElement('div');
-    footer.className='modal-footer';
-    const footerStart=document.createElement('div');
-    footerStart.className='modal-footer-start';
-    const footerEnd=document.createElement('div');
-    footerEnd.className='modal-footer-end';
+    const ensureIconMarkup = svg => {
+      if(typeof svg !== 'string') return '';
+      if(svg.includes('class="icon"')) return svg;
+      return svg.replace('<svg', '<svg class="icon"');
+    };
+
+    const footer=document.createElement('footer');
+    footer.className='modal-footer custom-footer';
+    const footerContent=document.createElement('div');
+    footerContent.className='footer-content';
+    footer.appendChild(footerContent);
+    const btnRow=document.createElement('div');
+    btnRow.className='btn-row';
+    footerContent.appendChild(btnRow);
     const saveIsEdit = !!existing;
     const saveLabel = saveIsEdit ? 'Save custom activity' : 'Add custom activity';
     const saveIcon = saveIsEdit ? saveIconSvg : addIconSvg;
-    const saveBtn=createIconButton({ icon: saveIcon, label: saveLabel, extraClass: 'btn-icon--primary' });
-    footerEnd.appendChild(saveBtn);
+
+    const createFooterButton = ({ icon, label, isPrimary }) => {
+      const button = document.createElement('button');
+      button.type='button';
+      button.className = ['btn', isPrimary ? 'primary' : ''].filter(Boolean).join(' ');
+      button.setAttribute('aria-label', label);
+      button.title = label;
+      button.innerHTML = ensureIconMarkup(icon);
+      return button;
+    };
+
     let deleteBtn=null;
     if(saveIsEdit){
-      deleteBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete custom activity', extraClass: 'btn-icon--subtle' });
-      footerStart.appendChild(deleteBtn);
+      deleteBtn=createFooterButton({ icon: deleteIconSvg, label: 'Delete custom activity', isPrimary: false });
+      btnRow.appendChild(deleteBtn);
     }
-    footer.appendChild(footerStart);
-    footer.appendChild(footerEnd);
+    const saveBtn=createFooterButton({ icon: saveIcon, label: saveLabel, isPrimary: true });
+    btnRow.appendChild(saveBtn);
     dialog.appendChild(footer);
 
     overlay.appendChild(dialog);

--- a/style.css
+++ b/style.css
@@ -1371,6 +1371,73 @@ button:focus{outline:2px solid var(--brand);outline-offset:2px}
   flex-shrink:0;
   flex-wrap:nowrap;
 }
+.close-btn{border-radius:999px;}
+.footer-content{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  inline-size:100%;
+}
+.btn-row{
+  display:flex;
+  align-items:center;
+  gap:var(--space-3);
+}
+.btn{
+  --btn-size:44px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:var(--btn-size);
+  min-width:var(--btn-size);
+  height:var(--btn-size);
+  min-height:var(--btn-size);
+  border-radius:12px;
+  border:1px solid var(--hairline);
+  background:var(--surface);
+  color:var(--muted);
+  padding:0;
+  cursor:pointer;
+  line-height:0;
+  transition:background-color .18s ease,color .18s ease,box-shadow .18s ease,border-color .18s ease,transform .18s ease;
+}
+.btn .icon{width:22px;height:22px;display:block;}
+.btn:focus-visible{
+  outline:2px solid var(--brand);
+  outline-offset:2px;
+  box-shadow:0 0 0 2px color-mix(in srgb,var(--brand) 20%,transparent);
+}
+@media(hover:hover){
+  .btn:not([disabled]):hover{
+    background:color-mix(in srgb,var(--brand) 16%,var(--surface));
+    border-color:color-mix(in srgb,var(--brand) 28%,var(--hairline));
+    color:var(--brand);
+  }
+}
+.btn:not([disabled]):active{
+  background:color-mix(in srgb,var(--brand) 22%,var(--surface));
+  transform:translateY(1px);
+}
+.btn[disabled]{
+  opacity:.45;
+  cursor:default;
+  box-shadow:none;
+}
+.btn.primary{
+  background:var(--brand);
+  border-color:color-mix(in srgb,var(--brand) 60%,var(--hairline));
+  color:var(--surface);
+}
+@media(hover:hover){
+  .btn.primary:not([disabled]):hover{
+    background:color-mix(in srgb,var(--brand) 85%,var(--surface) 15%);
+    color:var(--surface);
+  }
+}
+.btn.primary:not([disabled]):active{
+  background:color-mix(in srgb,var(--brand) 72%,var(--surface) 28%);
+  color:var(--surface);
+}
 .modal-footer-start,.modal-footer-end{display:flex;align-items:center;gap:var(--space-3);}
 .modal-footer-end{justify-content:flex-end;}
 .dinner-overlay{


### PR DESCRIPTION
Context: Sync the Custom modal chrome with the SPA shell.
Approach:
- Replace the Custom builder header with the SPA header structure, preserving the existing close handler and accessibility labels.
- Rebuild the footer to share SPA button markup while wiring the Add/Delete/Save actions to the original callbacks.
- Extend shared modal styles with SPA footer classes and rounded close-button/cta tokens for parity.
Guardrails upheld: Modal logic untouched; shared tokens reused; accessibility labels preserved; safe-area/sticky behavior retained.
Screenshots: Unable to capture within this environment (Playwright automation failed to connect to the dev server).
Notes: None.


------
https://chatgpt.com/codex/tasks/task_e_68f2651639fc8330bca32f5f32544898