### PR TITLE
Refine custom modal body layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -4158,21 +4158,25 @@
     body.className='modal-body spa-body custom-body';
     dialog.appendChild(body);
 
-    const shell=document.createElement('div');
-    shell.className='custom-modal-shell';
-    body.appendChild(shell);
+    const bodyTop=document.createElement('div');
+    bodyTop.className='body-top custom-body-top';
+    body.appendChild(bodyTop);
 
-    const timeBlock=document.createElement('div');
-    timeBlock.className='custom-time-block';
-    shell.appendChild(timeBlock);
+    const timePickerRegion=document.createElement('div');
+    timePickerRegion.className='time-picker custom-time-picker-region';
+    bodyTop.appendChild(timePickerRegion);
 
     const timeVisual=document.createElement('div');
     timeVisual.className='custom-time-visual';
-    timeBlock.appendChild(timeVisual);
+    timePickerRegion.appendChild(timeVisual);
 
-    const timeActions=document.createElement('div');
-    timeActions.className='custom-time-actions';
-    timeBlock.appendChild(timeActions);
+    const startEndStack=document.createElement('div');
+    startEndStack.className='start-end-stack custom-start-end-stack';
+    bodyTop.appendChild(startEndStack);
+
+    const startRow=document.createElement('div');
+    startRow.className='start-row custom-start-row';
+    startEndStack.appendChild(startRow);
 
     const startPill=document.createElement('div');
     startPill.className='pill custom-time-pill';
@@ -4183,6 +4187,10 @@
     const startValueNode=document.createElement('span');
     startValueNode.className='custom-time-value';
     startPill.appendChild(startValueNode);
+
+    const endRow=document.createElement('div');
+    endRow.className='end-row custom-end-row';
+    startEndStack.appendChild(endRow);
 
     const endPill=document.createElement('div');
     endPill.className='pill custom-time-pill';
@@ -4221,19 +4229,24 @@
     const timeError=document.createElement('p');
     timeError.className='custom-time-error';
     timeError.hidden=true;
-    timeBlock.appendChild(timeError);
+    // Keep the error message paired with the stacked time inputs so screen readers announce contextually.
+    startEndStack.appendChild(timeError);
 
-    const divider=document.createElement('div');
-    divider.className='custom-divider';
-    shell.appendChild(divider);
+    const bodyBottom=document.createElement('div');
+    bodyBottom.className='body-bottom custom-body-bottom';
+    body.appendChild(bodyBottom);
 
-    const pickerRow=document.createElement('div');
-    pickerRow.className='custom-picker-row';
-    shell.appendChild(pickerRow);
+    const activityName=document.createElement('div');
+    activityName.className='activity-name custom-activity-name';
+    bodyBottom.appendChild(activityName);
+
+    const activityLocation=document.createElement('div');
+    activityLocation.className='activity-location custom-activity-location';
+    bodyBottom.appendChild(activityLocation);
 
     const namePicker=document.createElement('div');
     namePicker.className='custom-picker custom-picker-name';
-    pickerRow.appendChild(namePicker);
+    activityName.appendChild(namePicker);
 
     const nameActionBtn=document.createElement('button');
     nameActionBtn.type='button';
@@ -4294,7 +4307,7 @@
 
     const locationPicker=document.createElement('div');
     locationPicker.className='custom-picker custom-picker-location';
-    pickerRow.appendChild(locationPicker);
+    activityLocation.appendChild(locationPicker);
 
     const locationField=document.createElement('button');
     locationField.type='button';
@@ -4913,10 +4926,10 @@
       endButton.title='Set End Time';
     }
 
-    timeActions.appendChild(startButton);
-    timeActions.appendChild(startPill);
-    timeActions.appendChild(endButton);
-    timeActions.appendChild(endPill);
+    startRow.appendChild(startButton);
+    startRow.appendChild(startPill);
+    endRow.appendChild(endButton);
+    endRow.appendChild(endPill);
 
     const handleSave=()=>{
       const titleValue = resolveTitle();

--- a/style.css
+++ b/style.css
@@ -1732,28 +1732,34 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-overlay{z-index:2200;}
 .custom-body{
   overflow:auto;
-  padding-block-end:calc(var(--spa-body-padding) + env(safe-area-inset-bottom));
   overscroll-behavior:contain;
   scrollbar-gutter:stable both-edges;
-  display:grid;
-  gap:var(--rhythm);
-  padding:var(--rhythm);
-  align-content:start;
+  display:flex;
+  flex-direction:column;
+  justify-content:space-between;
+  padding:var(--space-6) var(--space-7);
+  padding-block-end:calc(var(--space-6) + env(safe-area-inset-bottom));
+  background:var(--panel);
+  min-height:0;
 }
-/* Adopted new Custom modal shell (structure-only). */
 .custom-dialog{display:grid;grid-template-rows:auto 1fr auto;min-height:0;}
 .custom-dialog .modal-header,
 .custom-dialog .modal-footer{position:sticky;z-index:3;background:var(--surface);}
 .custom-dialog .modal-header{top:0;}
 .custom-dialog .modal-footer{bottom:0;}
-.custom-modal-shell{display:grid;gap:var(--rhythm);align-content:start;}
-.custom-time-block{display:grid;gap:var(--space-5);}
-.custom-time-visual{display:flex;justify-content:center;}
+.custom-dialog .body-top{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-7);flex:1;align-items:center;justify-items:center;width:100%;}
+.custom-dialog .time-picker{display:flex;align-items:center;justify-content:center;width:100%;height:100%;}
+.custom-time-visual{display:flex;justify-content:center;width:100%;}
 .custom-time-visual > .time-picker{width:100%;display:flex;flex-direction:column;gap:var(--space-5);align-items:stretch;}
 .custom-time-visual .time-picker-wheels{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-5);align-items:center;}
 .custom-time-visual .time-picker-inline-field{display:none;}
 .custom-time-visual .time-picker-column{min-height:calc(5 * var(--space-3));}
