### PR TITLE
Refactor custom modal body layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -4158,21 +4158,26 @@
     body.className='modal-body spa-body custom-body';
     dialog.appendChild(body);
 
-    const shell=document.createElement('div');
-    shell.className='custom-modal-shell';
-    body.appendChild(shell);
-
-    const timeBlock=document.createElement('div');
-    timeBlock.className='custom-time-block';
-    shell.appendChild(timeBlock);
+    const bodyTop=document.createElement('div');
+    bodyTop.className='body-top custom-body-top';
+    body.appendChild(bodyTop);
 
     const timeVisual=document.createElement('div');
-    timeVisual.className='custom-time-visual';
-    timeBlock.appendChild(timeVisual);
+    // The host keeps Codex' requested `.time-picker` wrapper while preserving our custom hooks.
+    timeVisual.className='time-picker custom-time-picker-host';
+    bodyTop.appendChild(timeVisual);
 
-    const timeActions=document.createElement('div');
-    timeActions.className='custom-time-actions';
-    timeBlock.appendChild(timeActions);
+    const startEndStack=document.createElement('div');
+    startEndStack.className='start-end-stack custom-start-end-stack';
+    bodyTop.appendChild(startEndStack);
+
+    const startRow=document.createElement('div');
+    startRow.className='start-row custom-start-row';
+    startEndStack.appendChild(startRow);
+
+    const endRow=document.createElement('div');
+    endRow.className='end-row custom-end-row';
+    startEndStack.appendChild(endRow);
 
     const startPill=document.createElement('div');
     startPill.className='pill custom-time-pill';
@@ -4221,19 +4226,15 @@
     const timeError=document.createElement('p');
     timeError.className='custom-time-error';
     timeError.hidden=true;
-    timeBlock.appendChild(timeError);
+    startEndStack.appendChild(timeError);
 
-    const divider=document.createElement('div');
-    divider.className='custom-divider';
-    shell.appendChild(divider);
-
-    const pickerRow=document.createElement('div');
-    pickerRow.className='custom-picker-row';
-    shell.appendChild(pickerRow);
+    const bodyBottom=document.createElement('div');
+    bodyBottom.className='body-bottom custom-body-bottom';
+    body.appendChild(bodyBottom);
 
     const namePicker=document.createElement('div');
-    namePicker.className='custom-picker custom-picker-name';
-    pickerRow.appendChild(namePicker);
+    namePicker.className='custom-picker custom-picker-name activity-name';
+    bodyBottom.appendChild(namePicker);
 
     const nameActionBtn=document.createElement('button');
     nameActionBtn.type='button';
@@ -4293,8 +4294,8 @@
     nameField.appendChild(existingPane);
 
     const locationPicker=document.createElement('div');
-    locationPicker.className='custom-picker custom-picker-location';
-    pickerRow.appendChild(locationPicker);
+    locationPicker.className='custom-picker custom-picker-location activity-location';
+    bodyBottom.appendChild(locationPicker);
 
     const locationField=document.createElement('button');
     locationField.type='button';
@@ -4913,10 +4914,10 @@
       endButton.title='Set End Time';
     }
 
