### PR TITLE
Align Custom modal header and footer with SPA

### DIFF
--- a/script.js
+++ b/script.js
@@ -4137,7 +4137,7 @@
     dialog.setAttribute('aria-labelledby','custom-dialog-title');
 
     const header=document.createElement('div');
-    header.className='modal-header custom-header';
+    header.className='modal-header';
     const title=document.createElement('h2');
     title.className='modal-title';
     title.id='custom-dialog-title';
@@ -4146,13 +4146,10 @@
     customModeDescriptor.className='sr-only';
     customModeDescriptor.textContent = existing ? ' – Editing custom activity' : ' – Add custom activity';
     title.appendChild(customModeDescriptor);
-    const headerBar=document.createElement('div');
-    headerBar.className='custom-header-bar';
-    headerBar.appendChild(title);
+    header.appendChild(title);
 
     const closeBtn=createModalCloseButton(()=> closeCustomBuilder({returnFocus:true}));
-    headerBar.appendChild(closeBtn);
-    header.appendChild(headerBar);
+    header.appendChild(closeBtn);
 
     dialog.appendChild(header);
 
@@ -4528,7 +4525,7 @@
     let deleteBtn=null;
     if(saveIsEdit){
       deleteBtn=createIconButton({ icon: deleteIconSvg, label: 'Delete custom activity', extraClass: 'btn-icon--subtle' });
-      footerStart.appendChild(deleteBtn);
+      footerEnd.insertBefore(deleteBtn, saveBtn);
     }
     footer.appendChild(footerStart);
     footer.appendChild(footerEnd);

--- a/style.css
+++ b/style.css
@@ -1743,9 +1743,9 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 /* Adopted new Custom modal shell (structure-only). */
 .custom-dialog{display:grid;grid-template-rows:auto 1fr auto;min-height:0;}
 .custom-dialog .modal-header,
-.custom-dialog .modal-footer{position:sticky;z-index:2;background:var(--panel);padding:var(--rhythm);}
-.custom-dialog .modal-header{top:0;border-bottom:1px solid var(--border-hairline);}
-.custom-dialog .modal-footer{bottom:0;border-top:1px solid var(--border-hairline);}
+.custom-dialog .modal-footer{position:sticky;z-index:3;background:var(--surface);}
+.custom-dialog .modal-header{top:0;}
+.custom-dialog .modal-footer{bottom:0;}
 .custom-modal-shell{display:grid;gap:var(--rhythm);align-content:start;}
 .custom-time-block{display:grid;gap:var(--space-5);}
 .custom-time-visual{display:flex;justify-content:center;}


### PR DESCRIPTION
Context: Match Custom builder shell to SPA modal
Approach: Rebuilt the Custom modal header/footer markup to reuse the SPA structure and button placement, and aligned the sticky shell styling to the shared modal tokens for consistent depth/spacing.
Guardrails upheld: Activities row height unchanged; shared tokens respected; SPA/iPad layout unaffected; accessibility labels retained.
Screenshots: ![Custom modal header/footer matching SPA](browser:/invocations/jakmvetj/artifacts/artifacts/custom-modal.png)
Notes: No automated tests are available for this static demo; visual QA performed via the demo page.


------
https://chatgpt.com/codex/tasks/task_e_68f27ae9e96c8330b34b3b27772bf239