-.custom-time-actions{display:grid;grid-template-columns:auto 1fr auto 1fr;gap:var(--space-4);align-items:center;}
+.custom-dialog .start-end-stack{display:flex;flex-direction:column;justify-content:center;gap:var(--space-6);width:100%;}
+.custom-dialog .start-row,
+.custom-dialog .end-row{display:flex;align-items:center;gap:var(--space-3);width:100%;}
+.custom-dialog .body-bottom{display:flex;flex-direction:column;gap:var(--space-5);margin-top:var(--space-8);width:100%;}
+.custom-dialog .activity-name,
+.custom-dialog .activity-location{width:100%;}
 .custom-hourglass-btn{width:40px;height:40px;border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);display:grid;place-items:center;padding:0;transition:box-shadow .18s ease,border-color .18s ease;}
 .custom-hourglass-btn:focus-visible{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 6px 16px rgba(42,107,255,.16);}
 .custom-hourglass-btn:disabled{opacity:.45;cursor:default;}
@@ -1767,12 +1773,8 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-clear-end:not(:disabled):hover{color:var(--ink);background:color-mix(in srgb,var(--brand) 12%,transparent);}
 .custom-clear-end:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 .custom-time-error{margin:0;font-size:13px;color:var(--brand);font-weight:600;}
-.custom-divider{height:1px;background:var(--border-hairline);}
-.custom-picker-row{display:grid;gap:var(--space-5);}
-@media (min-width:900px){
-  .custom-picker-row{grid-template-columns:1fr;}
-}
-.custom-picker{display:flex;align-items:center;gap:12px;}
+.custom-start-end-stack .custom-time-error{align-self:flex-start;padding-inline-start:calc(40px + var(--space-3));}
+.custom-picker{display:flex;align-items:center;gap:12px;width:100%;}
 .custom-picker-name{position:relative;}
 .custom-inline-action{width:40px;height:40px;border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);display:grid;place-items:center;padding:0;}
 .custom-inline-action:focus-visible{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 6px 16px rgba(42,107,255,.16);}
@@ -1803,6 +1805,8 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-picker-location{position:relative;}
 .custom-location-field{cursor:pointer;justify-content:center;}
 .custom-location-field[data-empty='true']{color:var(--muted);}
+.custom-dialog .activity-name input,
+.custom-dialog .activity-location button{width:100%;}
 .custom-location-dropdown{position:absolute;top:calc(100% + 10px);left:0;right:0;z-index:3;}
 .custom-location-list{border-radius:16px;border:1px solid var(--border-hairline);background:var(--surface,#fff);box-shadow:0 12px 32px rgba(15,23,42,.18);display:flex;flex-direction:column;max-block-size:min(240px,32vh);}
 .list-row{display:flex;align-items:center;min-height:44px;padding-inline:var(--space-3);padding-block:10px;border:0;background:transparent;font:inherit;font-size:15px;color:var(--ink);text-align:left;cursor:pointer;transition:background-color .18s ease,color .18s ease;justify-content:space-between;gap:12px;inline-size:100%;}


### PR DESCRIPTION
## Summary
- restructure the custom modal body into dedicated time and details regions that match the desktop blueprint
- group the hourglass controls with their start/end pills and move activity fields into full-width rows
- refresh custom modal styling to align with the new layout while keeping header/footer behavior intact

## Testing
- not run (not available in this environment)

## Checklist
- [x] Code comments added where non-obvious choices were made
- [ ] Screenshots included (not possible in this environment)
- [x] All acceptance criteria satisfied

------
https://chatgpt.com/codex/tasks/task_e_68f286d352208330ae08a25a464e9038