-    timeActions.appendChild(startButton);
-    timeActions.appendChild(startPill);
-    timeActions.appendChild(endButton);
-    timeActions.appendChild(endPill);
+    startRow.appendChild(startButton);
+    startRow.appendChild(startPill);
+    endRow.appendChild(endButton);
+    endRow.appendChild(endPill);
 
     const handleSave=()=>{
       const titleValue = resolveTitle();

--- a/style.css
+++ b/style.css
@@ -1732,13 +1732,16 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-overlay{z-index:2200;}
 .custom-body{
   overflow:auto;
-  padding-block-end:calc(var(--spa-body-padding) + env(safe-area-inset-bottom));
   overscroll-behavior:contain;
   scrollbar-gutter:stable both-edges;
-  display:grid;
-  gap:var(--rhythm);
-  padding:var(--rhythm);
-  align-content:start;
+  display:flex;
+  flex-direction:column;
+  justify-content:space-between;
+  padding:var(--space-6) var(--space-7);
+  padding-block-end:calc(var(--space-6) + env(safe-area-inset-bottom));
+  background:var(--panel);
+  min-height:0;
+  height:100%;
 }
 /* Adopted new Custom modal shell (structure-only). */
 .custom-dialog{display:grid;grid-template-rows:auto 1fr auto;min-height:0;}
@@ -1746,14 +1749,21 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-dialog .modal-footer{position:sticky;z-index:3;background:var(--surface);}
 .custom-dialog .modal-header{top:0;}
 .custom-dialog .modal-footer{bottom:0;}
-.custom-modal-shell{display:grid;gap:var(--rhythm);align-content:start;}
-.custom-time-block{display:grid;gap:var(--space-5);}
-.custom-time-visual{display:flex;justify-content:center;}
-.custom-time-visual > .time-picker{width:100%;display:flex;flex-direction:column;gap:var(--space-5);align-items:stretch;}
-.custom-time-visual .time-picker-wheels{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-5);align-items:center;}
-.custom-time-visual .time-picker-inline-field{display:none;}
-.custom-time-visual .time-picker-column{min-height:calc(5 * var(--space-3));}
-.custom-time-actions{display:grid;grid-template-columns:auto 1fr auto 1fr;gap:var(--space-4);align-items:center;}
+.custom-body-top,
+.custom-body-bottom{flex:1 1 0%;min-height:0;width:100%;}
+.custom-body-top{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-7);align-items:center;justify-items:center;}
+.custom-time-picker-host{display:flex;align-items:center;justify-content:center;width:100%;height:100%;}
+.custom-time-picker-host > .time-picker{width:100%;display:flex;flex-direction:column;gap:var(--space-5);align-items:stretch;}
+.custom-time-picker-host .time-picker-wheels{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--space-5);align-items:center;justify-items:center;}
+.custom-time-picker-host .time-picker-inline-field{display:none;}
+.custom-time-picker-host .time-picker-column{min-height:calc(5 * var(--space-3));}
+.custom-start-end-stack{display:flex;flex-direction:column;justify-content:center;gap:var(--space-6);width:100%;}
+.custom-start-row,
+.custom-end-row{display:flex;align-items:center;gap:var(--space-3);width:100%;}
+.custom-start-end-stack .custom-time-error{align-self:flex-start;}
+.custom-body-bottom{display:flex;flex-direction:column;gap:var(--space-5);margin-top:var(--space-8);width:100%;border-top:1px solid var(--border-hairline);padding-top:var(--space-6);}
+.custom-body-bottom .activity-name,
+.custom-body-bottom .activity-location{width:100%;}
 .custom-hourglass-btn{width:40px;height:40px;border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);display:grid;place-items:center;padding:0;transition:box-shadow .18s ease,border-color .18s ease;}
 .custom-hourglass-btn:focus-visible{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 6px 16px rgba(42,107,255,.16);}
 .custom-hourglass-btn:disabled{opacity:.45;cursor:default;}
@@ -1767,12 +1777,7 @@ body[data-theme='dark'] .chip--custom{color:var(--chip-custom-fg,#000);}
 .custom-clear-end:not(:disabled):hover{color:var(--ink);background:color-mix(in srgb,var(--brand) 12%,transparent);}
 .custom-clear-end:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
 .custom-time-error{margin:0;font-size:13px;color:var(--brand);font-weight:600;}
-.custom-divider{height:1px;background:var(--border-hairline);}
-.custom-picker-row{display:grid;gap:var(--space-5);}
-@media (min-width:900px){
-  .custom-picker-row{grid-template-columns:1fr;}
-}
-.custom-picker{display:flex;align-items:center;gap:12px;}
+.custom-picker{display:flex;align-items:center;gap:12px;width:100%;}
 .custom-picker-name{position:relative;}
 .custom-inline-action{width:40px;height:40px;border-radius:10px;border:1px solid var(--border-hairline);background:var(--surface,#fff);display:grid;place-items:center;padding:0;}
 .custom-inline-action:focus-visible{outline:2px solid var(--brand);outline-offset:2px;box-shadow:0 6px 16px rgba(42,107,255,.16);}


### PR DESCRIPTION
Context: Align the Custom activity modal body with the new desktop layout blueprint.
Approach: Rebuilt the body DOM to group the time picker with start/end rows beside it and stacked the name/location rows below, updating CSS to enforce the 50/50 grid split and full-width fields while preserving existing handlers.
Guardrails upheld: Header/footer unchanged, spa shell sticky behavior intact, unified time picker + chips retained, Apple spacing tokens only.
Screenshots: ![Custom modal desktop](browser:/invocations/kktmnmlu/artifacts/artifacts/custom-modal-desktop.png)
Notes: Manual QA via Playwright capture; no automated tests available.


------
https://chatgpt.com/codex/tasks/task_e_68f286d352208330ae08a25a464e9038